### PR TITLE
fix: discover MinerU output folder instead of constructing from method

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -812,9 +812,26 @@ class MineruParser(Parser):
 
         file_stem_subdir = output_dir / file_stem
         if file_stem_subdir.exists():
-            md_file = file_stem_subdir / method / f"{file_stem}.md"
-            json_file = file_stem_subdir / method / f"{file_stem}_content_list.json"
-            images_base_dir = file_stem_subdir / method
+            # Discover actual output folder - MinerU creates different folder names
+            # based on backend (e.g., "hybrid_auto" for hybrid-auto-engine with method=auto,
+            # "vlm" for vlm backends, or just the method name for pipeline backend)
+            found_output_dir = None
+            for subdir in file_stem_subdir.iterdir():
+                if subdir.is_dir():
+                    candidate = subdir / f"{file_stem}_content_list.json"
+                    if candidate.exists():
+                        found_output_dir = subdir
+                        break
+
+            if found_output_dir:
+                md_file = found_output_dir / f"{file_stem}.md"
+                json_file = found_output_dir / f"{file_stem}_content_list.json"
+                images_base_dir = found_output_dir
+            else:
+                # Fallback to method-based path for backwards compatibility
+                md_file = file_stem_subdir / method / f"{file_stem}.md"
+                json_file = file_stem_subdir / method / f"{file_stem}_content_list.json"
+                images_base_dir = file_stem_subdir / method
 
         # Read markdown content
         md_content = ""


### PR DESCRIPTION
MinerU creates output folders with different naming conventions depending on the backend used:
- pipeline backend: "{method}/" (e.g., "auto/")
- vlm-* backends: "vlm/"
- hybrid-* backends: "hybrid_{method}/" (e.g., "hybrid_auto/")

The _read_output_files() method was constructing the path using only the method parameter, which caused failures when using the default hybrid-* backend (the most common case).

This fix discovers the actual output folder by searching for the *_content_list.json file within subdirectories, with a fallback to the original method-based path for backwards compatibility.

Fixes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
Thanks for contributing to RAGAnything!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

[Briefly describe the changes made in this pull request.]

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

[List the specific changes made in this pull request.]

## Checklist

- [ ] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
