### PR TITLE
fix: replace __del__ with atexit to fix RAGAnything cleanup warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ pip install -e '.[all]'
 mineru --version
 
 # Check if properly configured
-python -c "from raganything import RAGAnything; rag = RAGAnything(); print('✅ MinerU installed properly' if rag.check_mineru_installation() else '❌ MinerU installation issue')"
+python -c "from raganything import RAGAnything; rag = RAGAnything(); print('✅ MinerU installed properly' if rag.check_parser_installation() else '❌ MinerU installation issue')"
 ```
 
 Models are downloaded automatically on first use. For manual download, refer to [MinerU Model Source Configuration](https://github.com/opendatalab/MinerU/blob/master/README.md#22-model-source-configuration).

--- a/README_zh.md
+++ b/README_zh.md
@@ -272,7 +272,7 @@ pip install -e '.[all]'
 mineru --version
 
 # 检查是否正确配置
-python -c "from raganything import RAGAnything; rag = RAGAnything(); print('✅ MinerU安装正常' if rag.check_mineru_installation() else '❌ MinerU安装有问题')"
+python -c "from raganything import RAGAnything; rag = RAGAnything(); print('✅ MinerU安装正常' if rag.check_parser_installation() else '❌ MinerU安装有问题')"
 ```
 
 模型在首次使用时自动下载。手动下载参考[MinerU模型源配置](https://github.com/opendatalab/MinerU/blob/master/README_zh-CN.md#22-%E6%A8%A1%E5%9E%8B%E6%BA%90%E9%85%8D%E7%BD%AE)：

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -11,6 +11,7 @@ import os
 from typing import Dict, Any, Optional, Callable
 import sys
 import asyncio
+import atexit
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -111,6 +112,9 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
             DoclingParser() if self.config.parser == "docling" else MineruParser()
         )
 
+        # Register close method for cleanup
+        atexit.register(self.close)
+
         # Create working directory if needed
         if not os.path.exists(self.working_dir):
             os.makedirs(self.working_dir)
@@ -128,7 +132,7 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
         )
         self.logger.info(f"  Max concurrent files: {self.config.max_concurrent_files}")
 
-    def __del__(self):
+    def close(self):
         """Cleanup resources when object is destroyed"""
         try:
             import asyncio


### PR DESCRIPTION
## Description

fix: replace `__del__` with atexit to fix RAGAnything cleanup warning

## Related Issues

Fixes #101 

## Changes Made

- README.md/README_zh.md: replace `check_mineru_installation` with `check_parser_installation`
- raganything.py: replace `__del__` with `atexit` to fix RAGAnything cleanup warning

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)
