### PR TITLE
feat(parser): add remote URL support for DoclingParser

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -35,7 +35,6 @@ import logging
 import urllib.parse
 import urllib.request
 import shutil
-import os
 from pathlib import Path
 from typing import (
     Dict,

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -110,8 +110,8 @@ class Parser:
                 },
             )
 
-            # Open connection to get headers
-            response = urllib.request.urlopen(req)
+            # Open connection to get headers (with an explicit timeout to prevent hanging)
+            response = urllib.request.urlopen(req, timeout=30)
 
             # If no extension in URL, try Content-Type header
             if not suffix:

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -32,6 +32,10 @@ import base64
 import subprocess
 import tempfile
 import logging
+import urllib.parse
+import urllib.request
+import shutil
+import os
 from pathlib import Path
 from typing import (
     Dict,
@@ -72,6 +76,55 @@ class Parser:
 
     # Class-level logger
     logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def _is_url(path: str) -> bool:
+        """Check if the path is a URL."""
+        try:
+            result = urllib.parse.urlparse(str(path))
+            return all([result.scheme, result.netloc])
+        except ValueError:
+            return False
+
+    def _download_file(self, url: str) -> Path:
+        """
+        Download a file from a URL to a temporary file.
+        Attempts to preserve the file extension from the URL.
+        """
+        try:
+            self.logger.info(f"Downloading file from URL: {url}")
+            
+            # Parse URL to get path and extension
+            parsed_url = urllib.parse.urlparse(url)
+            path = Path(parsed_url.path)
+            suffix = path.suffix if path.suffix else ""
+            
+            # Create a temporary file with the correct extension
+            # delete=False is important so we can close it and let other processes open it
+            # We must manually delete it later
+            fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+            os.close(fd)
+            tmp_path = Path(tmp_path)
+            
+            # Download the file
+            # We use a user-agent to avoid 403 Forbidden from some sites
+            req = urllib.request.Request(
+                url, 
+                data=None, 
+                headers={
+                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
+                }
+            )
+            
+            with urllib.request.urlopen(req) as response, open(tmp_path, 'wb') as out_file:
+                shutil.copyfileobj(response, out_file)
+                
+            self.logger.info(f"Downloaded to temporary file: {tmp_path} ({tmp_path.stat().st_size} bytes)")
+            return tmp_path
+            
+        except Exception as e:
+            self.logger.error(f"Failed to download file from {url}: {e}")
+            raise RuntimeError(f"Failed to download file from {url}: {e}")
 
     def __init__(self) -> None:
         """Initialize the base parser."""
@@ -1429,38 +1482,54 @@ class DoclingParser(Parser):
     ) -> List[Dict[str, Any]]:
         """
         Parse document using Docling based on file extension
-
+        
         Args:
-            file_path: Path to the file to be parsed
+            file_path: Path to the file to be parsed or URL
             method: Parsing method
             output_dir: Output directory path
             lang: Document language for optimization
             **kwargs: Additional parameters for docling command
-
+            
         Returns:
             List[Dict[str, Any]]: List of content blocks
         """
-        # Convert to Path object
-        file_path = Path(file_path)
-        if not file_path.exists():
-            raise FileNotFoundError(f"File does not exist: {file_path}")
+        downloaded_temp_file = None
+        
+        try:
+            # Check if input is a URL
+            if self._is_url(file_path):
+                file_path = self._download_file(file_path)
+                downloaded_temp_file = file_path
+                
+            # Convert to Path object
+            file_path = Path(file_path)
+            if not file_path.exists():
+                raise FileNotFoundError(f"File does not exist: {file_path}")
 
-        # Get file extension
-        ext = file_path.suffix.lower()
+            # Get file extension
+            ext = file_path.suffix.lower()
 
-        # Choose appropriate parser based on file type
-        if ext == ".pdf":
-            return self.parse_pdf(file_path, output_dir, method, lang, **kwargs)
-        elif ext in self.OFFICE_FORMATS:
-            return self.parse_office_doc(file_path, output_dir, lang, **kwargs)
-        elif ext in self.HTML_FORMATS:
-            return self.parse_html(file_path, output_dir, lang, **kwargs)
-        else:
-            raise ValueError(
-                f"Unsupported file format: {ext}. "
-                f"Docling only supports PDF files, Office formats ({', '.join(self.OFFICE_FORMATS)}) "
-                f"and HTML formats ({', '.join(self.HTML_FORMATS)})"
-            )
+            # Choose appropriate parser based on file type
+            if ext == ".pdf":
+                return self.parse_pdf(file_path, output_dir, method, lang, **kwargs)
+            elif ext in self.OFFICE_FORMATS:
+                return self.parse_office_doc(file_path, output_dir, lang, **kwargs)
+            elif ext in self.HTML_FORMATS:
+                return self.parse_html(file_path, output_dir, lang, **kwargs)
+            else:
+                raise ValueError(
+                    f"Unsupported file format: {ext}. "
+                    f"Docling only supports PDF files, Office formats ({', '.join(self.OFFICE_FORMATS)}) "
+                    f"and HTML formats ({', '.join(self.HTML_FORMATS)})"
+                )
+        finally:
+            # Clean up temporary file if we downloaded one
+            if downloaded_temp_file and downloaded_temp_file.exists():
+                try:
+                    downloaded_temp_file.unlink()
+                    self.logger.debug(f"Removed temporary file: {downloaded_temp_file}")
+                except Exception as e:
+                    self.logger.warning(f"Failed to remove temporary file {downloaded_temp_file}: {e}")
 
     def _run_docling_command(
         self,
@@ -1604,13 +1673,15 @@ class DoclingParser(Parser):
         content_list = []
         if not block.get("children"):
             cnt += 1
-            content_list.append(self.read_from_block(block, type, output_dir, cnt, num))
+            result = self.read_from_block(block, type, output_dir, cnt, num)
+            if result:
+                content_list.append(result)
         else:
             if type not in ["groups", "body"]:
                 cnt += 1
-                content_list.append(
-                    self.read_from_block(block, type, output_dir, cnt, num)
-                )
+                result = self.read_from_block(block, type, output_dir, cnt, num)
+                if result:
+                    content_list.append(result)
             members = block["children"]
             for member in members:
                 cnt += 1

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -1710,15 +1710,13 @@ class DoclingParser(Parser):
         content_list = []
         if not block.get("children"):
             cnt += 1
-            result = self.read_from_block(block, type, output_dir, cnt, num)
-            if result:
-                content_list.append(result)
+            content_list.append(self.read_from_block(block, type, output_dir, cnt, num))
         else:
             if type not in ["groups", "body"]:
                 cnt += 1
-                result = self.read_from_block(block, type, output_dir, cnt, num)
-                if result:
-                    content_list.append(result)
+                content_list.append(
+                    self.read_from_block(block, type, output_dir, cnt, num)
+                )
             members = block["children"]
             for member in members:
                 cnt += 1

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -89,42 +89,77 @@ class Parser:
     def _download_file(self, url: str) -> Path:
         """
         Download a file from a URL to a temporary file.
-        Attempts to preserve the file extension from the URL.
+        Attempts to preserve the file extension from the URL or Content-Type header.
         """
+        tmp_path = None
+        response = None
         try:
             self.logger.info(f"Downloading file from URL: {url}")
-            
+
             # Parse URL to get path and extension
             parsed_url = urllib.parse.urlparse(url)
             path = Path(parsed_url.path)
             suffix = path.suffix if path.suffix else ""
-            
+
+            # Create request with User-Agent to avoid 403 Forbidden from some sites
+            req = urllib.request.Request(
+                url,
+                data=None,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
+                },
+            )
+
+            # Open connection to get headers
+            response = urllib.request.urlopen(req)
+
+            # If no extension in URL, try Content-Type header
+            if not suffix:
+                content_type = (
+                    response.headers.get("Content-Type", "").split(";")[0].strip()
+                )
+                if content_type:
+                    import mimetypes
+
+                    guessed_ext = mimetypes.guess_extension(content_type)
+                    if guessed_ext:
+                        suffix = guessed_ext
+                        self.logger.info(
+                            f"Inferred file extension '{suffix}' from Content-Type: {content_type}"
+                        )
+
             # Create a temporary file with the correct extension
-            # delete=False is important so we can close it and let other processes open it
-            # We must manually delete it later
             fd, tmp_path = tempfile.mkstemp(suffix=suffix)
             os.close(fd)
             tmp_path = Path(tmp_path)
-            
-            # Download the file
-            # We use a user-agent to avoid 403 Forbidden from some sites
-            req = urllib.request.Request(
-                url, 
-                data=None, 
-                headers={
-                    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36'
-                }
-            )
-            
-            with urllib.request.urlopen(req) as response, open(tmp_path, 'wb') as out_file:
+
+            # Download the file content
+            with open(tmp_path, "wb") as out_file:
                 shutil.copyfileobj(response, out_file)
-                
-            self.logger.info(f"Downloaded to temporary file: {tmp_path} ({tmp_path.stat().st_size} bytes)")
+
+            self.logger.info(
+                f"Downloaded to temporary file: {tmp_path} ({tmp_path.stat().st_size} bytes)"
+            )
             return tmp_path
-            
+
         except Exception as e:
+            # Clean up temp file if it was created
+            if tmp_path and tmp_path.exists():
+                try:
+                    tmp_path.unlink()
+                    self.logger.debug(
+                        f"Cleaned up temporary file after failed download: {tmp_path}"
+                    )
+                except Exception as cleanup_error:
+                    self.logger.warning(
+                        f"Failed to clean up temp file {tmp_path}: {cleanup_error}"
+                    )
+
             self.logger.error(f"Failed to download file from {url}: {e}")
             raise RuntimeError(f"Failed to download file from {url}: {e}")
+        finally:
+            if response:
+                response.close()
 
     def __init__(self) -> None:
         """Initialize the base parser."""
@@ -1482,25 +1517,25 @@ class DoclingParser(Parser):
     ) -> List[Dict[str, Any]]:
         """
         Parse document using Docling based on file extension
-        
+
         Args:
             file_path: Path to the file to be parsed or URL
             method: Parsing method
             output_dir: Output directory path
             lang: Document language for optimization
             **kwargs: Additional parameters for docling command
-            
+
         Returns:
             List[Dict[str, Any]]: List of content blocks
         """
         downloaded_temp_file = None
-        
+
         try:
             # Check if input is a URL
             if self._is_url(file_path):
                 file_path = self._download_file(file_path)
                 downloaded_temp_file = file_path
-                
+
             # Convert to Path object
             file_path = Path(file_path)
             if not file_path.exists():
@@ -1529,7 +1564,9 @@ class DoclingParser(Parser):
                     downloaded_temp_file.unlink()
                     self.logger.debug(f"Removed temporary file: {downloaded_temp_file}")
                 except Exception as e:
-                    self.logger.warning(f"Failed to remove temporary file {downloaded_temp_file}: {e}")
+                    self.logger.warning(
+                        f"Failed to remove temporary file {downloaded_temp_file}: {e}"
+                    )
 
     def _run_docling_command(
         self,

--- a/tests/test_parser_url_download.py
+++ b/tests/test_parser_url_download.py
@@ -1,0 +1,129 @@
+"""Tests for the Parser URL detection and download helpers."""
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _load_parser_class():
+    """Load Parser without importing the heavy raganything package."""
+    import importlib.util
+
+    module_path = Path(__file__).resolve().parents[1] / "raganything" / "parser.py"
+    spec = importlib.util.spec_from_file_location("_raganything_parser", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.Parser
+
+
+Parser = _load_parser_class()
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://example.com/file.pdf", True),
+        ("http://example.com/path?id=1", True),
+        ("/local/path/file.pdf", False),
+        ("file.pdf", False),
+        ("", False),
+        ("ftp://example.com/x", True),
+    ],
+)
+def test_is_url(value, expected):
+    assert Parser._is_url(value) is expected
+
+
+def _fake_response(*, body: bytes = b"%PDF-1.4 fake", content_type: str = ""):
+    response = MagicMock()
+    response.headers.get.return_value = content_type
+    response.read = io.BytesIO(body).read
+    response.close = MagicMock()
+    return response
+
+
+def test_download_file_uses_extension_from_url_path(tmp_path):
+    parser = Parser()
+    response = _fake_response()
+
+    with patch("urllib.request.urlopen", return_value=response) as mock_open:
+        downloaded = parser._download_file("https://example.com/docs/report.pdf")
+
+    try:
+        assert downloaded.suffix == ".pdf"
+        assert downloaded.exists()
+        assert downloaded.read_bytes() == b"%PDF-1.4 fake"
+        mock_open.assert_called_once()
+        _, kwargs = mock_open.call_args
+        assert kwargs.get("timeout") == 30, "must pass an explicit timeout"
+    finally:
+        if downloaded.exists():
+            downloaded.unlink()
+
+
+def test_download_file_infers_extension_from_content_type(tmp_path):
+    parser = Parser()
+    response = _fake_response(content_type="application/pdf; charset=utf-8")
+
+    with patch("urllib.request.urlopen", return_value=response):
+        downloaded = parser._download_file("https://example.com/download?id=123")
+
+    try:
+        assert downloaded.suffix == ".pdf"
+        assert downloaded.exists()
+    finally:
+        if downloaded.exists():
+            downloaded.unlink()
+
+
+def test_download_file_cleans_up_temp_on_failure():
+    parser = Parser()
+    leaked: list[Path] = []
+
+    real_mkstemp = __import__("tempfile").mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        leaked.append(Path(name))
+        return fd, name
+
+    response = MagicMock()
+    response.headers.get.return_value = ""
+    response.read.side_effect = OSError("connection reset")
+    response.close = MagicMock()
+
+    with patch("urllib.request.urlopen", return_value=response), \
+         patch("tempfile.mkstemp", side_effect=tracking_mkstemp):
+        with pytest.raises(RuntimeError, match="Failed to download"):
+            parser._download_file("https://example.com/file.pdf")
+
+    assert leaked, "temp file should have been created"
+    for p in leaked:
+        assert not p.exists(), (
+            f"temp file {p} leaked after failed download — exception path "
+            "must clean it up"
+        )
+    response.close.assert_called_once()
+
+
+def test_download_file_cleans_up_temp_on_urlopen_failure():
+    """When urlopen itself fails, no temp file should be created or leaked."""
+    parser = Parser()
+    created: list[Path] = []
+
+    real_mkstemp = __import__("tempfile").mkstemp
+
+    def tracking_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        created.append(Path(name))
+        return fd, name
+
+    with patch("urllib.request.urlopen", side_effect=TimeoutError("stalled")), \
+         patch("tempfile.mkstemp", side_effect=tracking_mkstemp):
+        with pytest.raises(RuntimeError, match="Failed to download"):
+            parser._download_file("https://slow.example.com/file.pdf")
+
+    for p in created:
+        assert not p.exists(), f"temp file {p} leaked"

--- a/tests/test_parser_url_download.py
+++ b/tests/test_parser_url_download.py
@@ -1,4 +1,5 @@
 """Tests for the Parser URL detection and download helpers."""
+
 import io
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -94,8 +95,10 @@ def test_download_file_cleans_up_temp_on_failure():
     response.read.side_effect = OSError("connection reset")
     response.close = MagicMock()
 
-    with patch("urllib.request.urlopen", return_value=response), \
-         patch("tempfile.mkstemp", side_effect=tracking_mkstemp):
+    with (
+        patch("urllib.request.urlopen", return_value=response),
+        patch("tempfile.mkstemp", side_effect=tracking_mkstemp),
+    ):
         with pytest.raises(RuntimeError, match="Failed to download"):
             parser._download_file("https://example.com/file.pdf")
 
@@ -120,8 +123,10 @@ def test_download_file_cleans_up_temp_on_urlopen_failure():
         created.append(Path(name))
         return fd, name
 
-    with patch("urllib.request.urlopen", side_effect=TimeoutError("stalled")), \
-         patch("tempfile.mkstemp", side_effect=tracking_mkstemp):
+    with (
+        patch("urllib.request.urlopen", side_effect=TimeoutError("stalled")),
+        patch("tempfile.mkstemp", side_effect=tracking_mkstemp),
+    ):
         with pytest.raises(RuntimeError, match="Failed to download"):
             parser._download_file("https://slow.example.com/file.pdf")
 


### PR DESCRIPTION
- Implemented URL detection and secure downloading in Parser base class.
- Added temporary file handling with automatic cleanup in DoclingParser.
- Added user-agent headers to prevent 403 errors during document retrieval.
- Included verification script for automated URL parsing tests.
- add docling v2.72.0 to requirements
- Closes #183

## Description
This PR implements the ability to parse documents directly from a URL using the `DoclingParser`. It allows the RAG pipeline to ingest remote resources seamlessly by handling the download and cleanup process automatically.

## Related Issues
Closes #183

## Changes Made
* **`Parser` base class**: Added `_is_url()` for detection and `_download_file()` to handle retrieval with custom User-Agent headers.
* **`DoclingParser` class**: Integrated the URL workflow into the `parse_document` method, using `try...finally` to ensure disk cleanup of temporary files.
* **Verification script**: A verification script is included at scripts/test_url_parsing.py. I'm happy to remove it if you prefer to keep the scripts folder strictly for core utilities.

## Checklist
- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes
The implementation mimics a browser User-Agent to avoid `403 Forbidden` errors from common document hosts (like S3 or GitHub).