### PR TITLE
fix: handle messages= kwarg in vision_model_func (insert_content_list_example)

### DIFF
--- a/examples/insert_content_list_example.py
+++ b/examples/insert_content_list_example.py
@@ -211,9 +211,26 @@ async def demo_insert_content_list(
 
         # Define vision model function for image processing
         def vision_model_func(
-            prompt, system_prompt=None, history_messages=[], image_data=None, **kwargs
+            prompt,
+            system_prompt=None,
+            history_messages=[],
+            image_data=None,
+            messages=None,
+            **kwargs,
         ):
-            if image_data:
+            # If pre-built messages are provided (VLM enhanced query path), use them directly
+            if messages:
+                return openai_complete_if_cache(
+                    "gpt-4o",
+                    "",
+                    system_prompt=None,
+                    history_messages=[],
+                    messages=messages,
+                    api_key=api_key,
+                    base_url=base_url,
+                    **kwargs,
+                )
+            elif image_data:
                 return openai_complete_if_cache(
                     "gpt-4o",
                     "",


### PR DESCRIPTION
## Summary

Fixes #28, fixes #98.

`_call_vlm_with_multimodal_content` in `query.py` passes a pre-built `messages` list via `messages=` when executing VLM-enhanced queries that include multimodal content. The `vision_model_func` in `insert_content_list_example.py` did not accept this parameter, so it landed in `**kwargs` and was forwarded to `openai_complete_if_cache` — which also constructs its own `messages` from `prompt`, `system_prompt`, and `history_messages`. This produced:

```
TypeError: openai.resources.chat.completions.completions.AsyncCompletions.create()
    got multiple values for keyword argument 'messages'
```

**Fix:** add `messages=None` to the function signature and use the pre-built messages directly when present, mirroring the pattern already used in `raganything_example.py`.

## Test plan
- [ ] Run `demo_insert_content_list` against a PDF containing images and verify VLM-enhanced query completes without `multiple values for 'messages'` error
- [ ] Run with `image_data` path (no pre-built messages) — confirm image description still works