### PR TITLE
fix: forward system_prompt parameter in aquery_with_multimodal

### DIFF
--- a/raganything/query.py
+++ b/raganything/query.py
@@ -86,6 +86,7 @@ class QueryMixin:
                 "top_k",
                 "max_tokens",
                 "temperature",
+                "system_prompt",
                 # "only_need_context",
                 # "only_need_prompt",
             ]
@@ -249,7 +250,11 @@ class QueryMixin:
 
         # Generate cache key for multimodal query
         cache_key = self._generate_multimodal_cache_key(
-            query, multimodal_content, mode, **kwargs
+            query,
+            multimodal_content,
+            mode,
+            system_prompt=system_prompt,
+            **kwargs,
         )
 
         # Check cache if available and enabled

--- a/raganything/query.py
+++ b/raganything/query.py
@@ -196,6 +196,7 @@ class QueryMixin:
         query: str,
         multimodal_content: List[Dict[str, Any]] = None,
         mode: str = "mix",
+        system_prompt: str | None = None,
         **kwargs,
     ) -> str:
         """
@@ -207,6 +208,7 @@ class QueryMixin:
                 - type: Content type ("image", "table", "equation", etc.)
                 - Other fields depend on type (e.g., img_path, table_data, latex, etc.)
             mode: Query mode ("local", "global", "hybrid", "naive", "mix", "bypass")
+            system_prompt: Optional system prompt to include in the query
             **kwargs: Other query parameters, will be passed to QueryParam
 
         Returns:
@@ -243,7 +245,7 @@ class QueryMixin:
         # If no multimodal content, fallback to pure text query
         if not multimodal_content:
             self.logger.info("No multimodal content provided, executing text query")
-            return await self.aquery(query, mode=mode, **kwargs)
+            return await self.aquery(query, mode=mode, system_prompt=system_prompt, **kwargs)
 
         # Generate cache key for multimodal query
         cache_key = self._generate_multimodal_cache_key(
@@ -285,7 +287,7 @@ class QueryMixin:
         )
 
         # Execute enhanced query
-        result = await self.aquery(enhanced_query, mode=mode, **kwargs)
+        result = await self.aquery(enhanced_query, mode=mode, system_prompt=system_prompt, **kwargs)
 
         # Save to cache if available and enabled
         if (


### PR DESCRIPTION
## Summary

Fixes a bug where `system_prompt` was silently ignored when calling `aquery_with_multimodal`.

## Changes

- Added `system_prompt: str | None = None` parameter to `aquery_with_multimodal` method signature (before `**kwargs`)
- Forward `system_prompt` to the fallback `aquery()` call when no multimodal content is provided
- Forward `system_prompt` to the main `aquery()` call for the enhanced query
- Updated docstring to document the new parameter

## Why

Without this fix, callers passing `system_prompt` to `aquery_with_multimodal` would have it silently ignored, even though the inner `aquery()` method supports it.

Closes #257

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>