### PR TITLE
Allow configuring full-path in file_path fields in RAG

### DIFF
--- a/raganything/config.py
+++ b/raganything/config.py
@@ -103,6 +103,11 @@ class RAGAnythingConfig:
     content_format: str = field(default=get_env_value("CONTENT_FORMAT", "minerU", str))
     """Default content format for context extraction when processing documents."""
 
+    # Path Handling Configuration
+    # ---
+    use_full_path: bool = field(default=get_env_value("USE_FULL_PATH", False, bool))
+    """Whether to use full file path (True) or just basename (False) for file references in LightRAG."""
+
     def __post_init__(self):
         """Post-initialization setup for backward compatibility"""
         # Support legacy environment variable names for backward compatibility

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -26,6 +26,21 @@ from lightrag.utils import compute_mdhash_id
 class ProcessorMixin:
     """ProcessorMixin class containing document processing functionality for RAGAnything"""
 
+    def _get_file_reference(self, file_path: str) -> str:
+        """
+        Get file reference based on use_full_path configuration.
+        
+        Args:
+            file_path: Path to the file (can be absolute or relative)
+            
+        Returns:
+            str: Full path if use_full_path is True, otherwise basename
+        """
+        if self.config.use_full_path:
+            return str(file_path)
+        else:
+            return os.path.basename(file_path)
+
     def _generate_cache_key(
         self, file_path: Path, parse_method: str = None, **kwargs
     ) -> str:
@@ -541,7 +556,8 @@ class ProcessorMixin:
             file_path: File path (for reference)
             doc_id: Document ID for proper chunk association
         """
-        file_name = os.path.basename(file_path)
+        # Use full path or basename based on config
+        file_name = self._get_file_reference(file_path)
 
         # Collect all chunk results for batch processing (similar to text content processing)
         all_chunk_results = []
@@ -886,13 +902,16 @@ class ProcessorMixin:
             # Calculate tokens
             tokens = len(self.lightrag.tokenizer.encode(formatted_chunk_content))
 
+            # Use full path or basename based on config
+            file_ref = self._get_file_reference(file_path)
+
             # Build LightRAG standard chunk format
             chunks[chunk_id] = {
                 "content": formatted_chunk_content,  # Now uses the templated content
                 "tokens": tokens,
                 "full_doc_id": doc_id,
                 "chunk_order_index": chunk_order_index,
-                "file_path": os.path.basename(file_path),
+                "file_path": file_ref,
                 "llm_cache_list": [],  # LightRAG will populate this field
                 # Multimodal-specific metadata
                 "is_multimodal": True,
@@ -1021,6 +1040,9 @@ class ProcessorMixin:
         # Create entities_vdb entries for all multimodal main entities
         entities_to_store = {}
 
+        # Use full path or basename based on config
+        file_ref = self._get_file_reference(file_path)
+
         for data in multimodal_data_list:
             entity_info = data["entity_info"]
             entity_name = entity_info["entity_name"]
@@ -1045,7 +1067,7 @@ class ProcessorMixin:
                 "entity_type": entity_info.get("entity_type", content_type),
                 "content": entity_info.get("summary", description),
                 "source_id": chunk_id,
-                "file_path": os.path.basename(file_path),
+                "file_path": file_ref,
             }
 
             entities_to_store[entity_id] = entity_data
@@ -1254,6 +1276,9 @@ class ProcessorMixin:
         pipeline_status = await get_namespace_data("pipeline_status")
         pipeline_status_lock = get_pipeline_status_lock()
 
+        # Use full path or basename based on config
+        file_ref = self._get_file_reference(file_path)
+
         await merge_nodes_and_edges(
             chunk_results=enhanced_chunk_results,
             knowledge_graph_inst=self.lightrag.chunk_entity_relation_graph,
@@ -1268,7 +1293,7 @@ class ProcessorMixin:
             llm_response_cache=self.lightrag.llm_response_cache,
             current_file_number=1,
             total_files=1,
-            file_path=os.path.basename(file_path),
+            file_path=file_ref,
         )
 
         await self.lightrag._insert_done()
@@ -1475,7 +1500,8 @@ class ProcessorMixin:
         # Step 3: Insert pure text content with all parameters
         if text_content.strip():
             if file_name is None:
-                file_name = os.path.basename(file_path)
+                # Use full path or basename based on config
+                file_name = self._get_file_reference(file_path)
             await insert_text_content(
                 self.lightrag,
                 input=text_content,
@@ -1484,10 +1510,14 @@ class ProcessorMixin:
                 split_by_character_only=split_by_character_only,
                 ids=doc_id,
             )
+        else:
+            # Determine file reference even if no text content
+            if file_name is None:
+                file_name = self._get_file_reference(file_path)
 
         # Step 4: Process multimodal content (using specialized processors)
         if multimodal_items:
-            await self._process_multimodal_content(multimodal_items, file_path, doc_id)
+            await self._process_multimodal_content(multimodal_items, file_name, doc_id)
         else:
             # If no multimodal content, mark multimodal processing as complete
             # This ensures the document status properly reflects completion of all processing
@@ -1524,7 +1554,8 @@ class ProcessorMixin:
             doc_id: Optional document ID, if not provided will be generated from content
             **kwargs: Additional parameters for parser (e.g., lang, device, start_page, end_page, formula, table, backend, source)
         """
-        file_name = os.path.basename(file_path)
+        # Use full path or basename based on config
+        file_name = self._get_file_reference(file_path)
         doc_pre_id = f"doc-pre-{file_name}"
         pipeline_status = None
         pipeline_status_lock = None
@@ -1802,19 +1833,23 @@ class ProcessorMixin:
 
         # Step 2: Insert pure text content with all parameters
         if text_content.strip():
-            file_name = os.path.basename(file_path)
+            # Use full path or basename based on config
+            file_ref = self._get_file_reference(file_path)
             await insert_text_content(
                 self.lightrag,
                 input=text_content,
-                file_paths=file_name,
+                file_paths=file_ref,
                 split_by_character=split_by_character,
                 split_by_character_only=split_by_character_only,
                 ids=doc_id,
             )
+        else:
+            # Determine file reference even if no text content
+            file_ref = self._get_file_reference(file_path)
 
         # Step 3: Process multimodal content (using specialized processors)
         if multimodal_items:
-            await self._process_multimodal_content(multimodal_items, file_path, doc_id)
+            await self._process_multimodal_content(multimodal_items, file_ref, doc_id)
         else:
             # If no multimodal content, mark multimodal processing as complete
             # This ensures the document status properly reflects completion of all processing


### PR DESCRIPTION
## Description

Implemented an **use_full_path** configuration parameter in RAGAnything, so that users have the possibility to insert **absolute filepath** in RAG for future source file citation or download. Here's what was done:

Added new configuration parameter to RAGAnythingConfig:

**use_full_path: bool with default value False (backward compatible)**
Supports environment variable USE_FULL_PATH
Allows users to choose between full file paths or basenames
## Key Changes
Configuration Module (raganything/config.py):

Added the use_full_path field to the configuration dataclass
Follows existing patterns with environment variable support

Processor Module (raganything/processor.py):

Created _get_file_reference() helper method to centralize the logic
Updated all file path handling to respect the configuration:
Text content insertion
Multimodal content processing
Knowledge graph construction
Entity storage and merging

## Checklist

- [Done] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

