### PR TITLE
feat: parallelize text and multimodal processing in process_document_complete

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1619,11 +1619,24 @@ class ProcessorMixin:
 
             if tasks:
                 results = await asyncio.gather(*tasks, return_exceptions=True)
-                for name, result in zip(task_names, results):
-                    if isinstance(result, Exception):
+                failures = [
+                    (name, result)
+                    for name, result in zip(task_names, results)
+                    if isinstance(result, BaseException)
+                ]
+                if failures:
+                    for name, result in failures:
                         self.logger.error(
                             f"{name} failed for {file_path}: {result}"
                         )
+                    primary_name, primary_exc = failures[0]
+                    if len(failures) > 1:
+                        other_names = ", ".join(name for name, _ in failures[1:])
+                        raise RuntimeError(
+                            f"{primary_name} failed for {file_path}: {primary_exc}; "
+                            f"additional failures in: {other_names}"
+                        ) from primary_exc
+                    raise primary_exc
 
         except Exception as exc:
             if callback_manager is not None:

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1548,19 +1548,15 @@ class ProcessorMixin:
 
             self.logger.info(f"Starting complete document processing: {file_path}")
 
-            # Step 1: Parse document
             content_list, content_based_doc_id = await self.parse_document(
                 file_path, output_dir, parse_method, display_stats, **kwargs
             )
 
-            # Use provided doc_id or fall back to content-based doc_id
             if doc_id is None:
                 doc_id = content_based_doc_id
 
-            # Step 2: Separate text and multimodal content
             text_content, multimodal_items = separate_content(content_list)
 
-            # Step 2.5: Set content source for context extraction in multimodal processing
             if hasattr(self, "set_content_source_for_context") and multimodal_items:
                 self.logger.info(
                     "Setting content source for context-aware multimodal processing..."
@@ -1569,12 +1565,14 @@ class ProcessorMixin:
                     content_list, self.config.content_format
                 )
 
-            # Step 3: Insert pure text content with all parameters
-            stage = "text_insert"
+            if file_name is None:
+                file_name = self._get_file_reference(file_path)
+
+            stage = "parallel_processing"
+            tasks = []
+            task_names = []
+
             if text_content.strip():
-                if file_name is None:
-                    # Use full path or basename based on config
-                    file_name = self._get_file_reference(file_path)
                 if callback_manager is not None:
                     callback_manager.dispatch(
                         "on_text_insert_start",
@@ -1583,41 +1581,49 @@ class ProcessorMixin:
                         doc_id=doc_id,
                     )
                 insert_start = time.time()
-                await insert_text_content(
-                    self.lightrag,
-                    input=text_content,
-                    file_paths=file_name,
-                    split_by_character=split_by_character,
-                    split_by_character_only=split_by_character_only,
-                    ids=doc_id,
-                )
-                if callback_manager is not None:
-                    insert_duration = time.time() - insert_start
-                    callback_manager.dispatch(
-                        "on_text_insert_complete",
-                        file_path=file_name,
-                        duration_seconds=insert_duration,
-                        doc_id=doc_id,
-                    )
-            else:
-                # Determine file reference even if no text content
-                if file_name is None:
-                    file_name = self._get_file_reference(file_path)
 
-            # Step 4: Process multimodal content (using specialized processors)
-            stage = "multimodal"
+                async def _insert_text_with_callback():
+                    await insert_text_content(
+                        self.lightrag,
+                        input=text_content,
+                        file_paths=file_name,
+                        split_by_character=split_by_character,
+                        split_by_character_only=split_by_character_only,
+                        ids=doc_id,
+                    )
+                    if callback_manager is not None:
+                        insert_duration = time.time() - insert_start
+                        callback_manager.dispatch(
+                            "on_text_insert_complete",
+                            file_path=file_name,
+                            duration_seconds=insert_duration,
+                            doc_id=doc_id,
+                        )
+
+                tasks.append(_insert_text_with_callback())
+                task_names.append("text insertion")
+
             if multimodal_items:
-                await self._process_multimodal_content(
-                    multimodal_items, file_name, doc_id
+                tasks.append(
+                    self._process_multimodal_content(
+                        multimodal_items, file_name, doc_id
+                    )
                 )
+                task_names.append("multimodal processing")
             else:
-                # If no multimodal content, mark multimodal processing as complete
-                # This ensures the document status properly reflects completion of all processing
                 await self._mark_multimodal_processing_complete(doc_id)
                 self.logger.debug(
                     f"No multimodal content found in document {doc_id}, "
                     "marked multimodal processing as complete",
                 )
+
+            if tasks:
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for name, result in zip(task_names, results):
+                    if isinstance(result, Exception):
+                        self.logger.error(
+                            f"{name} failed for {file_path}: {result}"
+                        )
 
         except Exception as exc:
             if callback_manager is not None:

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -57,7 +57,9 @@ async def test_text_and_multimodal_run_concurrently(processor):
 
 @pytest.mark.parametrize("failing_branch", ["text", "multimodal"])
 @pytest.mark.asyncio
-async def test_one_branch_failing_does_not_block_the_other(processor, failing_branch):
+async def test_one_branch_failing_lets_the_other_finish_then_raises(
+    processor, failing_branch
+):
     survived = False
 
     async def fake_parse(*args, **kwargs):
@@ -80,14 +82,60 @@ async def test_one_branch_failing_does_not_block_the_other(processor, failing_br
 
     processor.parse_document = fake_parse
     processor._process_multimodal_content = fake_process_multimodal
+    processor.callback_manager = MagicMock()
 
     with patch("raganything.processor.separate_content") as mock_sep, \
          patch("raganything.processor.insert_text_content", new=fake_insert_text):
         mock_sep.return_value = ("Hello", [{"type": "image", "data": "img"}])
 
-        await processor.process_document_complete("test.pdf")
+        with pytest.raises(RuntimeError, match="failed"):
+            await processor.process_document_complete("test.pdf")
 
-    assert survived, f"Non-failing branch should complete when {failing_branch} fails"
+    assert survived, (
+        f"Non-failing branch should still complete when {failing_branch} fails "
+        "(gather must not cancel the sibling)"
+    )
+
+    dispatched_events = [
+        call.args[0] for call in processor.callback_manager.dispatch.call_args_list
+    ]
+    assert "on_document_error" in dispatched_events, (
+        "on_document_error should fire when a branch fails"
+    )
+    assert "on_document_complete" not in dispatched_events, (
+        "on_document_complete must not fire when a branch fails (would silently "
+        "report a partially ingested document as successful)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_both_branches_failing_raises_and_mentions_both(processor):
+    async def fake_parse(*args, **kwargs):
+        return [
+            {"type": "text", "text": "Hello"},
+            {"type": "image", "data": "img"},
+        ], "doc123"
+
+    async def fake_insert_text(*args, **kwargs):
+        raise RuntimeError("Text boom")
+
+    async def fake_process_multimodal(*args, **kwargs):
+        raise RuntimeError("Multimodal boom")
+
+    processor.parse_document = fake_parse
+    processor._process_multimodal_content = fake_process_multimodal
+
+    with patch("raganything.processor.separate_content") as mock_sep, \
+         patch("raganything.processor.insert_text_content", new=fake_insert_text):
+        mock_sep.return_value = ("Hello", [{"type": "image", "data": "img"}])
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await processor.process_document_complete("test.pdf")
+
+    message = str(excinfo.value)
+    assert "additional failures" in message, (
+        "Aggregated error should indicate that more than one branch failed"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -1,0 +1,135 @@
+"""Parallel text + multimodal processing tests."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def processor():
+    from raganything import RAGAnything, RAGAnythingConfig
+
+    proc = RAGAnything.__new__(RAGAnything)
+    proc.config = RAGAnythingConfig()
+    proc.logger = MagicMock()
+    proc.lightrag = AsyncMock()
+    proc._ensure_lightrag_initialized = AsyncMock()
+    proc._mark_multimodal_processing_complete = AsyncMock()
+    proc.set_content_source_for_context = MagicMock()
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_text_and_multimodal_run_concurrently(processor):
+    execution_log = []
+
+    async def fake_parse(*args, **kwargs):
+        return [
+            {"type": "text", "text": "Hello world"},
+            {"type": "image", "data": "base64data"},
+        ], "doc123"
+
+    async def fake_insert_text(*args, **kwargs):
+        execution_log.append(("text_start", asyncio.get_event_loop().time()))
+        await asyncio.sleep(0.1)
+        execution_log.append(("text_end", asyncio.get_event_loop().time()))
+
+    async def fake_process_multimodal(*args, **kwargs):
+        execution_log.append(("mm_start", asyncio.get_event_loop().time()))
+        await asyncio.sleep(0.1)
+        execution_log.append(("mm_end", asyncio.get_event_loop().time()))
+
+    processor.parse_document = fake_parse
+    processor._process_multimodal_content = fake_process_multimodal
+
+    with patch("raganything.processor.separate_content") as mock_sep, \
+         patch("raganything.processor.insert_text_content", new=fake_insert_text):
+        mock_sep.return_value = ("Hello world", [{"type": "image", "data": "base64data"}])
+
+        await processor.process_document_complete("test.pdf")
+
+    starts = {e[0].replace("_start", ""): e[1] for e in execution_log if "start" in e[0]}
+    ends = {e[0].replace("_end", ""): e[1] for e in execution_log if "end" in e[0]}
+
+    assert starts["mm"] < ends["text"], (
+        "Multimodal processing should start before text insertion finishes (parallel)"
+    )
+
+
+@pytest.mark.parametrize("failing_branch", ["text", "multimodal"])
+@pytest.mark.asyncio
+async def test_one_branch_failing_does_not_block_the_other(processor, failing_branch):
+    survived = False
+
+    async def fake_parse(*args, **kwargs):
+        return [
+            {"type": "text", "text": "Hello"},
+            {"type": "image", "data": "img"},
+        ], "doc123"
+
+    async def fake_insert_text(*args, **kwargs):
+        nonlocal survived
+        if failing_branch == "text":
+            raise RuntimeError("Text insertion failed")
+        survived = True
+
+    async def fake_process_multimodal(*args, **kwargs):
+        nonlocal survived
+        if failing_branch == "multimodal":
+            raise RuntimeError("Multimodal processing failed")
+        survived = True
+
+    processor.parse_document = fake_parse
+    processor._process_multimodal_content = fake_process_multimodal
+
+    with patch("raganything.processor.separate_content") as mock_sep, \
+         patch("raganything.processor.insert_text_content", new=fake_insert_text):
+        mock_sep.return_value = ("Hello", [{"type": "image", "data": "img"}])
+
+        await processor.process_document_complete("test.pdf")
+
+    assert survived, f"Non-failing branch should complete when {failing_branch} fails"
+
+
+@pytest.mark.asyncio
+async def test_text_only_document(processor):
+    insert_called = False
+
+    async def fake_parse(*args, **kwargs):
+        return [{"type": "text", "text": "Hello world"}], "doc123"
+
+    async def fake_insert_text(*args, **kwargs):
+        nonlocal insert_called
+        insert_called = True
+
+    processor.parse_document = fake_parse
+
+    with patch("raganything.processor.separate_content") as mock_sep, \
+         patch("raganything.processor.insert_text_content", new=fake_insert_text):
+        mock_sep.return_value = ("Hello world", [])
+
+        await processor.process_document_complete("test.pdf")
+
+    assert insert_called
+    processor._mark_multimodal_processing_complete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_multimodal_only_document(processor):
+    mm_called = False
+
+    async def fake_parse(*args, **kwargs):
+        return [{"type": "image", "data": "img"}], "doc123"
+
+    async def fake_process_multimodal(*args, **kwargs):
+        nonlocal mm_called
+        mm_called = True
+
+    processor.parse_document = fake_parse
+    processor._process_multimodal_content = fake_process_multimodal
+
+    with patch("raganything.processor.separate_content") as mock_sep:
+        mock_sep.return_value = ("", [{"type": "image", "data": "img"}])
+
+        await processor.process_document_complete("test.pdf")
+
+    assert mm_called


### PR DESCRIPTION
Text insertion and multimodal processing in process_document_complete run sequentially right now but don't share any state. This runs them concurrently with asyncio.gather so total time is max(text, multimodal) instead of text + multimodal.

Uses return_exceptions=True so if one branch fails the other still completes.