### PR TITLE
fix: create doc_status even when LightRAG lacks multimodal insert args

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -91,6 +91,67 @@ class ProcessorMixin:
 
         return cache_key
 
+    @staticmethod
+    def _current_doc_status_timestamp() -> str:
+        """Return a stable UTC timestamp for doc_status bookkeeping."""
+        return time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())
+
+    async def _ensure_doc_status_record(
+        self,
+        doc_id: str,
+        file_path: str,
+        *,
+        scheme_name: str | None = None,
+        status: DocStatus = DocStatus.READY,
+    ) -> Dict[str, Any]:
+        """Create a minimal doc_status entry when LightRAG has not created one yet."""
+        current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
+        if current_doc_status:
+            return current_doc_status
+
+        timestamp = self._current_doc_status_timestamp()
+        doc_status_payload: Dict[str, Any] = {
+            "status": status,
+            "content": "",
+            "content_summary": "",
+            "content_length": 0,
+            "error_msg": "",
+            "chunks_count": 0,
+            "chunks_list": [],
+            "created_at": timestamp,
+            "updated_at": timestamp,
+            "file_path": self._get_file_reference(file_path),
+        }
+        if scheme_name is not None:
+            doc_status_payload["scheme_name"] = scheme_name
+
+        await self.lightrag.doc_status.upsert({doc_id: doc_status_payload})
+        await self.lightrag.doc_status.index_done_callback()
+        return await self.lightrag.doc_status.get_by_id(doc_id) or doc_status_payload
+
+    async def _upsert_doc_status(
+        self,
+        doc_id: str,
+        file_path: str,
+        *,
+        scheme_name: str | None = None,
+        **updates,
+    ) -> Dict[str, Any]:
+        """Merge doc_status updates while preserving any existing LightRAG fields."""
+        current_doc_status = await self._ensure_doc_status_record(
+            doc_id,
+            file_path,
+            scheme_name=scheme_name,
+        )
+        updated_doc_status = {
+            **current_doc_status,
+            **updates,
+            "updated_at": self._current_doc_status_timestamp(),
+        }
+        await self.lightrag.doc_status.upsert({doc_id: updated_doc_status})
+        await self.lightrag.doc_status.index_done_callback()
+        return updated_doc_status
+
     def _generate_content_based_doc_id(self, content_list: List[Dict[str, Any]]) -> str:
         """
         Generate doc_id based on document content
@@ -1411,12 +1472,16 @@ class ProcessorMixin:
         try:
             current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
             if current_doc_status:
+                final_status = current_doc_status.get("status") or DocStatus.PROCESSED
+                if final_status != DocStatus.FAILED:
+                    final_status = DocStatus.PROCESSED
                 await self.lightrag.doc_status.upsert(
                     {
                         doc_id: {
                             **current_doc_status,
+                            "status": final_status,
                             "multimodal_processed": True,
-                            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+                            "updated_at": self._current_doc_status_timestamp(),
                         }
                     }
                 )
@@ -1533,6 +1598,7 @@ class ProcessorMixin:
         callback_manager = getattr(self, "callback_manager", None)
         doc_start_time = time.time()
         stage = "parse"
+        file_name = file_name or self._get_file_reference(file_path)
 
         try:
             # Ensure LightRAG is initialized
@@ -1557,6 +1623,13 @@ class ProcessorMixin:
             if doc_id is None:
                 doc_id = content_based_doc_id
 
+            await self._upsert_doc_status(
+                doc_id,
+                file_name,
+                status=DocStatus.HANDLING,
+                error_msg="",
+            )
+
             # Step 2: Separate text and multimodal content
             text_content, multimodal_items = separate_content(content_list)
 
@@ -1572,9 +1645,6 @@ class ProcessorMixin:
             # Step 3: Insert pure text content with all parameters
             stage = "text_insert"
             if text_content.strip():
-                if file_name is None:
-                    # Use full path or basename based on config
-                    file_name = self._get_file_reference(file_path)
                 if callback_manager is not None:
                     callback_manager.dispatch(
                         "on_text_insert_start",
@@ -1600,9 +1670,8 @@ class ProcessorMixin:
                         doc_id=doc_id,
                     )
             else:
-                # Determine file reference even if no text content
-                if file_name is None:
-                    file_name = self._get_file_reference(file_path)
+                # file_name was resolved before parsing so doc_status can be initialized early
+                pass
 
             # Step 4: Process multimodal content (using specialized processors)
             stage = "multimodal"
@@ -1620,6 +1689,18 @@ class ProcessorMixin:
                 )
 
         except Exception as exc:
+            if doc_id is not None:
+                try:
+                    await self._upsert_doc_status(
+                        doc_id,
+                        file_name,
+                        status=DocStatus.FAILED,
+                        error_msg=str(exc),
+                    )
+                except Exception as status_exc:
+                    self.logger.debug(
+                        f"Failed to persist doc_status error state for {doc_id}: {status_exc}"
+                    )
             if callback_manager is not None:
                 callback_manager.dispatch(
                     "on_document_error",
@@ -1790,6 +1871,14 @@ class ProcessorMixin:
             if doc_id is None:
                 doc_id = content_based_doc_id
 
+            await self._upsert_doc_status(
+                doc_id,
+                file_name,
+                scheme_name=scheme_name,
+                status=DocStatus.HANDLING,
+                error_msg="",
+            )
+
             # Step 2: Separate text and multimodal content
             text_content, multimodal_items = separate_content(content_list)
 
@@ -1917,6 +2006,14 @@ class ProcessorMixin:
         if doc_id is None:
             doc_id = self._generate_content_based_doc_id(content_list)
 
+        file_ref = self._get_file_reference(file_path)
+        await self._upsert_doc_status(
+            doc_id,
+            file_ref,
+            status=DocStatus.HANDLING,
+            error_msg="",
+        )
+
         # Display content statistics if requested
         if display_stats:
             self.logger.info("\nContent Information:")
@@ -1948,8 +2045,6 @@ class ProcessorMixin:
 
         # Step 2: Insert pure text content with all parameters
         if text_content.strip():
-            # Use full path or basename based on config
-            file_ref = self._get_file_reference(file_path)
             if callback_manager is not None:
                 callback_manager.dispatch(
                     "on_text_insert_start",
@@ -1975,8 +2070,8 @@ class ProcessorMixin:
                     doc_id=doc_id,
                 )
         else:
-            # Determine file reference even if no text content
-            file_ref = self._get_file_reference(file_path)
+            # file_ref was resolved before insertion so doc_status can be initialized early
+            pass
 
         # Step 3: Process multimodal content (using specialized processors)
         if multimodal_items:

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -152,6 +152,47 @@ class ProcessorMixin:
         await self.lightrag.doc_status.index_done_callback()
         return updated_doc_status
 
+    async def _get_multimodal_status_record(self, doc_id: str) -> Dict[str, Any] | None:
+        """Get compatibility multimodal completion state when doc_status cannot store it."""
+        if (
+            not hasattr(self, "multimodal_status_cache")
+            or self.multimodal_status_cache is None
+        ):
+            return None
+
+        return await self.multimodal_status_cache.get_by_id(doc_id)
+
+    async def _set_multimodal_status_record(self, doc_id: str, processed: bool) -> None:
+        """Persist multimodal completion state in a separate KV namespace."""
+        if (
+            not hasattr(self, "multimodal_status_cache")
+            or self.multimodal_status_cache is None
+        ):
+            return
+
+        await self.multimodal_status_cache.upsert(
+            {
+                doc_id: {
+                    "multimodal_processed": processed,
+                    "updated_at": self._current_doc_status_timestamp(),
+                }
+            }
+        )
+        await self.multimodal_status_cache.index_done_callback()
+
+    async def _get_multimodal_processed_flag(
+        self, doc_id: str, doc_status: Dict[str, Any] | None = None
+    ) -> bool:
+        """Read multimodal completion state from doc_status or compatibility cache."""
+        if doc_status is not None and "multimodal_processed" in doc_status:
+            return bool(doc_status.get("multimodal_processed", False))
+
+        compatibility_status = await self._get_multimodal_status_record(doc_id)
+        if compatibility_status is not None:
+            return bool(compatibility_status.get("multimodal_processed", False))
+
+        return False
+
     def _generate_content_based_doc_id(self, content_list: List[Dict[str, Any]]) -> str:
         """
         Generate doc_id based on document content
@@ -597,8 +638,8 @@ class ProcessorMixin:
             existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
             if existing_doc_status:
                 # Check if multimodal content is already processed
-                multimodal_processed = existing_doc_status.get(
-                    "multimodal_processed", False
+                multimodal_processed = await self._get_multimodal_processed_flag(
+                    doc_id, existing_doc_status
                 )
 
                 if multimodal_processed:
@@ -1498,6 +1539,7 @@ class ProcessorMixin:
                         "updated_at": self._current_doc_status_timestamp(),
                     }
                     await self.lightrag.doc_status.upsert({doc_id: fallback_payload})
+                    await self._set_multimodal_status_record(doc_id, True)
                 await self.lightrag.doc_status.index_done_callback()
                 self.logger.debug(
                     f"Marked multimodal content processing as complete for document {doc_id}"
@@ -1523,7 +1565,9 @@ class ProcessorMixin:
                 return False
 
             text_processed = doc_status.get("status") == DocStatus.PROCESSED
-            multimodal_processed = doc_status.get("multimodal_processed", False)
+            multimodal_processed = await self._get_multimodal_processed_flag(
+                doc_id, doc_status
+            )
 
             return text_processed and multimodal_processed
 
@@ -1555,7 +1599,9 @@ class ProcessorMixin:
                 }
 
             text_processed = doc_status.get("status") == DocStatus.PROCESSED
-            multimodal_processed = doc_status.get("multimodal_processed", False)
+            multimodal_processed = await self._get_multimodal_processed_flag(
+                doc_id, doc_status
+            )
             fully_processed = text_processed and multimodal_processed
 
             return {

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1475,16 +1475,29 @@ class ProcessorMixin:
                 final_status = current_doc_status.get("status") or DocStatus.PROCESSED
                 if final_status != DocStatus.FAILED:
                     final_status = DocStatus.PROCESSED
-                await self.lightrag.doc_status.upsert(
-                    {
-                        doc_id: {
-                            **current_doc_status,
-                            "status": final_status,
-                            "multimodal_processed": True,
-                            "updated_at": self._current_doc_status_timestamp(),
-                        }
+                update_payload = {
+                    **current_doc_status,
+                    "status": final_status,
+                    "multimodal_processed": True,
+                    "updated_at": self._current_doc_status_timestamp(),
+                }
+                try:
+                    await self.lightrag.doc_status.upsert({doc_id: update_payload})
+                except Exception as exc:
+                    # Older LightRAG versions reject unknown doc_status fields such as
+                    # multimodal_processed. Fall back to a schema-compatible status-only
+                    # update so image-only and multimodal documents still complete.
+                    self.logger.debug(
+                        "Falling back to schema-compatible doc_status update for %s: %s",
+                        doc_id,
+                        exc,
+                    )
+                    fallback_payload = {
+                        **current_doc_status,
+                        "status": final_status,
+                        "updated_at": self._current_doc_status_timestamp(),
                     }
-                )
+                    await self.lightrag.doc_status.upsert({doc_id: fallback_payload})
                 await self.lightrag.doc_status.index_done_callback()
                 self.logger.debug(
                     f"Marked multimodal content processing as complete for document {doc_id}"

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -94,6 +94,9 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
     parse_cache: Optional[Any] = field(default=None, init=False)
     """Parse result cache storage using LightRAG KV storage."""
 
+    multimodal_status_cache: Optional[Any] = field(default=None, init=False)
+    """Compatibility KV storage for multimodal completion state."""
+
     callback_manager: CallbackManager = field(
         default_factory=CallbackManager, init=False, repr=False
     )
@@ -314,6 +317,20 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                         )
                         await self.parse_cache.initialize()
 
+                    if self.multimodal_status_cache is None:
+                        self.logger.info(
+                            "Initializing multimodal status cache for pre-provided LightRAG instance"
+                        )
+                        self.multimodal_status_cache = (
+                            self.lightrag.key_string_value_json_storage_cls(
+                                namespace="multimodal_status",
+                                workspace=self.lightrag.workspace,
+                                global_config=self.lightrag.__dict__,
+                                embedding_func=self.embedding_func,
+                            )
+                        )
+                        await self.multimodal_status_cache.initialize()
+
                     # Initialize processors if not already done
                     if not self.modal_processors:
                         self._initialize_processors()
@@ -374,11 +391,21 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                 )
                 await self.parse_cache.initialize()
 
+                self.multimodal_status_cache = (
+                    self.lightrag.key_string_value_json_storage_cls(
+                        namespace="multimodal_status",
+                        workspace=self.lightrag.workspace,
+                        global_config=self.lightrag.__dict__,
+                        embedding_func=self.embedding_func,
+                    )
+                )
+                await self.multimodal_status_cache.initialize()
+
                 # Initialize processors after LightRAG is ready
                 self._initialize_processors()
 
                 self.logger.info(
-                    "LightRAG, parse cache, and multimodal processors initialized"
+                    "LightRAG, parse cache, multimodal status cache, and multimodal processors initialized"
                 )
                 return {"success": True}
 
@@ -421,6 +448,10 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
             if self.parse_cache is not None:
                 tasks.append(self.parse_cache.finalize())
                 self.logger.debug("Scheduled parse cache finalization")
+
+            if self.multimodal_status_cache is not None:
+                tasks.append(self.multimodal_status_cache.finalize())
+                self.logger.debug("Scheduled multimodal status cache finalization")
 
             # Finalize LightRAG storages if LightRAG is initialized
             if self.lightrag is not None:

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -5,6 +5,7 @@ Contains helper functions for content separation, text insertion, and other util
 """
 
 import base64
+import inspect
 from typing import Dict, List, Any, Tuple
 from pathlib import Path
 from lightrag.utils import logger
@@ -205,22 +206,46 @@ async def insert_text_content_with_multimodal_content(
     """
     logger.info("Starting text content insertion into LightRAG...")
 
-    # Use LightRAG's insert method with all parameters
+    insert_kwargs = {
+        "input": input,
+        "file_paths": file_paths,
+        "split_by_character": split_by_character,
+        "split_by_character_only": split_by_character_only,
+        "ids": ids,
+    }
+
     try:
-        await lightrag.ainsert(
-            input=input,
-            multimodal_content=multimodal_content,
-            file_paths=file_paths,
-            split_by_character=split_by_character,
-            split_by_character_only=split_by_character_only,
-            ids=ids,
-            scheme_name=scheme_name,
+        insert_signature = inspect.signature(lightrag.ainsert)
+        supported_params = insert_signature.parameters
+        accepts_any_kwargs = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in supported_params.values()
         )
-    except Exception as e:
-        logger.info(f"Error: {e}")
-        logger.info(
-            "If the error is caused by the ainsert function not having a multimodal content parameter, please update the raganything branch of lightrag"
+    except (TypeError, ValueError):
+        supported_params = {}
+        accepts_any_kwargs = True
+
+    if multimodal_content is not None and (
+        accepts_any_kwargs or "multimodal_content" in supported_params
+    ):
+        insert_kwargs["multimodal_content"] = multimodal_content
+    elif multimodal_content is not None:
+        logger.warning(
+            "LightRAG ainsert() does not accept multimodal_content; "
+            "retrying with text-only insertion so doc_status is still created"
         )
+
+    if scheme_name is not None and (
+        accepts_any_kwargs or "scheme_name" in supported_params
+    ):
+        insert_kwargs["scheme_name"] = scheme_name
+    elif scheme_name is not None:
+        logger.warning(
+            "LightRAG ainsert() does not accept scheme_name; "
+            "continuing without it for compatibility"
+        )
+
+    await lightrag.ainsert(**insert_kwargs)
 
     logger.info("Text content insertion complete")
 

--- a/tests/test_doc_status_creation.py
+++ b/tests/test_doc_status_creation.py
@@ -9,6 +9,21 @@ import pytest
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
+class InMemoryJsonStorage:
+    def __init__(self):
+        self.records = {}
+
+    async def get_by_id(self, key):
+        return self.records.get(key)
+
+    async def upsert(self, data):
+        for key, value in data.items():
+            self.records[key] = value
+
+    async def index_done_callback(self):
+        return None
+
+
 def _load_raganything_module(module_name: str, relative_path: str):
     module_path = PROJECT_ROOT / relative_path
     spec = importlib.util.spec_from_file_location(module_name, module_path)
@@ -136,6 +151,7 @@ async def test_process_document_complete_bootstraps_doc_status(
 
     processor = DummyProcessor()
     processor.lightrag = FakeLightRAG()
+    processor.multimodal_status_cache = InMemoryJsonStorage()
     processor.logger = types.SimpleNamespace(
         info=lambda *args, **kwargs: None,
         warning=lambda *args, **kwargs: None,
@@ -207,6 +223,7 @@ async def test_image_only_document_falls_back_when_multimodal_flag_is_unsupporte
 
     processor = DummyProcessor()
     processor.lightrag = FakeLightRAG()
+    processor.multimodal_status_cache = InMemoryJsonStorage()
     processor.logger = types.SimpleNamespace(
         info=lambda *args, **kwargs: None,
         warning=lambda *args, **kwargs: None,
@@ -255,3 +272,81 @@ async def test_image_only_document_falls_back_when_multimodal_flag_is_unsupporte
     assert doc_status["file_path"] == "figure.png"
     assert doc_status["status"] == DocStatus.PROCESSED
     assert "multimodal_processed" not in doc_status
+    assert processor.multimodal_status_cache.records["doc-image"] == {
+        "multimodal_processed": True,
+        "updated_at": doc_status["updated_at"],
+    }
+
+    processing_status = await processor.get_document_processing_status("doc-image")
+    assert processing_status["multimodal_processed"] is True
+    assert processing_status["fully_processed"] is True
+    assert await processor.is_document_fully_processed("doc-image") is True
+
+
+@pytest.mark.asyncio
+async def test_compatibility_multimodal_cache_prevents_repeat_processing(
+    raganything_modules,
+):
+    processor_module = raganything_modules.processor
+    DocStatus = raganything_modules.base.DocStatus
+
+    class FakeDocStatusStorage:
+        def __init__(self):
+            self.records = {
+                "doc-image": {
+                    "status": DocStatus.PROCESSED,
+                    "file_path": "figure.png",
+                }
+            }
+
+        async def get_by_id(self, key):
+            return self.records.get(key)
+
+    class FakeMultimodalStatusStorage:
+        def __init__(self):
+            self.records = {
+                "doc-image": {
+                    "multimodal_processed": True,
+                    "updated_at": "2026-04-22T00:00:00+00:00",
+                }
+            }
+
+        async def get_by_id(self, key):
+            return self.records.get(key)
+
+    class FakeLightRAG:
+        def __init__(self):
+            self.doc_status = FakeDocStatusStorage()
+
+    class DummyProcessor(processor_module.ProcessorMixin):
+        pass
+
+    processor = DummyProcessor()
+    processor.lightrag = FakeLightRAG()
+    processor.multimodal_status_cache = FakeMultimodalStatusStorage()
+    processor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+    processor.callback_manager = None
+
+    async def fake_ensure_lightrag_initialized():
+        return {"success": True}
+
+    called = {"batch": 0}
+
+    async def fake_batch_type_aware(*args, **kwargs):
+        called["batch"] += 1
+
+    processor._ensure_lightrag_initialized = fake_ensure_lightrag_initialized
+    processor._process_multimodal_content_batch_type_aware = fake_batch_type_aware
+
+    await processor._process_multimodal_content(
+        [{"type": "image", "img_path": "figure.png"}],
+        "figure.png",
+        "doc-image",
+    )
+
+    assert called["batch"] == 0

--- a/tests/testdoc_status_creation.py
+++ b/tests/testdoc_status_creation.py
@@ -1,0 +1,171 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_raganything_module(module_name: str, relative_path: str):
+    module_path = PROJECT_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def raganything_modules(monkeypatch):
+    logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+
+    fake_lightrag = types.ModuleType("lightrag")
+    fake_lightrag_utils = types.ModuleType("lightrag.utils")
+    fake_lightrag_utils.logger = logger
+    fake_lightrag_utils.compute_mdhash_id = (
+        lambda value, prefix="": f"{prefix}{abs(hash(value))}"
+    )
+
+    monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", fake_lightrag_utils)
+
+    rag_pkg = types.ModuleType("raganything")
+    rag_pkg.__path__ = [str(PROJECT_ROOT / "raganything")]
+    monkeypatch.setitem(sys.modules, "raganything", rag_pkg)
+
+    base_module = _load_raganything_module("raganything.base", "raganything/base.py")
+    _load_raganything_module("raganything.parser", "raganything/parser.py")
+    utils_module = _load_raganything_module("raganything.utils", "raganything/utils.py")
+    processor_module = _load_raganything_module(
+        "raganything.processor", "raganything/processor.py"
+    )
+
+    return types.SimpleNamespace(
+        base=base_module,
+        utils=utils_module,
+        processor=processor_module,
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_text_content_with_multimodal_falls_back_for_old_lightrag(
+    raganything_modules,
+):
+    calls = []
+
+    class FakeLightRAG:
+        async def ainsert(
+            self,
+            *,
+            input,
+            file_paths=None,
+            split_by_character=None,
+            split_by_character_only=False,
+            ids=None,
+        ):
+            calls.append(
+                {
+                    "input": input,
+                    "file_paths": file_paths,
+                    "split_by_character": split_by_character,
+                    "split_by_character_only": split_by_character_only,
+                    "ids": ids,
+                }
+            )
+
+    await raganything_modules.utils.insert_text_content_with_multimodal_content(
+        FakeLightRAG(),
+        input="hello world",
+        multimodal_content=[{"type": "image"}],
+        file_paths="sample.pdf",
+        ids="doc-compat",
+        scheme_name="test-scheme",
+    )
+
+    assert calls == [
+        {
+            "input": "hello world",
+            "file_paths": "sample.pdf",
+            "split_by_character": None,
+            "split_by_character_only": False,
+            "ids": "doc-compat",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_document_complete_bootstraps_doc_status(
+    raganything_modules,
+    tmp_path,
+):
+    processor_module = raganything_modules.processor
+    DocStatus = raganything_modules.base.DocStatus
+
+    class FakeDocStatusStorage:
+        def __init__(self):
+            self.records = {}
+
+        async def get_by_id(self, key):
+            return self.records.get(key)
+
+        async def upsert(self, data):
+            for key, value in data.items():
+                self.records[key] = value
+
+        async def index_done_callback(self):
+            return None
+
+    class FakeLightRAG:
+        def __init__(self):
+            self.doc_status = FakeDocStatusStorage()
+
+        async def ainsert(self, **kwargs):
+            return None
+
+    class DummyProcessor(processor_module.ProcessorMixin):
+        pass
+
+    processor = DummyProcessor()
+    processor.lightrag = FakeLightRAG()
+    processor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+    processor.config = types.SimpleNamespace(
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+        content_format="default",
+    )
+
+    async def fake_ensure_lightrag_initialized():
+        return {"success": True}
+
+    async def fake_parse_document(file_path, output_dir, parse_method, display_stats, **kwargs):
+        return ([{"type": "text", "text": "hello from test", "page_idx": 0}], "doc-generated")
+
+    processor._ensure_lightrag_initialized = fake_ensure_lightrag_initialized
+    processor.parse_document = fake_parse_document
+
+    await processor.process_document_complete(
+        file_path=str(tmp_path / "sample.pdf"),
+        doc_id="doc-custom",
+        file_name="sample.pdf",
+    )
+
+    doc_status = processor.lightrag.doc_status.records["doc-custom"]
+    assert doc_status["file_path"] == "sample.pdf"
+    assert doc_status["status"] == DocStatus.PROCESSED
+    assert doc_status["multimodal_processed"] is True

--- a/tests/testdoc_status_creation.py
+++ b/tests/testdoc_status_creation.py
@@ -169,3 +169,89 @@ async def test_process_document_complete_bootstraps_doc_status(
     assert doc_status["file_path"] == "sample.pdf"
     assert doc_status["status"] == DocStatus.PROCESSED
     assert doc_status["multimodal_processed"] is True
+
+
+@pytest.mark.asyncio
+async def test_image_only_document_falls_back_when_multimodal_flag_is_unsupported(
+    raganything_modules,
+    tmp_path,
+):
+    processor_module = raganything_modules.processor
+    DocStatus = raganything_modules.base.DocStatus
+
+    class FakeDocStatusStorage:
+        def __init__(self):
+            self.records = {}
+
+        async def get_by_id(self, key):
+            return self.records.get(key)
+
+        async def upsert(self, data):
+            for key, value in data.items():
+                if "multimodal_processed" in value:
+                    raise ValueError("unknown field: multimodal_processed")
+                self.records[key] = value
+
+        async def index_done_callback(self):
+            return None
+
+    class FakeLightRAG:
+        def __init__(self):
+            self.doc_status = FakeDocStatusStorage()
+
+        async def ainsert(self, **kwargs):
+            return None
+
+    class DummyProcessor(processor_module.ProcessorMixin):
+        pass
+
+    processor = DummyProcessor()
+    processor.lightrag = FakeLightRAG()
+    processor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+    processor.config = types.SimpleNamespace(
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+        content_format="default",
+    )
+
+    async def fake_ensure_lightrag_initialized():
+        return {"success": True}
+
+    async def fake_parse_document(
+        file_path, output_dir, parse_method, display_stats, **kwargs
+    ):
+        return (
+            [
+                {
+                    "type": "image",
+                    "img_path": str(tmp_path / "figure.png"),
+                    "page_idx": 0,
+                }
+            ],
+            "doc-image",
+        )
+
+    async def fake_process_multimodal_content(multimodal_items, file_name, doc_id):
+        await processor._mark_multimodal_processing_complete(doc_id)
+
+    processor._ensure_lightrag_initialized = fake_ensure_lightrag_initialized
+    processor.parse_document = fake_parse_document
+    processor._process_multimodal_content = fake_process_multimodal_content
+
+    await processor.process_document_complete(
+        file_path=str(tmp_path / "figure.png"),
+        doc_id="doc-image",
+        file_name="figure.png",
+    )
+
+    doc_status = processor.lightrag.doc_status.records["doc-image"]
+    assert doc_status["file_path"] == "figure.png"
+    assert doc_status["status"] == DocStatus.PROCESSED
+    assert "multimodal_processed" not in doc_status


### PR DESCRIPTION
## Summary
- bootstrap doc_status records before document insertion so process_document_complete and insert_content_list always persist a deletable document entry
- make multimodal text insertion compatible with LightRAG versions that do not accept multimodal_content or scheme_name in ainsert()
- add a regression test covering both the compatibility fallback and the missing doc_status bug from #244
- merge the latest upstream main into this branch so the PR is current with recent repository changes

## Testing
- python3 -m pytest tests/testdoc_status_creation.py
- python3 -m pytest tests/testdoc_status_creation.py tests/test_raganything_example.py  # fails locally because lightrag is not installed in this environment

Closes #244