### PR TITLE
fix: strip thinking tags before all JSON parse strategies

### DIFF
--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -546,6 +546,18 @@ class BaseModalProcessor:
 
     def _robust_json_parse(self, response: str) -> dict:
         """Robust JSON parsing with multiple fallback strategies"""
+        import re
+
+        # Pre-strip thinking/reasoning tags so all strategies (including the
+        # regex fallback) operate on the actual model output, not internal
+        # chain-of-thought text. Fixes issues with reasoning models like
+        # qwen2.5-think and deepseek-r1 (#159).
+        response = re.sub(
+            r"<think>.*?</think>", "", response, flags=re.DOTALL | re.IGNORECASE
+        )
+        response = re.sub(
+            r"<thinking>.*?</thinking>", "", response, flags=re.DOTALL | re.IGNORECASE
+        )
 
         # Strategy 1: Try direct parsing first
         for json_candidate in self._extract_all_json_candidates(response):


### PR DESCRIPTION
Closes #159

When using reasoning models (qwen2.5-think, deepseek-r1, etc.), the `<think>...</think>` tags were only stripped in `_extract_all_json_candidates()`, meaning the regex fallback strategy (`_extract_fields_with_regex`) still operated on the raw response including thinking content. This could cause it to extract content from the thinking section rather than the actual analysis.

This fix moves the think-tag stripping to the top of `_robust_json_parse()` so all downstream strategies work with clean model output.