### PR TITLE
fix: prevent same-name file collision in parser output directories (#51)

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -64,7 +64,9 @@ class Parser:
         pass
 
     @staticmethod
-    def _unique_output_dir(base_dir: Union[str, Path], file_path: Union[str, Path]) -> Path:
+    def _unique_output_dir(
+        base_dir: Union[str, Path], file_path: Union[str, Path]
+    ) -> Path:
         """Create a unique output subdirectory for a file to prevent same-name collisions.
 
         When multiple files share the same name (e.g. dir1/paper.pdf and dir2/paper.pdf),


### PR DESCRIPTION
When multiple files share the same name (e.g. dir1/paper.pdf and dir2/paper.pdf), their parser output was written to the same directory, causing data loss.

Add _unique_output_dir() that creates a unique subdirectory per file by appending a short hash of the file's absolute path (e.g. paper_a1b2c3d4/). This ensures each file gets its own isolated output directory.

<!--
Thanks for contributing to RAGAnything!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

[Briefly describe the changes made in this pull request.]

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

[List the specific changes made in this pull request.]

## Checklist

- [ ] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
