### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ import asyncio
 from raganything import RAGAnything
 from lightrag import LightRAG
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+from lightrag.kg.shared_storage import initialize_pipeline_status
 from lightrag.utils import EmbeddingFunc
 import os
 
@@ -541,6 +542,7 @@ async def load_existing_lightrag():
 
     # Initialize storage (this will load existing data if available)
     await lightrag_instance.initialize_storages()
+    await initialize_pipeline_status()
 
     # Now initialize RAGAnything with the existing LightRAG instance
     rag = RAGAnything(


### PR DESCRIPTION
Added `await initialize_pipeline_status()` to Section 6 `Loading Existing LightRAG Instance`, so that the example will work.

<!--
Thanks for contributing to RAGAnything!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

The ingestion of new documents to an exisiting LightRAG  in the README.md example (Section 6) instance fails.

## Related Issues

None

## Changes Made
To Section 6 of README.md:

added to package imports:
`from lightrag.kg.shared_storage import initialize_pipeline_status`

added under `# Initialize storage (this will load existing data if available)` .
`await initialize_pipeline_status()`


## Checklist

- [X] Changes tested locally
- [X] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Thanks for this product. It really works well.
