### PR TITLE
fix: strip <think> tags from modal processor fallback responses (closes #159)

### DIFF
--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -544,6 +544,30 @@ class BaseModalProcessor:
             chunk_results,
         )
 
+    @staticmethod
+    def _strip_thinking_tags(text: str) -> str:
+        """Remove <think>/<thinking> tags produced by reasoning models.
+
+        Models such as DeepSeek-R1 and Qwen2.5-think wrap their internal
+        chain-of-thought in ``<think>…</think>`` or ``<thinking>…</thinking>``
+        blocks before emitting the final answer.  When JSON parsing fails and
+        the raw LLM response is used as a fallback, storing the entire response
+        (including the reasoning preamble) pollutes the knowledge graph with
+        internal model thoughts rather than actual content descriptions.
+
+        This helper strips those blocks so that only the final answer text is
+        stored or surfaced to callers.
+        """
+        import re
+
+        cleaned = re.sub(
+            r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE
+        )
+        cleaned = re.sub(
+            r"<thinking>.*?</thinking>", "", cleaned, flags=re.DOTALL | re.IGNORECASE
+        )
+        return cleaned.strip()
+
     def _robust_json_parse(self, response: str) -> dict:
         """Robust JSON parsing with multiple fallback strategies"""
 
@@ -1019,14 +1043,15 @@ class ImageModalProcessor(BaseModalProcessor):
         except (json.JSONDecodeError, AttributeError, ValueError) as e:
             logger.error(f"Error parsing image analysis response: {e}")
             logger.debug(f"Raw response: {response}")
+            cleaned = self._strip_thinking_tags(response)
             fallback_entity = {
                 "entity_name": entity_name
                 if entity_name
-                else f"image_{compute_mdhash_id(response)}",
+                else f"image_{compute_mdhash_id(cleaned)}",
                 "entity_type": "image",
-                "summary": response[:100] + "..." if len(response) > 100 else response,
+                "summary": cleaned[:100] + "..." if len(cleaned) > 100 else cleaned,
             }
-            return response, fallback_entity
+            return cleaned, fallback_entity
 
 
 class TableModalProcessor(BaseModalProcessor):
@@ -1213,14 +1238,15 @@ class TableModalProcessor(BaseModalProcessor):
         except (json.JSONDecodeError, AttributeError, ValueError) as e:
             logger.error(f"Error parsing table analysis response: {e}")
             logger.debug(f"Raw response: {response}")
+            cleaned = self._strip_thinking_tags(response)
             fallback_entity = {
                 "entity_name": entity_name
                 if entity_name
-                else f"table_{compute_mdhash_id(response)}",
+                else f"table_{compute_mdhash_id(cleaned)}",
                 "entity_type": "table",
-                "summary": response[:100] + "..." if len(response) > 100 else response,
+                "summary": cleaned[:100] + "..." if len(cleaned) > 100 else cleaned,
             }
-            return response, fallback_entity
+            return cleaned, fallback_entity
 
 
 class EquationModalProcessor(BaseModalProcessor):
@@ -1397,14 +1423,15 @@ class EquationModalProcessor(BaseModalProcessor):
         except (json.JSONDecodeError, AttributeError, ValueError) as e:
             logger.error(f"Error parsing equation analysis response: {e}")
             logger.debug(f"Raw response: {response}")
+            cleaned = self._strip_thinking_tags(response)
             fallback_entity = {
                 "entity_name": entity_name
                 if entity_name
-                else f"equation_{compute_mdhash_id(response)}",
+                else f"equation_{compute_mdhash_id(cleaned)}",
                 "entity_type": "equation",
-                "summary": response[:100] + "..." if len(response) > 100 else response,
+                "summary": cleaned[:100] + "..." if len(cleaned) > 100 else cleaned,
             }
-            return response, fallback_entity
+            return cleaned, fallback_entity
 
 
 class GenericModalProcessor(BaseModalProcessor):
@@ -1559,11 +1586,12 @@ class GenericModalProcessor(BaseModalProcessor):
         except (json.JSONDecodeError, AttributeError, ValueError) as e:
             logger.error(f"Error parsing {content_type} analysis response: {e}")
             logger.debug(f"Raw response: {response}")
+            cleaned = self._strip_thinking_tags(response)
             fallback_entity = {
                 "entity_name": entity_name
                 if entity_name
-                else f"{content_type}_{compute_mdhash_id(response)}",
+                else f"{content_type}_{compute_mdhash_id(cleaned)}",
                 "entity_type": content_type,
-                "summary": response[:100] + "..." if len(response) > 100 else response,
+                "summary": cleaned[:100] + "..." if len(cleaned) > 100 else cleaned,
             }
-            return response, fallback_entity
+            return cleaned, fallback_entity

--- a/tests/test_strip_thinking_tags.py
+++ b/tests/test_strip_thinking_tags.py
@@ -1,0 +1,125 @@
+"""Tests for _strip_thinking_tags in BaseModalProcessor (issue #159).
+
+Reasoning models like DeepSeek-R1 and Qwen2.5-think wrap their chain-of-thought
+in <think>…</think> blocks.  When JSON parsing fails, the raw response was
+previously stored verbatim — polluting the knowledge graph with internal model
+reasoning instead of actual content descriptions.  These tests verify that the
+fallback path strips thinking tags before storing or returning the response.
+"""
+
+from raganything.modalprocessors import BaseModalProcessor
+
+
+class TestStripThinkingTags:
+    """Unit tests for BaseModalProcessor._strip_thinking_tags."""
+
+    def test_strips_think_tags(self):
+        raw = "<think>some reasoning here</think>final answer"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == "final answer"
+
+    def test_strips_thinking_tags(self):
+        raw = "<thinking>internal thought</thinking>real content"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == "real content"
+
+    def test_strips_multiline_think_block(self):
+        raw = "<think>\nline one\nline two\n</think>\nactual description"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == "actual description"
+
+    def test_case_insensitive(self):
+        raw = "<THINK>uppercase block</THINK>answer"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == "answer"
+
+    def test_no_tags_unchanged(self):
+        raw = "plain response without any tags"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == raw
+
+    def test_empty_string(self):
+        assert BaseModalProcessor._strip_thinking_tags("") == ""
+
+    def test_only_think_tags_returns_empty(self):
+        raw = "<think>nothing useful</think>"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == ""
+
+    def test_multiple_think_blocks(self):
+        raw = "<think>first</think>middle<think>second</think>end"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == "middleend"
+
+    def test_nested_angle_brackets_in_content_preserved(self):
+        """Content after think block that contains angle brackets must survive."""
+        raw = "<think>reasoning</think>result with <b>HTML</b>"
+        assert BaseModalProcessor._strip_thinking_tags(raw) == "result with <b>HTML</b>"
+
+
+class ConcreteProcessor(BaseModalProcessor):
+    """Minimal concrete subclass used to instantiate BaseModalProcessor."""
+
+    def __init__(self):
+        # Skip the full __init__ that requires a LightRAG instance
+        pass
+
+    async def process_multimodal_content(self, *args, **kwargs):
+        pass
+
+
+class TestParseResponseFallback:
+    """Tests that parse fallback paths return cleaned (think-stripped) content."""
+
+    THINK_RESPONSE = (
+        "<think>\nLet me analyze this step by step...\n</think>\n"
+        "This is the actual description of the image."
+    )
+
+    def setup_method(self):
+        self.proc = ConcreteProcessor()
+
+        # Patch _robust_json_parse to always raise ValueError so fallback fires
+        def always_fail(response):
+            raise ValueError("forced failure")
+
+        self.proc._robust_json_parse = always_fail
+
+    def test_image_fallback_strips_think(self):
+        from raganything.modalprocessors import ImageModalProcessor
+
+        proc = ConcreteProcessor()
+        proc.__class__ = ImageModalProcessor
+        proc._robust_json_parse = lambda r: (_ for _ in ()).throw(ValueError("forced"))
+
+        caption, entity = proc._parse_response(self.THINK_RESPONSE)
+        assert "<think>" not in caption
+        assert "<think>" not in entity["summary"]
+        assert "actual description" in caption
+
+    def test_table_fallback_strips_think(self):
+        from raganything.modalprocessors import TableModalProcessor
+
+        proc = ConcreteProcessor()
+        proc.__class__ = TableModalProcessor
+        proc._robust_json_parse = lambda r: (_ for _ in ()).throw(ValueError("forced"))
+
+        caption, entity = proc._parse_table_response(self.THINK_RESPONSE)
+        assert "<think>" not in caption
+        assert "<think>" not in entity["summary"]
+        assert "actual description" in caption
+
+    def test_equation_fallback_strips_think(self):
+        from raganything.modalprocessors import EquationModalProcessor
+
+        proc = ConcreteProcessor()
+        proc.__class__ = EquationModalProcessor
+        proc._robust_json_parse = lambda r: (_ for _ in ()).throw(ValueError("forced"))
+
+        caption, entity = proc._parse_equation_response(self.THINK_RESPONSE)
+        assert "<think>" not in caption
+        assert "<think>" not in entity["summary"]
+
+    def test_generic_fallback_strips_think(self):
+        from raganything.modalprocessors import GenericModalProcessor
+
+        proc = ConcreteProcessor()
+        proc.__class__ = GenericModalProcessor
+        proc._robust_json_parse = lambda r: (_ for _ in ()).throw(ValueError("forced"))
+
+        caption, entity = proc._parse_generic_response(self.THINK_RESPONSE)
+        assert "<think>" not in caption
+        assert "<think>" not in entity["summary"]


### PR DESCRIPTION
## Problem

Reasoning models such as **DeepSeek-R1** and **Qwen2.5-think** prepend their chain-of-thought inside `<think>…</think>` blocks before emitting the final answer.

When `_robust_json_parse` cannot extract a valid JSON object (e.g. because the model emitted only thinking content without a trailing structured answer), the four modal-processor parse methods fell back to returning the **raw** LLM response string as the `enhanced_caption` and `summary`.  This caused internal model reasoning to be stored in the knowledge graph instead of the actual content description — exactly the symptom reported in #159.

Affected methods (all shared the same pattern):
- `ImageModalProcessor._parse_response`
- `TableModalProcessor._parse_table_response`
- `EquationModalProcessor._parse_equation_response`
- `GenericModalProcessor._parse_generic_response`

## Fix

Added a static helper `BaseModalProcessor._strip_thinking_tags(text)` that removes `<think>…</think>` and `<thinking>…</thinking>` blocks (case-insensitive, handles multiline content) and applies it in the `except` fallback branch of all four methods before the cleaned text is stored or returned.

```python
# Before
return response, fallback_entity          # raw think-tag content stored

# After
cleaned = self._strip_thinking_tags(response)
...
return cleaned, fallback_entity           # only final-answer text stored
```

The helper is intentionally a `@staticmethod` on the base class so subclasses and future processors can reuse it without extra imports.

## Tests

`tests/test_strip_thinking_tags.py` — 13 new unit tests:
- Tag variants (`<think>`, `<thinking>`, uppercase)
- Multiline and multiple blocks
- No-op on plain text / empty string
- Full fallback path exercised for all four processor classes

All 13 pass; `ruff check` + `ruff format --check` clean.

## Checklist

- [x] Bug reproduced and root cause identified
- [x] Fix applied to all four affected parse methods
- [x] Unit tests added (13 tests, all passing)
- [x] `ruff` lint + format checks pass
- [x] No breaking changes to public API