### PR TITLE
feat: add custom parser plugin system (closes #151)

### DIFF
--- a/examples/raganything_example.py
+++ b/examples/raganything_example.py
@@ -289,8 +289,10 @@ def main():
     parser.add_argument(
         "--parser",
         default=os.getenv("PARSER", "mineru"),
-        choices=["mineru", "docling", "paddleocr"],
-        help="Parser selection",
+        help=(
+            "Parser selection (mineru, docling, paddleocr, or any "
+            "registered custom parser name)."
+        ),
     )
 
     args = parser.parse_args()

--- a/examples/raganything_example.py
+++ b/examples/raganything_example.py
@@ -290,8 +290,11 @@ def main():
         "--parser",
         default=os.getenv("PARSER", "mineru"),
         help=(
-            "Parser selection (mineru, docling, paddleocr, or any "
-            "registered custom parser name)."
+            "Parser selection. Built-ins: mineru, docling, paddleocr. "
+            "Custom parsers that you register via register_parser() in the "
+            "same Python process are also accepted when using RAGAnything as "
+            "a library. This example script does not perform any automatic "
+            "plugin discovery."
         ),
     )
 

--- a/raganything/batch_parser.py
+++ b/raganything/batch_parser.py
@@ -382,9 +382,11 @@ def main():
     parser.add_argument("--output", "-o", required=True, help="Output directory")
     parser.add_argument(
         "--parser",
-        choices=list(SUPPORTED_PARSERS),
         default="mineru",
-        help="Parser to use",
+        help=(
+            "Parser to use. Built-ins: mineru, docling, paddleocr. "
+            "Also accepts custom parsers registered via register_parser()."
+        ),
     )
     parser.add_argument(
         "--method",

--- a/raganything/batch_parser.py
+++ b/raganything/batch_parser.py
@@ -385,7 +385,10 @@ def main():
         default="mineru",
         help=(
             "Parser to use. Built-ins: mineru, docling, paddleocr. "
-            "Also accepts custom parsers registered via register_parser()."
+            "When using RAGAnything as a library, any custom parsers that you "
+            "have registered via register_parser() in the current process "
+            "are also accepted. The standalone CLI itself does not perform "
+            "plugin discovery."
         ),
     )
     parser.add_argument(

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -2111,10 +2111,122 @@ class PaddleOCRParser(Parser):
             return False
 
 
+# Custom parser registry for Bring-Your-Own-Parser support (see #151)
+_CUSTOM_PARSERS: Dict[str, type] = {}
+
+
+def register_parser(name: str, parser_class: type) -> None:
+    """Register a custom parser class for use with RAGAnything.
+
+    This enables the Bring-Your-Own-Parser pattern: users can integrate
+    any document parser (e.g., Marker, Unstructured, Surya) by subclassing
+    ``Parser`` and registering it here.
+
+    Args:
+        name: Unique identifier for the parser (e.g., "marker", "surya").
+              Must not collide with built-in names ("mineru", "docling", "paddleocr").
+        parser_class: A subclass of ``Parser`` that implements at least
+                      ``parse_document``, ``check_installation``, and
+                      optionally ``parse_pdf``, ``parse_image``, ``parse_office_doc``.
+
+    Raises:
+        TypeError: If *parser_class* is not a subclass of ``Parser``.
+        ValueError: If *name* collides with a built-in parser name.
+
+    Example::
+
+        from raganything.parser import Parser, register_parser
+
+        class MarkerParser(Parser):
+            def check_installation(self) -> bool:
+                try:
+                    import marker
+                    return True
+                except ImportError:
+                    return False
+
+            def parse_pdf(self, pdf_path, output_dir="./output", method="auto", **kw):
+                import marker
+                # ... your implementation ...
+                return content_list
+
+            def parse_document(self, file_path, output_dir="./output", method="auto", **kw):
+                return self.parse_pdf(pdf_path=file_path, output_dir=output_dir, method=method, **kw)
+
+        register_parser("marker", MarkerParser)
+    """
+    name = name.strip().lower()
+    if not isinstance(parser_class, type) or not issubclass(parser_class, Parser):
+        raise TypeError(
+            f"parser_class must be a subclass of Parser, got {parser_class!r}"
+        )
+    _BUILTIN_NAMES = {"mineru", "docling", "paddleocr"}
+    if name in _BUILTIN_NAMES:
+        raise ValueError(
+            f"Cannot override built-in parser '{name}'. "
+            f"Choose a different name for your custom parser."
+        )
+    _CUSTOM_PARSERS[name] = parser_class
+    Parser.logger.info(f"Registered custom parser: '{name}' -> {parser_class.__name__}")
+
+
+def unregister_parser(name: str) -> None:
+    """Remove a previously registered custom parser.
+
+    Args:
+        name: The parser name to remove.
+
+    Raises:
+        KeyError: If no custom parser with that name is registered.
+    """
+    name = name.strip().lower()
+    if name not in _CUSTOM_PARSERS:
+        raise KeyError(f"No custom parser registered with name '{name}'")
+    del _CUSTOM_PARSERS[name]
+    Parser.logger.info(f"Unregistered custom parser: '{name}'")
+
+
+def list_parsers() -> Dict[str, str]:
+    """Return a mapping of all available parser names to their class names.
+
+    Returns:
+        Dict mapping parser name to the fully-qualified class name.
+        Includes both built-in and custom parsers.
+    """
+    result: Dict[str, str] = {
+        "mineru": "MineruParser",
+        "docling": "DoclingParser",
+        "paddleocr": "PaddleOCRParser",
+    }
+    for name, cls in _CUSTOM_PARSERS.items():
+        result[name] = cls.__name__
+    return result
+
+
 SUPPORTED_PARSERS = ("mineru", "docling", "paddleocr")
 
 
+def get_supported_parsers() -> tuple:
+    """Return all supported parser names including custom registered parsers."""
+    return SUPPORTED_PARSERS + tuple(_CUSTOM_PARSERS.keys())
+
+
 def get_parser(parser_type: str) -> Parser:
+    """Get a parser instance by name.
+
+    Checks built-in parsers first, then falls back to the custom parser
+    registry populated via :func:`register_parser`.
+
+    Args:
+        parser_type: Parser name (e.g., "mineru", "docling", "paddleocr",
+                     or any custom registered name).
+
+    Returns:
+        An instance of the requested parser.
+
+    Raises:
+        ValueError: If the parser name is not recognized.
+    """
     parser_name = (parser_type or "mineru").strip().lower()
     if parser_name == "mineru":
         return MineruParser()
@@ -2122,12 +2234,13 @@ def get_parser(parser_type: str) -> Parser:
         return DoclingParser()
     if parser_name == "paddleocr":
         return PaddleOCRParser()
+    # Check custom parser registry
+    if parser_name in _CUSTOM_PARSERS:
+        return _CUSTOM_PARSERS[parser_name]()
     raise ValueError(
         f"Unsupported parser type: {parser_type}. "
-        f"Supported parsers: {', '.join(SUPPORTED_PARSERS)}"
+        f"Supported parsers: {', '.join(get_supported_parsers())}"
     )
-
-
 def main():
     """
     Main function to run the document parser from command line

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -2111,6 +2111,18 @@ class PaddleOCRParser(Parser):
             return False
 
 
+def _normalize_parser_name(name: str) -> str:
+    """Normalize and validate a parser name for registry APIs."""
+    if not isinstance(name, str):
+        raise TypeError(
+            f"parser name must be a non-empty string, got {type(name).__name__}"
+        )
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("parser name must be a non-empty string")
+    return normalized
+
+
 # Custom parser registry for Bring-Your-Own-Parser support (see #151)
 _CUSTOM_PARSERS: Dict[str, type] = {}
 
@@ -2155,19 +2167,21 @@ def register_parser(name: str, parser_class: type) -> None:
 
         register_parser("marker", MarkerParser)
     """
-    name = name.strip().lower()
+    normalized_name = _normalize_parser_name(name)
     if not isinstance(parser_class, type) or not issubclass(parser_class, Parser):
         raise TypeError(
             f"parser_class must be a subclass of Parser, got {parser_class!r}"
         )
     _BUILTIN_NAMES = {"mineru", "docling", "paddleocr"}
-    if name in _BUILTIN_NAMES:
+    if normalized_name in _BUILTIN_NAMES:
         raise ValueError(
-            f"Cannot override built-in parser '{name}'. "
+            f"Cannot override built-in parser '{normalized_name}'. "
             f"Choose a different name for your custom parser."
         )
-    _CUSTOM_PARSERS[name] = parser_class
-    Parser.logger.info(f"Registered custom parser: '{name}' -> {parser_class.__name__}")
+    _CUSTOM_PARSERS[normalized_name] = parser_class
+    Parser.logger.info(
+        "Registered custom parser: '%s' -> %s", normalized_name, parser_class.__name__
+    )
 
 
 def unregister_parser(name: str) -> None:
@@ -2177,13 +2191,15 @@ def unregister_parser(name: str) -> None:
         name: The parser name to remove.
 
     Raises:
+        TypeError: If *name* is not a string.
+        ValueError: If *name* is empty or only whitespace.
         KeyError: If no custom parser with that name is registered.
     """
-    name = name.strip().lower()
-    if name not in _CUSTOM_PARSERS:
-        raise KeyError(f"No custom parser registered with name '{name}'")
-    del _CUSTOM_PARSERS[name]
-    Parser.logger.info(f"Unregistered custom parser: '{name}'")
+    normalized_name = _normalize_parser_name(name)
+    if normalized_name not in _CUSTOM_PARSERS:
+        raise KeyError(f"No custom parser registered with name '{normalized_name}'")
+    del _CUSTOM_PARSERS[normalized_name]
+    Parser.logger.info("Unregistered custom parser: '%s'", normalized_name)
 
 
 def list_parsers() -> Dict[str, str]:
@@ -2306,9 +2322,11 @@ def main():
     )
     parser.add_argument(
         "--parser",
-        choices=list(SUPPORTED_PARSERS),
         default="mineru",
-        help="Parser selection",
+        help=(
+            "Parser selection. Built-ins: mineru, docling, paddleocr. "
+            "Custom parsers registered via register_parser() are also accepted."
+        ),
     )
     parser.add_argument(
         "--vlm_url",

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -2,11 +2,23 @@
 """
 Generic Document Parser Utility
 
-This module provides functionality for parsing PDF and image documents using MinerU 2.0 library,
-and converts the parsing results into markdown and JSON formats
+This module provides functionality for parsing documents using the built-in
+MinerU, Docling, and PaddleOCR parsers, and exposes a small registry for
+**in-process** custom parsers (see :func:`register_parser`).
 
-Note: MinerU 2.0 no longer includes LibreOffice document conversion module.
-For Office documents (.doc, .docx, .ppt, .pptx), please convert them to PDF format first.
+Important notes:
+
+- The custom parser registry is primarily intended for Python usage, where your
+  application imports a parser implementation and calls :func:`register_parser`
+  before invoking RAGAnything APIs.
+- The standalone CLI (``python -m raganything.parser`` or the installed console
+  script) does **not** perform automatic plugin discovery; it will only see
+  custom parsers that have already been registered in the current process
+  (for example via a wrapper script or :mod:`sitecustomize`).
+
+MinerU 2.0 no longer includes LibreOffice document conversion module.
+For Office documents (.doc, .docx, .ppt, .pptx), please convert them to PDF
+format first.
 """
 
 from __future__ import annotations
@@ -2325,7 +2337,10 @@ def main():
         default="mineru",
         help=(
             "Parser selection. Built-ins: mineru, docling, paddleocr. "
-            "Custom parsers registered via register_parser() are also accepted."
+            "Custom parsers registered via register_parser() in the same "
+            "Python process are also accepted when you integrate RAGAnything "
+            "as a library. The standalone CLI itself only sees parsers that "
+            "have already been registered in this process."
         ),
     )
     parser.add_argument(

--- a/tests/test_custom_parser.py
+++ b/tests/test_custom_parser.py
@@ -1,0 +1,129 @@
+"""Tests for the custom parser plugin system (addresses #151)."""
+
+import pytest
+
+from raganything.parser import (
+    Parser,
+    get_parser,
+    register_parser,
+    unregister_parser,
+    list_parsers,
+    get_supported_parsers,
+    _CUSTOM_PARSERS,
+    SUPPORTED_PARSERS,
+)
+
+
+class DummyParser(Parser):
+    """Minimal custom parser for testing."""
+
+    def check_installation(self) -> bool:
+        return True
+
+    def parse_document(self, file_path, output_dir="./output", method="auto", **kw):
+        return [{"type": "text", "text": "dummy parsed content", "page_idx": 0}]
+
+    def parse_pdf(self, pdf_path, output_dir="./output", method="auto", **kw):
+        return self.parse_document(file_path=pdf_path, output_dir=output_dir, method=method, **kw)
+
+
+class AnotherParser(Parser):
+    """Another custom parser for testing."""
+
+    def check_installation(self) -> bool:
+        return False
+
+    def parse_document(self, file_path, output_dir="./output", method="auto", **kw):
+        return [{"type": "text", "text": "another parsed", "page_idx": 0}]
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Ensure a clean custom parser registry for every test."""
+    _CUSTOM_PARSERS.clear()
+    yield
+    _CUSTOM_PARSERS.clear()
+
+
+class TestRegisterParser:
+    def test_register_and_get(self):
+        register_parser("dummy", DummyParser)
+        parser = get_parser("dummy")
+        assert isinstance(parser, DummyParser)
+
+    def test_register_case_insensitive(self):
+        register_parser("  Dummy  ", DummyParser)
+        parser = get_parser("dummy")
+        assert isinstance(parser, DummyParser)
+
+    def test_register_rejects_non_parser_subclass(self):
+        with pytest.raises(TypeError, match="subclass of Parser"):
+            register_parser("bad", dict)
+
+    def test_register_rejects_builtin_name(self):
+        for name in ("mineru", "docling", "paddleocr"):
+            with pytest.raises(ValueError, match="Cannot override built-in"):
+                register_parser(name, DummyParser)
+
+    def test_register_overwrites_same_custom_name(self):
+        register_parser("custom", DummyParser)
+        register_parser("custom", AnotherParser)
+        parser = get_parser("custom")
+        assert isinstance(parser, AnotherParser)
+
+
+class TestUnregisterParser:
+    def test_unregister_existing(self):
+        register_parser("dummy", DummyParser)
+        unregister_parser("dummy")
+        with pytest.raises(ValueError, match="Unsupported parser type"):
+            get_parser("dummy")
+
+    def test_unregister_nonexistent(self):
+        with pytest.raises(KeyError, match="No custom parser"):
+            unregister_parser("nonexistent")
+
+
+class TestListParsers:
+    def test_list_builtin_only(self):
+        result = list_parsers()
+        assert "mineru" in result
+        assert "docling" in result
+        assert "paddleocr" in result
+        assert len(result) == 3
+
+    def test_list_includes_custom(self):
+        register_parser("dummy", DummyParser)
+        result = list_parsers()
+        assert "dummy" in result
+        assert result["dummy"] == "DummyParser"
+        assert len(result) == 4
+
+
+class TestGetSupportedParsers:
+    def test_builtin_only(self):
+        supported = get_supported_parsers()
+        assert set(SUPPORTED_PARSERS).issubset(set(supported))
+
+    def test_includes_custom(self):
+        register_parser("dummy", DummyParser)
+        supported = get_supported_parsers()
+        assert "dummy" in supported
+
+
+class TestGetParserFallback:
+    def test_builtin_parsers_still_work(self):
+        """Ensure built-in parsers are unaffected by the plugin system."""
+        for name in SUPPORTED_PARSERS:
+            parser = get_parser(name)
+            assert isinstance(parser, Parser)
+
+    def test_unknown_parser_raises(self):
+        with pytest.raises(ValueError, match="Unsupported parser type"):
+            get_parser("totally-unknown")
+
+    def test_custom_parser_content(self):
+        register_parser("dummy", DummyParser)
+        parser = get_parser("dummy")
+        content = parser.parse_document("fake.pdf")
+        assert content == [{"type": "text", "text": "dummy parsed content", "page_idx": 0}]

--- a/tests/test_custom_parser.py
+++ b/tests/test_custom_parser.py
@@ -72,6 +72,24 @@ class TestRegisterParser:
         assert isinstance(parser, AnotherParser)
 
 
+class TestParserNameValidation:
+    def test_register_rejects_non_string_name(self):
+        with pytest.raises(TypeError, match="non-empty string"):
+            register_parser(123, DummyParser)  # type: ignore[arg-type]
+
+    def test_register_rejects_blank_name(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            register_parser("   ", DummyParser)
+
+    def test_unregister_rejects_non_string_name(self):
+        with pytest.raises(TypeError, match="non-empty string"):
+            unregister_parser(None)  # type: ignore[arg-type]
+
+    def test_unregister_rejects_blank_name(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            unregister_parser("   ")
+
+
 class TestUnregisterParser:
     def test_unregister_existing(self):
         register_parser("dummy", DummyParser)
@@ -127,3 +145,41 @@ class TestGetParserFallback:
         parser = get_parser("dummy")
         content = parser.parse_document("fake.pdf")
         assert content == [{"type": "text", "text": "dummy parsed content", "page_idx": 0}]
+
+
+class TestCliIntegration:
+    def test_cli_accepts_custom_parser_name(self, monkeypatch, tmp_path):
+        """Ensure CLI argument parsing does not reject custom parser names."""
+        import sys
+        from raganything import parser as parser_module
+
+        class DummyCliParser(Parser):
+            def check_installation(self) -> bool:
+                return True
+
+            def parse_document(
+                self, file_path, output_dir="./output", method="auto", **kwargs
+            ):
+                # Do not touch the filesystem; just return a dummy result.
+                return [{"type": "text", "text": "ok", "page_idx": 0}]
+
+        def fake_get_parser(name: str) -> Parser:
+            assert name == "custom-cli"
+            return DummyCliParser()
+
+        monkeypatch.setattr(parser_module, "get_parser", fake_get_parser)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "raganything-parser",
+                str(tmp_path / "dummy.pdf"),
+                "--parser",
+                "custom-cli",
+            ],
+        )
+
+        # If argparse still enforced choices, this would raise SystemExit
+        # before our fake_get_parser is even called.
+        exit_code = parser_module.main()
+        assert exit_code == 0


### PR DESCRIPTION
### Summary
This PR adds a small, extensible custom parser plugin system for `raganything.parser`, so users can register their own parsers (Marker, Unstructured, Surya, etc.) without modifying the core code.

### Motivation
Currently `get_parser()` only supports three hard-coded parsers. Several users have asked for a Bring-Your-Own-Parser mechanism (#151) to try different backends or reuse existing tooling. This PR introduces a registry-based approach that keeps the existing behavior intact while allowing safe, opt-in extension.

### Changes
- **`raganything/parser.py`**
  - Added a `_CUSTOM_PARSERS` registry for user-defined parsers.
  - Updated `get_parser()` to resolve built-in parsers first, then fall back to the custom registry (case-insensitive name matching).
  - Prevented overriding of built-in parser names (`mineru`, `docling`, `paddleocr`).
  - Enforced that custom parsers must subclass `Parser`, with clear error messages if validation fails.
  - Added public APIs: `register_parser()`, `unregister_parser()`, `list_parsers()`, `get_supported_parsers()`.
- **`tests/test_custom_parser.py`**
  - Tests for registration, resolution, case-insensitive matching, built-in name protection, type validation, and unregister/list behavior.

### Testing
- Ran `pytest` locally including `tests/test_custom_parser.py`; all tests passed.
- Verified that existing behavior for the three built-in parsers remains unchanged.

Thanks for your work on RAG-Anything—very happy to adjust the API shape or naming if you prefer a different direction for the parser registry.