### PR TITLE
Fix status comparison case mismatch in processor.py

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -460,7 +460,7 @@ class ProcessorMixin:
             self.logger.debug("No multimodal content to process")
             return
 
-        # Check multimodal processing status - handle LightRAG's early "PROCESSED" marking
+        # Check multimodal processing status - handle LightRAG's early DocStatus.PROCESSED marking
         try:
             existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
             if existing_doc_status:
@@ -475,15 +475,15 @@ class ProcessorMixin:
                     )
                     return
 
-                # Even if status is "PROCESSED" (text processing done),
+                # Even if status is DocStatus.PROCESSED (text processing done),
                 # we still need to process multimodal content if not yet done
                 doc_status = existing_doc_status.get("status", "")
-                if doc_status == "PROCESSED" and not multimodal_processed:
+                if doc_status == DocStatus.PROCESSED and not multimodal_processed:
                     self.logger.info(
                         f"Document {doc_id} text processing is complete, but multimodal content still needs processing"
                     )
                     # Continue with multimodal processing
-                elif doc_status == "PROCESSED" and multimodal_processed:
+                elif doc_status == DocStatus.PROCESSED and multimodal_processed:
                     self.logger.info(
                         f"Document {doc_id} is fully processed (text + multimodal)"
                     )
@@ -1352,7 +1352,7 @@ class ProcessorMixin:
             if not doc_status:
                 return False
 
-            text_processed = doc_status.get("status") == "PROCESSED"
+            text_processed = doc_status.get("status") == DocStatus.PROCESSED
             multimodal_processed = doc_status.get("multimodal_processed", False)
 
             return text_processed and multimodal_processed
@@ -1384,7 +1384,7 @@ class ProcessorMixin:
                     "chunks_count": 0,
                 }
 
-            text_processed = doc_status.get("status") == "PROCESSED"
+            text_processed = doc_status.get("status") == DocStatus.PROCESSED
             multimodal_processed = doc_status.get("multimodal_processed", False)
             fully_processed = text_processed and multimodal_processed
 


### PR DESCRIPTION
## Description

Fixed a bug where document status comparisons were using uppercase `"PROCESSED"` string instead of the `DocStatus.PROCESSED` enum, causing `text_processed` to always return `False`.

## Related Issues

This fixes a bug where the status check never matches because:
- LightRAG stores status as lowercase `"processed"` (from DocStatus enum)
- RAGAnything was checking against uppercase `"PROCESSED"` string
- Comparison: `"processed" == "PROCESSED"` always returns `False`

## Changes Made

Replaced hardcoded `"PROCESSED"` strings with `DocStatus.PROCESSED` enum constant in 4 locations:
- Line 481: `process_multimodal_content()` - first status check
- Line 486: `process_multimodal_content()` - second status check  
- Line 1355: `is_document_fully_processed()` - status comparison
- Line 1387: `get_document_processing_status()` - status comparison

Also updated related comments for consistency.

## Benefits

- Fixes the case mismatch bug
- Makes code type-safe (DocStatus enum already imported)
- Removes magic strings
- Future-proof if enum values change

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

The `DocStatus` enum was already imported at line 14, so this is just using the existing constant instead of hardcoded strings. Compatible with both LightRAG v1.4.9.2 and v1.4.9.3.