### PR TITLE
fix: use valid CID font names for Chinese text rendering (fixes #24)

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -346,38 +346,22 @@ class Parser:
                     heading_style.fontName = "WenQuanYi"
 
                 # Try to register a font that supports Chinese characters
+                # UnicodeCIDFont only supports specific CID font names:
+                #   STSong-Light (Chinese), MSung-Light (Chinese Traditional),
+                #   HeiseiMin-W3 / HeiseiKakuGo-W5 (Japanese),
+                #   HYSMyeongJo-Medium (Korean)
+                # System font names like "SimSun", "SimHei", "STHeiti" are
+                # NOT valid CID names and silently fail (#24).
                 try:
-                    # Try to use system fonts that support Chinese
-                    import platform
+                    from reportlab.pdfbase.cidfonts import UnicodeCIDFont
 
-                    system = platform.system()
-                    if system == "Windows":
-                        # Try common Windows fonts
-                        for font_name in ["SimSun", "SimHei", "Microsoft YaHei"]:
-                            try:
-                                from reportlab.pdfbase.cidfonts import (
-                                    UnicodeCIDFont,
-                                )
-
-                                pdfmetrics.registerFont(UnicodeCIDFont(font_name))
-                                normal_style.fontName = font_name
-                                heading_style.fontName = font_name
-                                break
-                            except Exception:
-                                continue
-                    elif system == "Darwin":  # macOS
-                        for font_name in ["STSong-Light", "STHeiti"]:
-                            try:
-                                from reportlab.pdfbase.cidfonts import (
-                                    UnicodeCIDFont,
-                                )
-
-                                pdfmetrics.registerFont(UnicodeCIDFont(font_name))
-                                normal_style.fontName = font_name
-                                heading_style.fontName = font_name
-                                break
-                            except Exception:
-                                continue
+                    # STSong-Light is the standard CID font for Simplified
+                    # Chinese and works cross-platform (reportlab ships the
+                    # required CID resources internally).
+                    pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+                    if not support_chinese:
+                        normal_style.fontName = "STSong-Light"
+                        heading_style.fontName = "STSong-Light"
                 except Exception:
                     pass  # Use default fonts if Chinese font setup fails
 

--- a/tests/test_chinese_cid_font.py
+++ b/tests/test_chinese_cid_font.py
@@ -1,0 +1,44 @@
+"""Tests for Chinese CID font registration (issue #24).
+
+Verifies that STSong-Light is registered as the cross-platform Chinese CID
+font instead of invalid system font names like SimSun/SimHei.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+class TestChineseCIDFont:
+    """Test CID font registration for Chinese text rendering."""
+
+    def test_stsong_light_is_valid_cid_font(self):
+        """STSong-Light should register successfully as a CID font."""
+        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+        from reportlab.pdfbase import pdfmetrics
+
+        font = UnicodeCIDFont("STSong-Light")
+        pdfmetrics.registerFont(font)
+        # No exception means it worked
+
+    def test_invalid_cid_font_names_raise(self):
+        """Font names used in the old code should fail as CID fonts."""
+        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+
+        invalid_names = ["SimSun", "SimHei", "Microsoft YaHei", "STHeiti"]
+        for name in invalid_names:
+            with pytest.raises(Exception):
+                UnicodeCIDFont(name)
+
+    def test_all_valid_cid_cjk_font_names(self):
+        """Verify the set of valid CJK CID font names in reportlab."""
+        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+        from reportlab.pdfbase import pdfmetrics
+
+        valid_cjk = ["STSong-Light", "MSung-Light", "HeiseiMin-W3", "HeiseiKakuGo-W5", "HYSMyeongJo-Medium"]
+        for name in valid_cjk:
+            font = UnicodeCIDFont(name)
+            pdfmetrics.registerFont(font)


### PR DESCRIPTION
Fixes #24

## What

Fixes Chinese text rendering failure in PDF output caused by invalid CID font names. Chinese characters would display as black squares or fallback to default Latin fonts on Windows and macOS.

## Root Cause

`reportlab.pdfbase.cidfonts.UnicodeCIDFont` only supports a fixed set of CID font names: `STSong-Light`, `MSung-Light`, `HeiseiMin-W3`, `HeiseiKakuGo-W5`, `HYSMyeongJo-Medium`.

The old code tried to register system font names (`SimSun`, `SimHei`, `Microsoft YaHei`, `STHeiti`) which are NOT valid CID font names. All registration calls silently failed due to the `except Exception: continue` blocks, leaving no Chinese-capable font selected.

## Fix

- Replace the platform-specific invalid font name loops with `STSong-Light`, the standard cross-platform CID font for Simplified Chinese (reportlab ships the required CID resources internally)
- Only apply the fallback when WenQuanYi (Linux TrueType font) is not already registered
- Remove dead code paths for non-existent CID font names

## How to Test

```bash
python -m pytest tests/test_chinese_cid_font.py -v
```

3 tests:
- `test_stsong_light_is_valid_cid_font` — STSong-Light registers successfully
- `test_invalid_cid_font_names_raise` — old font names (SimSun etc.) correctly raise errors
- `test_all_valid_cid_cjk_font_names` — all valid CJK CID fonts are usable