### PR TITLE
fix: store multimodal_processed in separate KV namespace to prevent DocProcessingStatus errors

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -531,29 +531,34 @@ class ProcessorMixin:
                 doc_id=doc_id,
             )
 
-        # Check multimodal processing status - handle LightRAG's early DocStatus.PROCESSED marking
+        # Check multimodal processing status using the dedicated multimodal_status store
+        # (kept separate from LightRAG's doc_status so the LightRAG Server API never
+        # encounters unknown fields when deserializing DocProcessingStatus objects)
         try:
+            multimodal_record = (
+                await self.multimodal_status.get_by_id(doc_id)
+                if self.multimodal_status is not None
+                else None
+            )
+            multimodal_processed = (
+                multimodal_record.get("multimodal_processed", False)
+                if multimodal_record
+                else False
+            )
+
+            if multimodal_processed:
+                self.logger.info(
+                    f"Document {doc_id} multimodal content is already processed"
+                )
+                return
+
             existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
             if existing_doc_status:
-                # Check if multimodal content is already processed
-                multimodal_processed = existing_doc_status.get(
-                    "multimodal_processed", False
-                )
-
-                if multimodal_processed:
-                    self.logger.info(
-                        f"Document {doc_id} multimodal content is already processed"
-                    )
-                    return
-
-                # Even if status is DocStatus.PROCESSED (text processing done),
-                # we still need to process multimodal content if not yet done
                 doc_status = existing_doc_status.get("status", "")
                 if doc_status == DocStatus.PROCESSED and not multimodal_processed:
                     self.logger.info(
                         f"Document {doc_id} text processing is complete, but multimodal content still needs processing"
                     )
-                    # Continue with multimodal processing
                 elif doc_status == DocStatus.PROCESSED and multimodal_processed:
                     self.logger.info(
                         f"Document {doc_id} is fully processed (text + multimodal)"
@@ -1407,20 +1412,18 @@ class ProcessorMixin:
             )
 
     async def _mark_multimodal_processing_complete(self, doc_id: str):
-        """Mark multimodal content processing as complete in the document status."""
+        """Mark multimodal content processing as complete in the dedicated multimodal_status store."""
         try:
-            current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
-            if current_doc_status:
-                await self.lightrag.doc_status.upsert(
+            if self.multimodal_status is not None:
+                await self.multimodal_status.upsert(
                     {
                         doc_id: {
-                            **current_doc_status,
                             "multimodal_processed": True,
                             "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                         }
                     }
                 )
-                await self.lightrag.doc_status.index_done_callback()
+                await self.multimodal_status.index_done_callback()
                 self.logger.debug(
                     f"Marked multimodal content processing as complete for document {doc_id}"
                 )
@@ -1445,7 +1448,17 @@ class ProcessorMixin:
                 return False
 
             text_processed = doc_status.get("status") == DocStatus.PROCESSED
-            multimodal_processed = doc_status.get("multimodal_processed", False)
+
+            multimodal_record = (
+                await self.multimodal_status.get_by_id(doc_id)
+                if self.multimodal_status is not None
+                else None
+            )
+            multimodal_processed = (
+                multimodal_record.get("multimodal_processed", False)
+                if multimodal_record
+                else False
+            )
 
             return text_processed and multimodal_processed
 
@@ -1477,7 +1490,17 @@ class ProcessorMixin:
                 }
 
             text_processed = doc_status.get("status") == DocStatus.PROCESSED
-            multimodal_processed = doc_status.get("multimodal_processed", False)
+
+            multimodal_record = (
+                await self.multimodal_status.get_by_id(doc_id)
+                if self.multimodal_status is not None
+                else None
+            )
+            multimodal_processed = (
+                multimodal_record.get("multimodal_processed", False)
+                if multimodal_record
+                else False
+            )
             fully_processed = text_processed and multimodal_processed
 
             return {

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -94,6 +94,10 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
     parse_cache: Optional[Any] = field(default=None, init=False)
     """Parse result cache storage using LightRAG KV storage."""
 
+    multimodal_status: Optional[Any] = field(default=None, init=False)
+    """Separate KV storage for multimodal processing state (keeps it out of LightRAG's
+    DocProcessingStatus so the LightRAG Server API can deserialize doc records cleanly)."""
+
     callback_manager: CallbackManager = field(
         default_factory=CallbackManager, init=False, repr=False
     )
@@ -314,6 +318,18 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                         )
                         await self.parse_cache.initialize()
 
+                    # Initialize multimodal status storage if not already done
+                    if self.multimodal_status is None:
+                        self.multimodal_status = (
+                            self.lightrag.key_string_value_json_storage_cls(
+                                namespace="raganything_multimodal_status",
+                                workspace=self.lightrag.workspace,
+                                global_config=self.lightrag.__dict__,
+                                embedding_func=self.embedding_func,
+                            )
+                        )
+                        await self.multimodal_status.initialize()
+
                     # Initialize processors if not already done
                     if not self.modal_processors:
                         self._initialize_processors()
@@ -374,6 +390,18 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                 )
                 await self.parse_cache.initialize()
 
+                # Initialize multimodal status storage (separate from LightRAG's doc_status
+                # so the LightRAG Server API never encounters unknown fields)
+                self.multimodal_status = (
+                    self.lightrag.key_string_value_json_storage_cls(
+                        namespace="raganything_multimodal_status",
+                        workspace=self.lightrag.workspace,
+                        global_config=self.lightrag.__dict__,
+                        embedding_func=self.embedding_func,
+                    )
+                )
+                await self.multimodal_status.initialize()
+
                 # Initialize processors after LightRAG is ready
                 self._initialize_processors()
 
@@ -421,6 +449,11 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
             if self.parse_cache is not None:
                 tasks.append(self.parse_cache.finalize())
                 self.logger.debug("Scheduled parse cache finalization")
+
+            # Finalize multimodal status storage if it exists
+            if self.multimodal_status is not None:
+                tasks.append(self.multimodal_status.finalize())
+                self.logger.debug("Scheduled multimodal status finalization")
 
             # Finalize LightRAG storages if LightRAG is initialized
             if self.lightrag is not None:


### PR DESCRIPTION
## Summary

Fixes #91, fixes #119.

RAGAnything was injecting a `multimodal_processed` field directly into LightRAG's `doc_status` KV records. The LightRAG Server API deserializes those records into `DocProcessingStatus` dataclass objects. Any LightRAG version whose `DocProcessingStatus` does not declare `multimodal_processed` raised:

```
DocProcessingStatus.__init__() got an unexpected keyword argument 'multimodal_processed'
500 Internal Server Error on /documents/paginated
```

**Fix:** introduce a dedicated `raganything_multimodal_status` KV namespace (same storage class as `parse_cache`) to hold per-document multimodal processing state. LightRAG's own `doc_status` records are no longer modified with RAGAnything-specific fields, so `DocProcessingStatus` deserialization always succeeds regardless of LightRAG version.

Changes:
- `raganything/raganything.py` — add `multimodal_status` field, initialize in both pre-provided and newly-created LightRAG paths, finalize in `finalize_storages`
- `raganything/processor.py` — all `multimodal_processed` reads/writes now go through `self.multimodal_status`; `doc_status` upserts no longer contain this field

## Test plan
- [ ] Process a document, then call `/documents/paginated` on LightRAG Server — confirm no 500 error
- [ ] Verify `adelete_by_doc_id` still works after processing
- [ ] Confirm `is_document_fully_processed()` and `get_document_processing_status()` return correct values