### PR TITLE
fix: create doc_status even when LightRAG lacks multimodal insert args

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -91,6 +91,67 @@ class ProcessorMixin:
 
         return cache_key
 
+    @staticmethod
+    def _current_doc_status_timestamp() -> str:
+        """Return a stable UTC timestamp for doc_status bookkeeping."""
+        return time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+
+    async def _ensure_doc_status_record(
+        self,
+        doc_id: str,
+        file_path: str,
+        *,
+        scheme_name: str | None = None,
+        status: DocStatus = DocStatus.READY,
+    ) -> Dict[str, Any]:
+        """Create a minimal doc_status entry when LightRAG has not created one yet."""
+        current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
+        if current_doc_status:
+            return current_doc_status
+
+        timestamp = self._current_doc_status_timestamp()
+        doc_status_payload: Dict[str, Any] = {
+            "status": status,
+            "content": "",
+            "content_summary": "",
+            "content_length": 0,
+            "error_msg": "",
+            "chunks_count": 0,
+            "chunks_list": [],
+            "created_at": timestamp,
+            "updated_at": timestamp,
+            "file_path": self._get_file_reference(file_path),
+        }
+        if scheme_name is not None:
+            doc_status_payload["scheme_name"] = scheme_name
+
+        await self.lightrag.doc_status.upsert({doc_id: doc_status_payload})
+        await self.lightrag.doc_status.index_done_callback()
+        return await self.lightrag.doc_status.get_by_id(doc_id) or doc_status_payload
+
+    async def _upsert_doc_status(
+        self,
+        doc_id: str,
+        file_path: str,
+        *,
+        scheme_name: str | None = None,
+        **updates,
+    ) -> Dict[str, Any]:
+        """Merge doc_status updates while preserving any existing LightRAG fields."""
+        current_doc_status = await self._ensure_doc_status_record(
+            doc_id,
+            file_path,
+            scheme_name=scheme_name,
+        )
+        updated_doc_status = {
+            **current_doc_status,
+            **updates,
+            "updated_at": self._current_doc_status_timestamp(),
+        }
+        await self.lightrag.doc_status.upsert({doc_id: updated_doc_status})
+        await self.lightrag.doc_status.index_done_callback()
+        return updated_doc_status
+
     def _generate_content_based_doc_id(self, content_list: List[Dict[str, Any]]) -> str:
         """
         Generate doc_id based on document content
@@ -1411,12 +1472,16 @@ class ProcessorMixin:
         try:
             current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
             if current_doc_status:
+                final_status = current_doc_status.get("status") or DocStatus.PROCESSED
+                if final_status != DocStatus.FAILED:
+                    final_status = DocStatus.PROCESSED
                 await self.lightrag.doc_status.upsert(
                     {
                         doc_id: {
                             **current_doc_status,
+                            "status": final_status,
                             "multimodal_processed": True,
-                            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+                            "updated_at": self._current_doc_status_timestamp(),
                         }
                     }
                 )
@@ -1533,6 +1598,7 @@ class ProcessorMixin:
         callback_manager = getattr(self, "callback_manager", None)
         doc_start_time = time.time()
         stage = "parse"
+        file_name = file_name or self._get_file_reference(file_path)
 
         try:
             # Ensure LightRAG is initialized
@@ -1557,6 +1623,13 @@ class ProcessorMixin:
             if doc_id is None:
                 doc_id = content_based_doc_id
 
+            await self._upsert_doc_status(
+                doc_id,
+                file_name,
+                status=DocStatus.HANDLING,
+                error_msg="",
+            )
+
             # Step 2: Separate text and multimodal content
             text_content, multimodal_items = separate_content(content_list)
 
@@ -1572,9 +1645,6 @@ class ProcessorMixin:
             # Step 3: Insert pure text content with all parameters
             stage = "text_insert"
             if text_content.strip():
-                if file_name is None:
-                    # Use full path or basename based on config
-                    file_name = self._get_file_reference(file_path)
                 if callback_manager is not None:
                     callback_manager.dispatch(
                         "on_text_insert_start",
@@ -1600,9 +1670,8 @@ class ProcessorMixin:
                         doc_id=doc_id,
                     )
             else:
-                # Determine file reference even if no text content
-                if file_name is None:
-                    file_name = self._get_file_reference(file_path)
+                # file_name was resolved before parsing so doc_status can be initialized early
+                pass
 
             # Step 4: Process multimodal content (using specialized processors)
             stage = "multimodal"
@@ -1620,6 +1689,18 @@ class ProcessorMixin:
                 )
 
         except Exception as exc:
+            if doc_id is not None:
+                try:
+                    await self._upsert_doc_status(
+                        doc_id,
+                        file_name,
+                        status=DocStatus.FAILED,
+                        error_msg=str(exc),
+                    )
+                except Exception as status_exc:
+                    self.logger.debug(
+                        f"Failed to persist doc_status error state for {doc_id}: {status_exc}"
+                    )
             if callback_manager is not None:
                 callback_manager.dispatch(
                     "on_document_error",
@@ -1790,6 +1871,14 @@ class ProcessorMixin:
             if doc_id is None:
                 doc_id = content_based_doc_id
 
+            await self._upsert_doc_status(
+                doc_id,
+                file_name,
+                scheme_name=scheme_name,
+                status=DocStatus.HANDLING,
+                error_msg="",
+            )
+
             # Step 2: Separate text and multimodal content
             text_content, multimodal_items = separate_content(content_list)
 
@@ -1917,6 +2006,14 @@ class ProcessorMixin:
         if doc_id is None:
             doc_id = self._generate_content_based_doc_id(content_list)
 
+        file_ref = self._get_file_reference(file_path)
+        await self._upsert_doc_status(
+            doc_id,
+            file_ref,
+            status=DocStatus.HANDLING,
+            error_msg="",
+        )
+
         # Display content statistics if requested
         if display_stats:
             self.logger.info("\nContent Information:")
@@ -1948,8 +2045,6 @@ class ProcessorMixin:
 
         # Step 2: Insert pure text content with all parameters
         if text_content.strip():
-            # Use full path or basename based on config
-            file_ref = self._get_file_reference(file_path)
             if callback_manager is not None:
                 callback_manager.dispatch(
                     "on_text_insert_start",
@@ -1975,8 +2070,8 @@ class ProcessorMixin:
                     doc_id=doc_id,
                 )
         else:
-            # Determine file reference even if no text content
-            file_ref = self._get_file_reference(file_path)
+            # file_ref was resolved before insertion so doc_status can be initialized early
+            pass
 
         # Step 3: Process multimodal content (using specialized processors)
         if multimodal_items:

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -5,6 +5,7 @@ Contains helper functions for content separation, text insertion, and other util
 """
 
 import base64
+import inspect
 from typing import Dict, List, Any, Tuple
 from pathlib import Path
 from lightrag.utils import logger
@@ -205,22 +206,46 @@ async def insert_text_content_with_multimodal_content(
     """
     logger.info("Starting text content insertion into LightRAG...")
 
-    # Use LightRAG's insert method with all parameters
+    insert_kwargs = {
+        "input": input,
+        "file_paths": file_paths,
+        "split_by_character": split_by_character,
+        "split_by_character_only": split_by_character_only,
+        "ids": ids,
+    }
+
     try:
-        await lightrag.ainsert(
-            input=input,
-            multimodal_content=multimodal_content,
-            file_paths=file_paths,
-            split_by_character=split_by_character,
-            split_by_character_only=split_by_character_only,
-            ids=ids,
-            scheme_name=scheme_name,
+        insert_signature = inspect.signature(lightrag.ainsert)
+        supported_params = insert_signature.parameters
+        accepts_any_kwargs = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in supported_params.values()
         )
-    except Exception as e:
-        logger.info(f"Error: {e}")
-        logger.info(
-            "If the error is caused by the ainsert function not having a multimodal content parameter, please update the raganything branch of lightrag"
+    except (TypeError, ValueError):
+        supported_params = {}
+        accepts_any_kwargs = True
+
+    if multimodal_content is not None and (
+        accepts_any_kwargs or "multimodal_content" in supported_params
+    ):
+        insert_kwargs["multimodal_content"] = multimodal_content
+    elif multimodal_content is not None:
+        logger.warning(
+            "LightRAG ainsert() does not accept multimodal_content; "
+            "retrying with text-only insertion so doc_status is still created"
         )
+
+    if scheme_name is not None and (
+        accepts_any_kwargs or "scheme_name" in supported_params
+    ):
+        insert_kwargs["scheme_name"] = scheme_name
+    elif scheme_name is not None:
+        logger.warning(
+            "LightRAG ainsert() does not accept scheme_name; "
+            "continuing without it for compatibility"
+        )
+
+    await lightrag.ainsert(**insert_kwargs)
 
     logger.info("Text content insertion complete")
 

--- a/tests/testdoc_status_creation.py
+++ b/tests/testdoc_status_creation.py
@@ -1,0 +1,171 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_raganything_module(module_name: str, relative_path: str):
+    module_path = PROJECT_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def raganything_modules(monkeypatch):
+    logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+
+    fake_lightrag = types.ModuleType("lightrag")
+    fake_lightrag_utils = types.ModuleType("lightrag.utils")
+    fake_lightrag_utils.logger = logger
+    fake_lightrag_utils.compute_mdhash_id = (
+        lambda value, prefix="": f"{prefix}{abs(hash(value))}"
+    )
+
+    monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", fake_lightrag_utils)
+
+    rag_pkg = types.ModuleType("raganything")
+    rag_pkg.__path__ = [str(PROJECT_ROOT / "raganything")]
+    monkeypatch.setitem(sys.modules, "raganything", rag_pkg)
+
+    base_module = _load_raganything_module("raganything.base", "raganything/base.py")
+    _load_raganything_module("raganything.parser", "raganything/parser.py")
+    utils_module = _load_raganything_module("raganything.utils", "raganything/utils.py")
+    processor_module = _load_raganything_module(
+        "raganything.processor", "raganything/processor.py"
+    )
+
+    return types.SimpleNamespace(
+        base=base_module,
+        utils=utils_module,
+        processor=processor_module,
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_text_content_with_multimodal_falls_back_for_old_lightrag(
+    raganything_modules,
+):
+    calls = []
+
+    class FakeLightRAG:
+        async def ainsert(
+            self,
+            *,
+            input,
+            file_paths=None,
+            split_by_character=None,
+            split_by_character_only=False,
+            ids=None,
+        ):
+            calls.append(
+                {
+                    "input": input,
+                    "file_paths": file_paths,
+                    "split_by_character": split_by_character,
+                    "split_by_character_only": split_by_character_only,
+                    "ids": ids,
+                }
+            )
+
+    await raganything_modules.utils.insert_text_content_with_multimodal_content(
+        FakeLightRAG(),
+        input="hello world",
+        multimodal_content=[{"type": "image"}],
+        file_paths="sample.pdf",
+        ids="doc-compat",
+        scheme_name="test-scheme",
+    )
+
+    assert calls == [
+        {
+            "input": "hello world",
+            "file_paths": "sample.pdf",
+            "split_by_character": None,
+            "split_by_character_only": False,
+            "ids": "doc-compat",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_document_complete_bootstraps_doc_status(
+    raganything_modules,
+    tmp_path,
+):
+    processor_module = raganything_modules.processor
+    DocStatus = raganything_modules.base.DocStatus
+
+    class FakeDocStatusStorage:
+        def __init__(self):
+            self.records = {}
+
+        async def get_by_id(self, key):
+            return self.records.get(key)
+
+        async def upsert(self, data):
+            for key, value in data.items():
+                self.records[key] = value
+
+        async def index_done_callback(self):
+            return None
+
+    class FakeLightRAG:
+        def __init__(self):
+            self.doc_status = FakeDocStatusStorage()
+
+        async def ainsert(self, **kwargs):
+            return None
+
+    class DummyProcessor(processor_module.ProcessorMixin):
+        pass
+
+    processor = DummyProcessor()
+    processor.lightrag = FakeLightRAG()
+    processor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+    processor.config = types.SimpleNamespace(
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+        content_format="default",
+    )
+
+    async def fake_ensure_lightrag_initialized():
+        return {"success": True}
+
+    async def fake_parse_document(file_path, output_dir, parse_method, display_stats, **kwargs):
+        return ([{"type": "text", "text": "hello from test", "page_idx": 0}], "doc-generated")
+
+    processor._ensure_lightrag_initialized = fake_ensure_lightrag_initialized
+    processor.parse_document = fake_parse_document
+
+    await processor.process_document_complete(
+        file_path=str(tmp_path / "sample.pdf"),
+        doc_id="doc-custom",
+        file_name="sample.pdf",
+    )
+
+    doc_status = processor.lightrag.doc_status.records["doc-custom"]
+    assert doc_status["file_path"] == "sample.pdf"
+    assert doc_status["status"] == DocStatus.PROCESSED
+    assert doc_status["multimodal_processed"] is True


### PR DESCRIPTION
## Summary
- bootstrap doc_status records before document insertion so process_document_complete and insert_content_list always persist a deletable document entry
- make multimodal text insertion compatible with LightRAG versions that do not accept multimodal_content or scheme_name in ainsert()
- add a regression test covering both the compatibility fallback and the missing doc_status bug from #244

## Testing
- python3 -m pytest tests/testdoc_status_creation.py

Closes #244