### PR TITLE
feat(examples): make LLM and vision model names configurable via env vars

### DIFF
--- a/env.example
+++ b/env.example
@@ -112,6 +112,7 @@ MAX_TOKENS=32768
 ### LLM Binding type: openai, ollama, lollms, azure_openai, lmstudio, vllm
 LLM_BINDING=openai
 LLM_MODEL=gpt-4o
+VISION_MODEL=gpt-4o
 LLM_BINDING_HOST=https://api.openai.com/v1
 LLM_BINDING_API_KEY=your_api_key
 ### Optional for Azure

--- a/examples/raganything_example.py
+++ b/examples/raganything_example.py
@@ -116,9 +116,12 @@ async def process_with_rag(
         )
 
         # Define LLM model function
+        llm_model = os.getenv("LLM_MODEL", "gpt-4o-mini")
+        vision_model = os.getenv("VISION_MODEL", "gpt-4o")
+
         def llm_model_func(prompt, system_prompt=None, history_messages=[], **kwargs):
             return openai_complete_if_cache(
-                "gpt-4o-mini",
+                llm_model,
                 prompt,
                 system_prompt=system_prompt,
                 history_messages=history_messages,
@@ -139,7 +142,7 @@ async def process_with_rag(
             # If messages format is provided (for multimodal VLM enhanced query), use it directly
             if messages:
                 return openai_complete_if_cache(
-                    "gpt-4o",
+                    vision_model,
                     "",
                     system_prompt=None,
                     history_messages=[],
@@ -151,7 +154,7 @@ async def process_with_rag(
             # Traditional single image format
             elif image_data:
                 return openai_complete_if_cache(
-                    "gpt-4o",
+                    vision_model,
                     "",
                     system_prompt=None,
                     history_messages=[],


### PR DESCRIPTION
## Summary

Currently, LLM and vision model names (`gpt-4o-mini`, `gpt-4o`) are hardcoded in example scripts. Users who rely on OpenAI-compatible providers (e.g. Azure, local inference servers, third-party proxies) must edit the Python source to change models — while `EMBEDDING_MODEL` and `EMBEDDING_DIM` are already read from environment variables.

This PR brings LLM/vision model configuration in line with the existing embedding pattern.

### Changes

- **`example_knowledge_qa.py`**: read `LLM_MODEL`, `VISION_MODEL`, `EMBEDDING_MODEL`, `EMBEDDING_DIM` from env (defaults preserved: `gpt-4o-mini`, `gpt-4o`, `text-embedding-3-large`, `3072`)
- **`examples/raganything_example.py`**: read `LLM_MODEL`, `VISION_MODEL` from env (same defaults)
- **`env.example`**: document the new `VISION_MODEL` variable alongside `LLM_MODEL`

### Usage after this change

Users can now switch models without touching code:

```dotenv
# .env
LLM_MODEL=kimi-k2.5
VISION_MODEL=kimi-k2.5
EMBEDDING_MODEL=text-embedding-3-large
EMBEDDING_DIM=3072
```

## Test plan

- [ ] Verify defaults are unchanged (existing OpenAI users unaffected)
- [ ] Verify model names are picked up correctly when env vars are set
- [ ] `examples/lmstudio_integration_example.py` already uses this pattern — confirm consistency