### PR TITLE
fix(examples): use openai_embed.func to prevent double EmbeddingFunc wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ async def main():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed(
+        func=lambda texts: openai_embed.func(
             texts,
             model="text-embedding-3-large",
             api_key=api_key,
@@ -485,7 +485,7 @@ async def process_multimodal_content():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model="text-embedding-3-large",
                 api_key=api_key,
@@ -711,7 +711,7 @@ async def load_existing_lightrag():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model="text-embedding-3-large",
                 api_key=api_key,
@@ -874,7 +874,7 @@ async def insert_content_list_example():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed(
+        func=lambda texts: openai_embed.func(
             texts,
             model="text-embedding-3-large",
             api_key=api_key,

--- a/README_zh.md
+++ b/README_zh.md
@@ -389,7 +389,7 @@ async def main():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed(
+        func=lambda texts: openai_embed.func(
             texts,
             model="text-embedding-3-large",
             api_key=api_key,
@@ -467,7 +467,7 @@ async def process_multimodal_content():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model="text-embedding-3-large",
                 api_key=api_key,
@@ -692,7 +692,7 @@ async def load_existing_lightrag():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model="text-embedding-3-large",
                 api_key=api_key,
@@ -855,7 +855,7 @@ async def insert_content_list_example():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed(
+        func=lambda texts: openai_embed.func(
             texts,
             model="text-embedding-3-large",
             api_key=api_key,

--- a/examples/insert_content_list_example.py
+++ b/examples/insert_content_list_example.py
@@ -252,7 +252,7 @@ async def demo_insert_content_list(
         embedding_func = EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model=embedding_model,
                 api_key=api_key,

--- a/examples/modalprocessors_example.py
+++ b/examples/modalprocessors_example.py
@@ -175,7 +175,7 @@ async def initialize_rag(api_key: str, base_url: str = None):
         embedding_func=EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model=embedding_model,
                 api_key=api_key,

--- a/examples/raganything_example.py
+++ b/examples/raganything_example.py
@@ -189,7 +189,7 @@ async def process_with_rag(
         embedding_func = EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
-            func=lambda texts: openai_embed(
+            func=lambda texts: openai_embed.func(
                 texts,
                 model=embedding_model,
                 api_key=api_key,


### PR DESCRIPTION
## Summary

- Fix `Vector count mismatch: expected N vectors but got 2N vectors` error caused by double `EmbeddingFunc` wrapping in all examples and README docs
- `openai_embed` is an `EmbeddingFunc` instance (decorated with `@wrap_embedding_func_with_attrs`). Wrapping it inside a lambda passed to another `EmbeddingFunc` causes `__call__` to execute twice, doubling the returned vector count
- Changed `openai_embed(` → `openai_embed.func(` in 5 files (3 examples + 2 READMEs) to access the unwrapped async function directly, as documented in lightrag-hku's own codebase

## Root cause

`EmbeddingFunc.__post_init__` has auto-unwrap logic for nested `EmbeddingFunc`, but it cannot detect the nesting when the inner `EmbeddingFunc` is hidden behind a lambda:

```python
# ❌ Bug: lambda hides EmbeddingFunc from __post_init__ unwrap detection
EmbeddingFunc(
    func=lambda texts: openai_embed(texts, ...)  # openai_embed is EmbeddingFunc
)

# ✅ Fix: use .func to access the raw async function
EmbeddingFunc(
    func=lambda texts: openai_embed.func(texts, ...)
)
```

This pattern is already documented in lightrag-hku's source:
- `wrap_embedding_func_with_attrs` docstring warns against this exact pattern
- `azure_openai_embed` internally uses `openai_embed.func()` for the same reason

## Related issues

- Root cause of [HKUDS/LightRAG#2549](https://github.com/HKUDS/LightRAG/issues/2549) — reported 3 months ago, workarounds proposed but root cause was not identified
- Affects all users running the examples as-is with OpenAI embeddings

## Files changed

| File | Occurrences fixed |
|------|:-:|
| `README.md` | 4 |
| `README_zh.md` | 4 |
| `examples/raganything_example.py` | 1 |
| `examples/insert_content_list_example.py` | 1 |
| `examples/modalprocessors_example.py` | 1 |

Note: `vllm_integration_example.py` and `lmstudio_integration_example.py` are not affected — they define standalone async functions instead of using the lambda pattern.

## Test plan

- [x] Verified `openai_embed` is an `EmbeddingFunc` instance (`type()` confirms)
- [x] Reproduced the 2x vector bug with minimal test (2 texts → 4 vectors)
- [x] Confirmed fix returns correct shape `(2, 3072)` with `openai_embed.func`
- [x] Full end-to-end test: processed a 17-page PDF (RAG-Anything paper) through the complete pipeline — document parsing, multimodal analysis, knowledge graph construction, and all 3 query types (text, table, equation) succeeded without errors