### PR TITLE
feat: incremental folder scan — skip unchanged files via MD5 manifest

### DIFF
--- a/raganything/batch.py
+++ b/raganything/batch.py
@@ -5,6 +5,8 @@ Contains methods for processing multiple documents in batch mode
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 from pathlib import Path
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
@@ -31,6 +33,47 @@ class BatchMixin:
     # ORIGINAL BATCH PROCESSING METHOD (RESTORED)
     # ==========================================
 
+    # ------------------------------------------------------------------
+    # Incremental scan helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _file_md5(file_path: Path, block_size: int = 65536) -> str:
+        """Return the hex MD5 digest of *file_path*."""
+        h = hashlib.md5()
+        with open(file_path, "rb") as fh:
+            for block in iter(lambda: fh.read(block_size), b""):
+                h.update(block)
+        return h.hexdigest()
+
+    def _manifest_path(self, folder_path: Path) -> Path:
+        """Return the path to the incremental-scan manifest for *folder_path*.
+
+        The manifest is stored inside the RAG working directory so it is not
+        mixed in with the source documents.
+        """
+        working_dir = Path(self.config.working_dir)
+        working_dir.mkdir(parents=True, exist_ok=True)
+        # Use a deterministic name derived from the folder path so that
+        # multiple source folders can each have their own manifest.
+        folder_hash = hashlib.md5(str(folder_path.resolve()).encode()).hexdigest()[:8]
+        return working_dir / f".folder_manifest_{folder_hash}.json"
+
+    def _load_manifest(self, manifest_path: Path) -> Dict[str, Any]:
+        if manifest_path.exists():
+            try:
+                with open(manifest_path, "r", encoding="utf-8") as fh:
+                    return json.load(fh)
+            except (json.JSONDecodeError, OSError):
+                return {}
+        return {}
+
+    def _save_manifest(self, manifest_path: Path, manifest: Dict[str, Any]) -> None:
+        with open(manifest_path, "w", encoding="utf-8") as fh:
+            json.dump(manifest, fh, indent=2)
+
+    # ------------------------------------------------------------------
+
     async def process_folder_complete(
         self,
         folder_path: str,
@@ -42,9 +85,10 @@ class BatchMixin:
         file_extensions: Optional[List[str]] = None,
         recursive: bool = None,
         max_workers: int = None,
+        incremental: bool = False,
     ):
         """
-        Process all supported files in a folder
+        Process all supported files in a folder.
 
         Args:
             folder_path: Path to the folder containing files to process
@@ -56,6 +100,11 @@ class BatchMixin:
             file_extensions: List of file extensions to process (optional)
             recursive: Whether to process folders recursively (optional)
             max_workers: Maximum number of workers for concurrent processing (optional)
+            incremental: When *True*, skip files whose MD5 digest has not changed
+                since the last successful run.  A manifest file is stored inside
+                ``config.working_dir`` to track previously processed files.
+                New files and files whose content has changed are always
+                (re-)processed.
         """
         if output_dir is None:
             output_dir = self.config.parser_output_dir
@@ -90,6 +139,51 @@ class BatchMixin:
             self.logger.warning(f"No supported files found in {folder_path}")
             return
 
+        # ---- Incremental filtering ----------------------------------------
+        manifest: Dict[str, Any] = {}
+        manifest_path: Optional[Path] = None
+        skipped_files: List[str] = []
+
+        if incremental:
+            manifest_path = self._manifest_path(folder_path_obj)
+            manifest = self._load_manifest(manifest_path)
+            filtered: List[Path] = []
+            for fp in files_to_process:
+                key = str(fp.resolve())
+                try:
+                    current_md5 = self._file_md5(fp)
+                    current_mtime = fp.stat().st_mtime
+                except OSError:
+                    # File disappeared between glob and now — skip it.
+                    continue
+                entry = manifest.get(key)
+                if entry and entry.get("md5") == current_md5:
+                    skipped_files.append(str(fp))
+                else:
+                    # Store prospective MD5 so we can update after success.
+                    manifest[key] = {
+                        "md5": current_md5,
+                        "mtime": current_mtime,
+                        "processed": False,
+                    }
+                    filtered.append(fp)
+            files_to_process = filtered
+            if skipped_files:
+                self.logger.info(
+                    f"Incremental scan: skipping {len(skipped_files)} unchanged "
+                    f"file(s), processing {len(files_to_process)} new/changed file(s)"
+                )
+        # ---- End incremental filtering ------------------------------------
+
+        if not files_to_process:
+            if incremental:
+                self.logger.info(
+                    "Incremental scan: all files are up to date, nothing to process"
+                )
+            else:
+                self.logger.warning(f"No supported files found in {folder_path}")
+            return
+
         self.logger.info(
             f"Found {len(files_to_process)} files to process in {folder_path}"
         )
@@ -105,10 +199,9 @@ class BatchMixin:
         async def process_single_file(file_path: Path):
             async with semaphore:
                 is_in_subdir = (
-                    lambda file_path, dir_path: len(
-                        file_path.relative_to(dir_path).parents
+                    lambda file_path, dir_path: (
+                        len(file_path.relative_to(dir_path).parents) > 1
                     )
-                    > 1
                 )(file_path, folder_path_obj)
 
                 try:
@@ -157,11 +250,28 @@ class BatchMixin:
                 else:
                     failed_files.append((file_path, error))
 
+        # ---- Update incremental manifest ----------------------------------
+        if incremental and manifest_path is not None:
+            successful_set = set(successful_files)
+            for key in list(manifest.keys()):
+                # Only mark as processed if it was actually in this run.
+                if key in successful_set or Path(key).resolve() in {
+                    Path(f).resolve() for f in successful_set
+                }:
+                    manifest[key]["processed"] = True
+                elif not manifest[key].get("processed"):
+                    # Failed file: remove from manifest so it is retried next run.
+                    del manifest[key]
+            self._save_manifest(manifest_path, manifest)
+        # ---- End manifest update ------------------------------------------
+
         # Display statistics if requested
         if display_stats:
             self.logger.info("Processing complete!")
             self.logger.info(f"  Successful: {len(successful_files)} files")
             self.logger.info(f"  Failed: {len(failed_files)} files")
+            if incremental and skipped_files:
+                self.logger.info(f"  Skipped (unchanged): {len(skipped_files)} files")
             if failed_files:
                 self.logger.warning("Failed files:")
                 for file_path, error in failed_files:

--- a/tests/test_incremental_folder_scan.py
+++ b/tests/test_incremental_folder_scan.py
@@ -1,0 +1,270 @@
+"""Tests for incremental folder scanning (issue #156).
+
+``process_folder_complete(incremental=True)`` must:
+- skip files whose MD5 has not changed since the last successful run
+- process new files and files whose content changed
+- persist a manifest so the decision survives across calls
+- remove failed files from the manifest so they are retried
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_batch_mixin(working_dir: str):
+    """Return a BatchMixin-like object with a minimal config."""
+    from raganything.batch import BatchMixin
+
+    obj = object.__new__(BatchMixin)
+    obj.logger = MagicMock()
+
+    cfg = MagicMock()
+    cfg.working_dir = working_dir
+    cfg.parser_output_dir = os.path.join(working_dir, "output")
+    cfg.parse_method = "auto"
+    cfg.supported_file_extensions = [".txt", ".pdf"]
+    cfg.recursive_folder_processing = False
+    cfg.max_concurrent_files = 2
+    obj.config = cfg
+
+    obj._ensure_lightrag_initialized = AsyncMock()
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper methods
+# ---------------------------------------------------------------------------
+
+
+class TestFileMd5:
+    def test_returns_hex_string(self, tmp_path):
+        f = tmp_path / "a.txt"
+        f.write_bytes(b"hello")
+        from raganything.batch import BatchMixin
+
+        md5 = BatchMixin._file_md5(f)
+        assert len(md5) == 32
+        assert all(c in "0123456789abcdef" for c in md5)
+
+    def test_different_content_different_hash(self, tmp_path):
+        from raganything.batch import BatchMixin
+
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_bytes(b"hello")
+        f2.write_bytes(b"world")
+        assert BatchMixin._file_md5(f1) != BatchMixin._file_md5(f2)
+
+    def test_same_content_same_hash(self, tmp_path):
+        from raganything.batch import BatchMixin
+
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_bytes(b"identical")
+        f2.write_bytes(b"identical")
+        assert BatchMixin._file_md5(f1) == BatchMixin._file_md5(f2)
+
+
+class TestManifestIO:
+    def test_load_missing_manifest_returns_empty(self, tmp_path):
+
+        obj = _make_batch_mixin(str(tmp_path))
+        mp = tmp_path / "does_not_exist.json"
+        assert obj._load_manifest(mp) == {}
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+
+        obj = _make_batch_mixin(str(tmp_path))
+        mp = tmp_path / "manifest.json"
+        data = {"/some/file.txt": {"md5": "abc123", "processed": True}}
+        obj._save_manifest(mp, data)
+        assert obj._load_manifest(mp) == data
+
+    def test_load_corrupt_manifest_returns_empty(self, tmp_path):
+
+        obj = _make_batch_mixin(str(tmp_path))
+        mp = tmp_path / "corrupt.json"
+        mp.write_text("not valid json {{{{")
+        assert obj._load_manifest(mp) == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for process_folder_complete(incremental=True)
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalFolderScan:
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_processes_all_files_on_first_run(self, tmp_path):
+
+        src = tmp_path / "docs"
+        src.mkdir()
+        (src / "a.txt").write_text("alpha")
+        (src / "b.txt").write_text("beta")
+
+        obj = _make_batch_mixin(str(tmp_path / "wd"))
+        processed = []
+
+        async def fake_process(file_path, **kwargs):
+            processed.append(file_path)
+
+        obj.process_document_complete = fake_process
+
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+
+        assert len(processed) == 2
+
+    def test_skips_unchanged_files_on_second_run(self, tmp_path):
+
+        src = tmp_path / "docs"
+        src.mkdir()
+        (src / "a.txt").write_text("alpha")
+        (src / "b.txt").write_text("beta")
+
+        obj = _make_batch_mixin(str(tmp_path / "wd"))
+        processed_runs = []
+
+        async def fake_process(file_path, **kwargs):
+            processed_runs.append(file_path)
+
+        obj.process_document_complete = fake_process
+
+        # First run — processes both files
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+        assert len(processed_runs) == 2
+        processed_runs.clear()
+
+        # Second run — nothing changed, should skip both
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+        assert processed_runs == []
+
+    def test_reprocesses_changed_file(self, tmp_path):
+
+        src = tmp_path / "docs"
+        src.mkdir()
+        (src / "a.txt").write_text("alpha")
+        (src / "b.txt").write_text("beta")
+
+        obj = _make_batch_mixin(str(tmp_path / "wd"))
+        processed_runs = []
+
+        async def fake_process(file_path, **kwargs):
+            processed_runs.append(Path(file_path).name)
+
+        obj.process_document_complete = fake_process
+
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+        processed_runs.clear()
+
+        # Change only b.txt
+        (src / "b.txt").write_text("CHANGED CONTENT")
+
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+
+        assert processed_runs == ["b.txt"], processed_runs
+
+    def test_processes_newly_added_file(self, tmp_path):
+
+        src = tmp_path / "docs"
+        src.mkdir()
+        (src / "a.txt").write_text("alpha")
+
+        obj = _make_batch_mixin(str(tmp_path / "wd"))
+        processed_runs = []
+
+        async def fake_process(file_path, **kwargs):
+            processed_runs.append(Path(file_path).name)
+
+        obj.process_document_complete = fake_process
+
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+        processed_runs.clear()
+
+        # Add a new file
+        (src / "new.txt").write_text("new document")
+
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+
+        assert processed_runs == ["new.txt"]
+
+    def test_failed_file_is_retried_next_run(self, tmp_path):
+
+        src = tmp_path / "docs"
+        src.mkdir()
+        (src / "ok.txt").write_text("fine")
+        (src / "bad.txt").write_text("trouble")
+
+        obj = _make_batch_mixin(str(tmp_path / "wd"))
+        call_count: dict[str, int] = {}
+
+        async def fake_process(file_path, **kwargs):
+            name = Path(file_path).name
+            call_count[name] = call_count.get(name, 0) + 1
+            if name == "bad.txt":
+                raise RuntimeError("simulated failure")
+
+        obj.process_document_complete = fake_process
+
+        # First run — bad.txt fails
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+
+        # Second run — bad.txt must be retried; ok.txt must be skipped
+        self._run(
+            obj.process_folder_complete(str(src), incremental=True, display_stats=False)
+        )
+
+        assert call_count["ok.txt"] == 1, "ok.txt should only be processed once"
+        assert call_count["bad.txt"] == 2, "bad.txt should be retried after failure"
+
+    def test_non_incremental_does_not_create_manifest(self, tmp_path):
+
+        src = tmp_path / "docs"
+        src.mkdir()
+        (src / "a.txt").write_text("hi")
+
+        wd = tmp_path / "wd"
+        wd.mkdir()
+        obj = _make_batch_mixin(str(wd))
+
+        async def fake_process(file_path, **kwargs):
+            pass
+
+        obj.process_document_complete = fake_process
+
+        self._run(
+            obj.process_folder_complete(
+                str(src), incremental=False, display_stats=False
+            )
+        )
+
+        manifest_files = list(wd.glob(".folder_manifest_*.json"))
+        assert manifest_files == [], (
+            "No manifest should be written for non-incremental runs"
+        )


### PR DESCRIPTION
## Summary

Closes #156 — adds `incremental=True` to `process_folder_complete` so that unchanged files are skipped on subsequent runs.

### How it works

When `incremental=True` is passed:

1. `process_folder_complete` computes the **MD5 digest** of every discovered file.
2. The digest is compared against a lightweight JSON manifest stored in `config.working_dir` (one manifest per source folder, keyed by a hash of the folder path so multiple folders coexist safely).
3. **Unchanged files** (digest matches the manifest) are silently skipped.
4. **New or changed files** are processed normally.
5. After the run, successfully processed files are marked in the manifest. **Failed files are removed** so they are automatically retried on the next call.

The `incremental=False` default means existing code is completely unaffected.

### New API

```python
await rag.process_folder_complete(
    folder_path="./documents",
    incremental=True,   # skip unchanged files
)
```

### Changes

| File | Change |
|------|--------|
| `raganything/batch.py` | Added `incremental` param + 4 helper methods + manifest update logic |
| `tests/test_incremental_folder_scan.py` | 12 new unit tests |

## Test plan

- [x] `test_processes_all_files_on_first_run` — first run always processes everything
- [x] `test_skips_unchanged_files_on_second_run` — unchanged files are skipped
- [x] `test_reprocesses_changed_file` — modified file is re-processed
- [x] `test_processes_newly_added_file` — new files are picked up
- [x] `test_failed_file_is_retried_next_run` — failed files removed from manifest
- [x] `test_non_incremental_does_not_create_manifest` — no side effects when `incremental=False`
- [x] MD5 helpers + manifest I/O (3 + 3 tests)

All 12 pass; the 4 pre-existing failures in `test_callbacks` and `test_chinese_cid_font` are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)