### PR TITLE
fix: create example log directory correctly

### DIFF
--- a/examples/raganything_example.py
+++ b/examples/raganything_example.py
@@ -37,7 +37,7 @@ def configure_logging():
     log_file_path = os.path.abspath(os.path.join(log_dir, "raganything_example.log"))
 
     print(f"\nRAGAnything example log file: {log_file_path}\n")
-    os.makedirs(os.path.dirname(log_dir), exist_ok=True)
+    os.makedirs(os.path.dirname(log_file_path) or ".", exist_ok=True)
 
     # Get log file max size and backup count from environment variables
     log_max_bytes = int(os.getenv("LOG_MAX_BYTES", 10485760))  # Default 10MB

--- a/tests/test_raganything_example.py
+++ b/tests/test_raganything_example.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_example_module():
+    module_path = (
+        Path(__file__).resolve().parents[1] / "examples" / "raganything_example.py"
+    )
+    spec = importlib.util.spec_from_file_location("raganything_example", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_configure_logging_creates_log_dir(monkeypatch, tmp_path):
+    module = _load_example_module()
+    log_dir = tmp_path / "nested" / "logs"
+
+    monkeypatch.setenv("LOG_DIR", str(log_dir))
+    module.configure_logging()
+
+    assert log_dir.is_dir()
+    assert (log_dir / "raganything_example.log").parent == log_dir


### PR DESCRIPTION
## Summary
- create the actual example log directory instead of its parent in `configure_logging()`
- add a focused regression test covering nested `LOG_DIR` values
- keep the fix scoped to the current mainline example file that replaced the older OpenAI demo path

## Testing
- `uv run python -m pytest tests/test_raganything_example.py -q`
- `uv run ruff check examples/raganything_example.py tests/test_raganything_example.py`
- `uv run ruff format --check examples/raganything_example.py tests/test_raganything_example.py`
- `git diff --check`
