### PR TITLE
fix: detect ainsert signature instead of silently swallowing TypeError

### DIFF
--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -203,10 +203,14 @@ async def insert_text_content_with_multimodal_content(
         file_paths: single string of the file path or list of file paths, used for citation
         scheme_name: scheme name (optional)
     """
+    import inspect
+
     logger.info("Starting text content insertion into LightRAG...")
 
-    # Use LightRAG's insert method with all parameters
-    try:
+    sig = inspect.signature(lightrag.ainsert)
+    supports_multimodal = "multimodal_content" in sig.parameters
+
+    if supports_multimodal:
         await lightrag.ainsert(
             input=input,
             multimodal_content=multimodal_content,
@@ -216,10 +220,19 @@ async def insert_text_content_with_multimodal_content(
             ids=ids,
             scheme_name=scheme_name,
         )
-    except Exception as e:
-        logger.info(f"Error: {e}")
-        logger.info(
-            "If the error is caused by the ainsert function not having a multimodal content parameter, please update the raganything branch of lightrag"
+    else:
+        logger.warning(
+            "LightRAG.ainsert does not support multimodal_content; "
+            "falling back to text-only insertion. Upgrade to the RAGAnything "
+            "branch of LightRAG to enable full multimodal support."
+        )
+        await lightrag.ainsert(
+            input=input,
+            file_paths=file_paths,
+            split_by_character=split_by_character,
+            split_by_character_only=split_by_character_only,
+            ids=ids,
+            scheme_name=scheme_name,
         )
 
     logger.info("Text content insertion complete")


### PR DESCRIPTION
## Summary

Fixes #244.

`insert_text_content_with_multimodal_content` in `utils.py` was wrapping the entire `lightrag.ainsert()` call in a bare `except Exception` that logged a hint and returned silently. When LightRAG's `ainsert` does not accept a `multimodal_content` keyword argument (i.e. the standard PyPI release rather than the RAGAnything branch), the `TypeError` was swallowed — meaning:

- No text was indexed
- No `kv_store_doc_status` entry was written
- `adelete_by_doc_id` returned 404

**Fix:** use `inspect.signature` to check upfront whether `ainsert` accepts `multimodal_content`. If it does, call with the full argument set. If not, emit a visible `logger.warning` and fall back to text-only insertion so the document is still indexed and `doc_status` is correctly written. Real errors (network failures, LLM errors, etc.) now propagate instead of being silently dropped.

## Test plan
- [ ] Run `process_document_complete()` against the standard PyPI LightRAG release — confirm `kv_store_doc_status` is created and `adelete_by_doc_id` succeeds
- [ ] Run against the RAGAnything LightRAG branch — confirm full multimodal path still works
- [ ] Confirm any real `ainsert` errors (e.g. bad API key) now surface as exceptions