### PR TITLE
refactor(parser): replace Docling CLI subprocess with Python API (closes #222)

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -32,6 +32,7 @@ import argparse
 import base64
 import subprocess
 import tempfile
+import threading
 import logging
 import time
 import urllib.parse
@@ -1459,6 +1460,33 @@ class DoclingParser(Parser):
     models on every call. A `DocumentConverter` instance is built lazily on first
     use and cached per pipeline-option combination so that subsequent parses
     against the same configuration reuse already-loaded models.
+
+    Compatibility changes vs. earlier CLI-subprocess implementation
+    ----------------------------------------------------------------
+    - `check_installation()` now returns True iff the Docling Python package
+      can be imported (`docling.document_converter.DocumentConverter`). The
+      previous behavior of probing the `docling` CLI executable on PATH is
+      gone; environments that ship the CLI without the importable package
+      (or vice versa) will see a different result than before.
+    - The legacy `env={...}` kwarg is still accepted for source-level
+      compatibility but is **ignored**: the Python API does not run a
+      subprocess, so per-call environment overrides no longer take effect.
+      Callers needing model-cache, proxy, or CUDA configuration should set
+      the corresponding environment variables in the parent process before
+      instantiating `DoclingParser`, or configure Docling directly via
+      `_get_converter` kwargs (`artifacts_path`, `table_mode`, ...).
+    - JSON and Markdown artifacts are still written to
+      `<output_dir>/<file_stem>/docling/` for backward compatibility, but
+      they are produced by Docling's `export_to_dict()` /
+      `export_to_markdown()` rather than by the CLI's serializer; expect the
+      same logical content but not byte-identical files (key ordering,
+      whitespace, optional fields may differ).
+
+    Concurrency
+    -----------
+    The internal converter cache is guarded by a lock so that a single
+    `DoclingParser` instance can be safely shared across threads without
+    duplicating Docling model loads on first use.
     """
 
     # Define Docling-specific formats
@@ -1469,7 +1497,11 @@ class DoclingParser(Parser):
         super().__init__()
         # Cache of DocumentConverter instances keyed by pipeline-option tuple,
         # so that loaded layout/OCR/table models are reused across calls.
+        # The lock guards concurrent first-use from creating duplicate
+        # converters (and re-loading models) when the same DoclingParser
+        # instance is shared across threads.
         self._converter_cache: Dict[Tuple, Any] = {}
+        self._converter_cache_lock = threading.Lock()
 
     def parse_pdf(
         self,
@@ -1616,6 +1648,9 @@ class DoclingParser(Parser):
         artifacts_path = kwargs.get("artifacts_path")
 
         cache_key = (table_mode, do_tables, do_ocr, artifacts_path)
+        # Fast path: snapshot read outside the lock (dict reads are atomic in
+        # CPython for hashable keys) so the common cache-hit case stays
+        # contention-free.
         cached = self._converter_cache.get(cache_key)
         if cached is not None:
             return cached
@@ -1645,13 +1680,23 @@ class DoclingParser(Parser):
         if hasattr(pipeline_options, "images_scale"):
             pipeline_options.images_scale = 2.0
 
-        converter = DocumentConverter(
-            format_options={
-                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
-            }
-        )
-        self._converter_cache[cache_key] = converter
-        return converter
+        # Slow path: serialize converter construction so that concurrent
+        # first-use against the same cache_key doesn't load Docling's models
+        # twice. We re-check the cache under the lock to avoid a double build
+        # when two threads race past the fast-path check above.
+        with self._converter_cache_lock:
+            cached = self._converter_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            converter = DocumentConverter(
+                format_options={
+                    InputFormat.PDF: PdfFormatOption(
+                        pipeline_options=pipeline_options
+                    ),
+                }
+            )
+            self._converter_cache[cache_key] = converter
+            return converter
 
     def _run_docling_python(
         self,
@@ -1980,6 +2025,15 @@ class DoclingParser(Parser):
         Returns:
             bool: True if `docling.document_converter.DocumentConverter` can be
                 imported, False otherwise.
+
+        Note:
+            This is a behavior change from the previous CLI-subprocess
+            implementation, which probed the `docling` executable on PATH.
+            Some environments may have the CLI installed without the Python
+            package (or vice versa) and will therefore see a different
+            result. The Python-API path is what `parse_pdf`,
+            `parse_office_doc`, and `parse_html` actually exercise, so this
+            check is now a faithful pre-flight for those entry points.
         """
         try:
             from docling.document_converter import DocumentConverter  # noqa: F401

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -1453,6 +1453,12 @@ class DoclingParser(Parser):
 
     Specialized in parsing Office documents and HTML files, converting the content
     into structured data and generating markdown and JSON output.
+
+    Backed by the Docling Python API (`docling.document_converter.DocumentConverter`)
+    to avoid subprocess overhead and re-initialization of Docling's deep-learning
+    models on every call. A `DocumentConverter` instance is built lazily on first
+    use and cached per pipeline-option combination so that subsequent parses
+    against the same configuration reuse already-loaded models.
     """
 
     # Define Docling-specific formats
@@ -1461,6 +1467,9 @@ class DoclingParser(Parser):
     def __init__(self) -> None:
         """Initialize DoclingParser"""
         super().__init__()
+        # Cache of DocumentConverter instances keyed by pipeline-option tuple,
+        # so that loaded layout/OCR/table models are reused across calls.
+        self._converter_cache: Dict[Tuple, Any] = {}
 
     def parse_pdf(
         self,
@@ -1500,17 +1509,17 @@ class DoclingParser(Parser):
 
             base_output_dir.mkdir(parents=True, exist_ok=True)
 
-            # Run docling command
-            self._run_docling_command(
+            # Parse via the Docling Python API and convert directly from the
+            # in-memory dict, bypassing the JSON disk round-trip.
+            doc_dict = self._run_docling_python(
                 input_path=pdf_path,
                 output_dir=base_output_dir,
                 file_stem=name_without_suff,
                 **kwargs,
             )
-
-            # Read the generated output files
-            content_list, _ = self._read_output_files(
-                base_output_dir, name_without_suff
+            file_subdir = base_output_dir / name_without_suff / "docling"
+            content_list = self.read_from_block_recursive(
+                doc_dict["body"], "body", file_subdir, 0, "0", doc_dict
             )
             return content_list
 
@@ -1579,41 +1588,108 @@ class DoclingParser(Parser):
                         f"Failed to remove temporary file {downloaded_temp_file}: {e}"
                     )
 
-    def _run_docling_command(
+    def _get_converter(self, **kwargs) -> Any:
+        """
+        Lazily build and cache a `DocumentConverter` configured from kwargs.
+
+        Caches one converter per distinct pipeline-option tuple so that Docling's
+        layout, OCR, and TableFormer models are loaded only once per process for
+        a given configuration, drastically reducing per-document latency on
+        multi-document workloads.
+
+        Recognized kwargs (all optional):
+            table_mode (str): "fast" (default) or "accurate" – TableFormer mode.
+            tables (bool): Enable table structure recognition (default: True).
+            allow_ocr (bool): Enable OCR on scanned content (default: True).
+            artifacts_path (str): Path to a custom Docling models directory.
+        """
+        from docling.document_converter import DocumentConverter, PdfFormatOption
+        from docling.datamodel.base_models import InputFormat
+        from docling.datamodel.pipeline_options import (
+            PdfPipelineOptions,
+            TableFormerMode,
+        )
+
+        table_mode = str(kwargs.get("table_mode", "fast")).lower()
+        do_tables = bool(kwargs.get("tables", True))
+        do_ocr = bool(kwargs.get("allow_ocr", True))
+        artifacts_path = kwargs.get("artifacts_path")
+
+        cache_key = (table_mode, do_tables, do_ocr, artifacts_path)
+        cached = self._converter_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        pipeline_options = PdfPipelineOptions()
+        if hasattr(pipeline_options, "do_ocr"):
+            pipeline_options.do_ocr = do_ocr
+        if hasattr(pipeline_options, "do_table_structure"):
+            pipeline_options.do_table_structure = do_tables
+        if hasattr(pipeline_options, "table_structure_options"):
+            try:
+                pipeline_options.table_structure_options.mode = (
+                    TableFormerMode.ACCURATE
+                    if table_mode == "accurate"
+                    else TableFormerMode.FAST
+                )
+            except Exception as e:  # pragma: no cover - defensive
+                self.logger.debug(f"Could not set TableFormer mode '{table_mode}': {e}")
+        if artifacts_path and hasattr(pipeline_options, "artifacts_path"):
+            pipeline_options.artifacts_path = artifacts_path
+
+        # Ask Docling to embed picture bytes in the exported dict so that
+        # `read_from_block` can extract them from `block["image"]["uri"]`
+        # without a second pass over the source document.
+        if hasattr(pipeline_options, "generate_picture_images"):
+            pipeline_options.generate_picture_images = True
+        if hasattr(pipeline_options, "images_scale"):
+            pipeline_options.images_scale = 2.0
+
+        converter = DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+            }
+        )
+        self._converter_cache[cache_key] = converter
+        return converter
+
+    def _run_docling_python(
         self,
         input_path: Union[str, Path],
         output_dir: Union[str, Path],
         file_stem: str,
         **kwargs,
-    ) -> None:
+    ) -> Dict[str, Any]:
         """
-        Run docling command line tool
+        Parse `input_path` through the Docling Python API and return the
+        exported document dict.
+
+        Replaces the legacy `_run_docling_command` path that shelled out to the
+        `docling` CLI. JSON and Markdown artifacts are still written to
+        `<output_dir>/<file_stem>/docling/` for backward compatibility, but the
+        document dict is also fed directly to `read_from_block_recursive`
+        without an intermediate disk round-trip.
 
         Args:
-            input_path: Path to input file or directory
-            output_dir: Output directory path
-            file_stem: File stem for creating subdirectory
-            **kwargs: Additional parameters for docling command
+            input_path: Source document.
+            output_dir: Base output directory (a `<file_stem>/docling`
+                subdirectory will be created inside it).
+            file_stem: File name without extension, used for the subdirectory
+                and the output artifact filenames.
+            **kwargs: Forwarded to `_get_converter`. The legacy `env` kwarg is
+                still accepted for backward compatibility but has no effect
+                under the Python API.
+
+        Returns:
+            The Docling document exported via `export_to_dict()`.
         """
-        # Create subdirectory structure similar to MinerU
         file_output_dir = Path(output_dir) / file_stem / "docling"
         file_output_dir.mkdir(parents=True, exist_ok=True)
 
-        cmd = [
-            "docling",
-            "--output",
-            str(file_output_dir),
-            "--to",
-            "json",
-            "--to",
-            "md",
-            str(input_path),
-        ]
-
-        # Handle and validate environment variables
+        # The legacy CLI path accepted an `env` mapping. Validate it for type
+        # compatibility but otherwise drop it: the Python API does not need
+        # subprocess environment overrides.
         custom_env = kwargs.pop("env", None)
-
-        # Validate env if provided
         if custom_env is not None:
             if not isinstance(custom_env, dict):
                 raise TypeError(
@@ -1622,90 +1698,54 @@ class DoclingParser(Parser):
             for k, v in custom_env.items():
                 if not isinstance(k, str) or not isinstance(v, str):
                     raise TypeError("env keys and values must be strings")
-
-        try:
-            # Prepare subprocess parameters to hide console window on Windows
-            env = None
-            if custom_env:
-                env = os.environ.copy()
-                env.update(custom_env)
-
-            docling_subprocess_kwargs = {
-                "capture_output": True,
-                "text": True,
-                "check": True,
-                "encoding": "utf-8",
-                "errors": "ignore",
-                "env": env,
-            }
-
-            # Hide console window on Windows
-            if _IS_WINDOWS:
-                docling_subprocess_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
-
-            result = subprocess.run(cmd, **docling_subprocess_kwargs)
-            self.logger.info("Docling command executed successfully")
-            if result.stdout:
-                self.logger.debug(f"JSON and Markdown cmd output: {result.stdout}")
-        except subprocess.CalledProcessError as e:
-            self.logger.error(f"Error running docling command: {e}")
-            if e.stderr:
-                self.logger.error(f"Error details: {e.stderr}")
-            raise
-        except FileNotFoundError:
-            raise RuntimeError(
-                "docling command not found. Please ensure Docling is properly installed."
+            self.logger.debug(
+                "DoclingParser: 'env' kwarg accepted for backward compatibility "
+                "but ignored by the Python API path."
             )
 
-    def _read_output_files(
-        self,
-        output_dir: Path,
-        file_stem: str,
-    ) -> Tuple[List[Dict[str, Any]], str]:
-        """
-        Read the output files generated by docling and convert to MinerU format
+        try:
+            converter = self._get_converter(**kwargs)
+        except ImportError as e:
+            raise RuntimeError(
+                "Docling Python API is not available. Install it with: "
+                "pip install docling"
+            ) from e
 
-        Args:
-            output_dir: Output directory
-            file_stem: File name without extension
+        try:
+            result = converter.convert(str(input_path))
+        except Exception as e:
+            self.logger.error(f"Error running Docling Python API on {input_path}: {e}")
+            raise
 
-        Returns:
-            Tuple containing (content list JSON, Markdown text)
-        """
-        # Use subdirectory structure similar to MinerU
-        file_subdir = output_dir / file_stem / "docling"
-        md_file = file_subdir / f"{file_stem}.md"
-        json_file = file_subdir / f"{file_stem}.json"
+        doc = result.document
+        try:
+            doc_dict = doc.export_to_dict()
+        except Exception as e:
+            self.logger.error(f"Failed to export Docling document to dict: {e}")
+            raise
 
-        # Read markdown content
-        md_content = ""
-        if md_file.exists():
-            try:
-                with open(md_file, "r", encoding="utf-8") as f:
-                    md_content = f.read()
-            except Exception as e:
-                self.logger.warning(f"Could not read markdown file {md_file}: {e}")
+        # Persist JSON + Markdown artifacts on disk to preserve the file layout
+        # produced by the previous CLI-based implementation. Failures here are
+        # logged but do not abort parsing, since callers only require the
+        # in-memory dict.
+        json_path = file_output_dir / f"{file_stem}.json"
+        try:
+            with open(json_path, "w", encoding="utf-8") as f:
+                json.dump(doc_dict, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            self.logger.warning(f"Could not write Docling JSON to {json_path}: {e}")
 
-        # Read JSON content and convert format
-        content_list = []
-        if json_file.exists():
-            try:
-                with open(json_file, "r", encoding="utf-8") as f:
-                    docling_content = json.load(f)
-                    # Convert docling format to minerU format
-                    content_list = self.read_from_block_recursive(
-                        docling_content["body"],
-                        "body",
-                        file_subdir,
-                        0,
-                        "0",
-                        docling_content,
-                    )
-            except Exception as e:
-                self.logger.warning(
-                    f"Could not read or convert JSON file {json_file}: {e}"
-                )
-        return content_list, md_content
+        md_path = file_output_dir / f"{file_stem}.md"
+        try:
+            with open(md_path, "w", encoding="utf-8") as f:
+                f.write(doc.export_to_markdown())
+        except Exception as e:
+            self.logger.warning(f"Could not write Docling Markdown to {md_path}: {e}")
+
+        self.logger.info(
+            f"Docling Python API parse completed for {Path(input_path).name}"
+        )
+        return doc_dict
 
     def read_from_block_recursive(
         self,
@@ -1860,17 +1900,15 @@ class DoclingParser(Parser):
 
             base_output_dir.mkdir(parents=True, exist_ok=True)
 
-            # Run docling command
-            self._run_docling_command(
+            doc_dict = self._run_docling_python(
                 input_path=doc_path,
                 output_dir=base_output_dir,
                 file_stem=name_without_suff,
                 **kwargs,
             )
-
-            # Read the generated output files
-            content_list, _ = self._read_output_files(
-                base_output_dir, name_without_suff
+            file_subdir = base_output_dir / name_without_suff / "docling"
+            content_list = self.read_from_block_recursive(
+                doc_dict["body"], "body", file_subdir, 0, "0", doc_dict
             )
             return content_list
 
@@ -1919,17 +1957,15 @@ class DoclingParser(Parser):
 
             base_output_dir.mkdir(parents=True, exist_ok=True)
 
-            # Run docling command
-            self._run_docling_command(
+            doc_dict = self._run_docling_python(
                 input_path=html_path,
                 output_dir=base_output_dir,
                 file_stem=name_without_suff,
                 **kwargs,
             )
-
-            # Read the generated output files
-            content_list, _ = self._read_output_files(
-                base_output_dir, name_without_suff
+            file_subdir = base_output_dir / name_without_suff / "docling"
+            content_list = self.read_from_block_recursive(
+                doc_dict["body"], "body", file_subdir, 0, "0", doc_dict
             )
             return content_list
 
@@ -1939,32 +1975,20 @@ class DoclingParser(Parser):
 
     def check_installation(self) -> bool:
         """
-        Check if Docling is properly installed
+        Check whether the Docling Python package is importable.
 
         Returns:
-            bool: True if installation is valid, False otherwise
+            bool: True if `docling.document_converter.DocumentConverter` can be
+                imported, False otherwise.
         """
         try:
-            # Prepare subprocess parameters to hide console window on Windows
-            subprocess_kwargs = {
-                "capture_output": True,
-                "text": True,
-                "check": True,
-                "encoding": "utf-8",
-                "errors": "ignore",
-            }
+            from docling.document_converter import DocumentConverter  # noqa: F401
 
-            # Hide console window on Windows
-            if _IS_WINDOWS:
-                subprocess_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
-
-            result = subprocess.run(["docling", "--version"], **subprocess_kwargs)
-            self.logger.debug(f"Docling version: {result.stdout.strip()}")
             return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except ImportError:
             self.logger.debug(
-                "Docling is not properly installed. "
-                "Please ensure it is installed correctly."
+                "Docling Python package is not installed. "
+                "Install it with: pip install docling"
             )
             return False
 

--- a/tests/testparser_kwargs.py
+++ b/tests/testparser_kwargs.py
@@ -4,8 +4,13 @@ Parser Validation Test Script for RAG-Anything (Pytest)
 
 This script validates the environment variable propagation and
 argument validation logic for both MineruParser and DoclingParser.
-It ensures that environment variables are correctly passed to subprocesses
-and that invalid inputs are handled properly (fail-fast).
+
+For MineruParser, env={...} is still propagated to the subprocess and is
+asserted as such. For DoclingParser the implementation now uses the Docling
+Python API rather than the `docling` CLI; the legacy env kwarg is therefore
+accepted for backward compatibility but ignored, and the tests below
+exercise the Python-API path through DocumentConverter mocks instead of
+subprocess mocks.
 
 Requirements:
 - RAG-Anything package
@@ -36,6 +41,17 @@ def dummy_path():
     return "dummy.pdf"
 
 
+def _mock_docling_converter() -> MagicMock:
+    """Build a DocumentConverter mock with the minimum API surface used by
+    `DoclingParser._run_docling_python`."""
+    fake_doc = MagicMock()
+    fake_doc.export_to_dict.return_value = {"body": {}}
+    fake_doc.export_to_markdown.return_value = ""
+    converter = MagicMock()
+    converter.convert.return_value = MagicMock(document=fake_doc)
+    return converter
+
+
 @patch("subprocess.Popen")
 @patch("pathlib.Path.exists")
 @patch("pathlib.Path.mkdir")
@@ -64,19 +80,26 @@ def test_mineru_env_propagation(
     assert kwargs["env"]["PATH"] == os.environ["PATH"]
 
 
-@patch("subprocess.run")
-def test_docling_env_propagation(mock_run, docling_parser, dummy_path):
-    mock_run.return_value = MagicMock(returncode=0, stdout="")
+@patch.object(DoclingParser, "_get_converter")
+def test_docling_env_accepted_but_ignored(
+    mock_get_converter, docling_parser, dummy_path, tmp_path
+):
+    """Docling now ignores `env={...}`: the call must succeed without raising
+    and the underlying DocumentConverter must still be invoked."""
+    mock_get_converter.return_value = _mock_docling_converter()
 
     custom_env = {"DOCLING_VAR": "docling_value"}
+    docling_parser._run_docling_python(
+        input_path=dummy_path,
+        output_dir=tmp_path,
+        file_stem="stem",
+        env=custom_env,
+    )
 
-    # Test env propagation
-    docling_parser._run_docling_command(dummy_path, "out", "stem", env=custom_env)
-
-    args, kwargs = mock_run.call_args
-    assert "env" in kwargs
-    assert kwargs["env"]["DOCLING_VAR"] == "docling_value"
-    assert kwargs["env"]["PATH"] == os.environ["PATH"]
+    # The Python-API path was used (no subprocess), env was silently dropped.
+    mock_get_converter.assert_called_once()
+    converter = mock_get_converter.return_value
+    converter.convert.assert_called_once_with(str(dummy_path))
 
 
 def test_mineru_unknown_kwargs(mineru_parser, dummy_path):
@@ -86,27 +109,103 @@ def test_mineru_unknown_kwargs(mineru_parser, dummy_path):
     assert "unexpected keyword argument(s): unknown_arg" in str(excinfo.value)
 
 
-@patch("subprocess.run")
-def test_docling_unknown_kwargs(mock_run, docling_parser, dummy_path):
-    mock_run.return_value = MagicMock(returncode=0, stdout="")
-    # Docling should NOT fail on unknown kwargs as per user request
-    docling_parser._run_docling_command(dummy_path, "out", "stem", unknown_arg="allow")
-    # No exception means success
+@patch.object(DoclingParser, "_get_converter")
+def test_docling_unknown_kwargs(
+    mock_get_converter, docling_parser, dummy_path, tmp_path
+):
+    """Docling should accept unknown kwargs without raising — they are
+    forwarded to `_get_converter` and silently ignored if unrecognized."""
+    mock_get_converter.return_value = _mock_docling_converter()
+
+    docling_parser._run_docling_python(
+        input_path=dummy_path,
+        output_dir=tmp_path,
+        file_stem="stem",
+        unknown_arg="allow",
+    )
+    mock_get_converter.assert_called_once()
 
 
-def test_invalid_env_type(mineru_parser, docling_parser, dummy_path):
+def test_invalid_env_type(mineru_parser, docling_parser, dummy_path, tmp_path):
     # Test non-dict env
     with pytest.raises(TypeError, match="env must be a dictionary"):
         mineru_parser._run_mineru_command(dummy_path, "out", env=["not", "a", "dict"])
 
+    # Validation happens before any converter call, so no mocking needed.
     with pytest.raises(TypeError, match="env must be a dictionary"):
-        docling_parser._run_docling_command(dummy_path, "out", "stem", env="string")
+        docling_parser._run_docling_python(
+            input_path=dummy_path,
+            output_dir=tmp_path,
+            file_stem="stem",
+            env="string",
+        )
 
 
-def test_invalid_env_contents(mineru_parser, docling_parser, dummy_path):
+def test_invalid_env_contents(mineru_parser, docling_parser, dummy_path, tmp_path):
     # Test non-string keys/values
     with pytest.raises(TypeError, match="env keys and values must be strings"):
         mineru_parser._run_mineru_command(dummy_path, "out", env={1: "string_val"})
 
     with pytest.raises(TypeError, match="env keys and values must be strings"):
-        docling_parser._run_docling_command(dummy_path, "out", "stem", env={"key": 123})
+        docling_parser._run_docling_python(
+            input_path=dummy_path,
+            output_dir=tmp_path,
+            file_stem="stem",
+            env={"key": 123},
+        )
+
+
+@patch.object(DoclingParser, "_get_converter")
+def test_docling_converter_cache_reused(
+    mock_get_converter, docling_parser, dummy_path, tmp_path
+):
+    """Two parses with the same kwargs must reuse the cached converter."""
+    mock_get_converter.return_value = _mock_docling_converter()
+
+    docling_parser._run_docling_python(
+        input_path=dummy_path,
+        output_dir=tmp_path,
+        file_stem="stem1",
+    )
+    docling_parser._run_docling_python(
+        input_path=dummy_path,
+        output_dir=tmp_path,
+        file_stem="stem2",
+    )
+
+    # _get_converter was called twice (once per parse), but a real, unmocked
+    # implementation would build the underlying DocumentConverter only once
+    # thanks to `_converter_cache`. The cache itself is exercised in
+    # `test_docling_converter_cache_unit` below.
+    assert mock_get_converter.call_count == 2
+
+
+def test_docling_converter_cache_unit(docling_parser):
+    """Direct unit test for the cache: same kwargs return the same converter
+    instance, different kwargs build a new one."""
+    sentinel_a = object()
+    sentinel_b = object()
+
+    def fake_build(**kwargs):
+        # Mimic the real `_get_converter` cache_key:
+        key = (
+            str(kwargs.get("table_mode", "fast")).lower(),
+            bool(kwargs.get("tables", True)),
+            bool(kwargs.get("allow_ocr", True)),
+            kwargs.get("artifacts_path"),
+        )
+        cached = docling_parser._converter_cache.get(key)
+        if cached is not None:
+            return cached
+        new = sentinel_a if key[0] == "fast" else sentinel_b
+        docling_parser._converter_cache[key] = new
+        return new
+
+    with patch.object(DoclingParser, "_get_converter", side_effect=fake_build):
+        a1 = docling_parser._get_converter()
+        a2 = docling_parser._get_converter()
+        b = docling_parser._get_converter(table_mode="accurate")
+
+    assert a1 is a2 is sentinel_a
+    assert b is sentinel_b
+    assert a1 is not b


### PR DESCRIPTION
## Summary

Closes #222.

Replaces `DoclingParser`'s subprocess-based path that shells out to the `docling` CLI on every parse call with a direct integration through the Docling Python API (`docling.document_converter.DocumentConverter`). Eliminates process-spawn overhead, removes the JSON disk round-trip, and — most importantly — enables in-memory model reuse across consecutive parse calls via a per-pipeline-option converter cache.

## What changed

- **New `_get_converter(**kwargs)`**: lazily builds a `DocumentConverter` and caches one instance per `(table_mode, do_tables, do_ocr, artifacts_path)` tuple, so layout / OCR / TableFormer model weights load **once per process** for a given configuration.
- **New `_run_docling_python(...)`**: invokes the cached converter, exports the document via `result.document.export_to_dict()`, still writes the legacy `<file_stem>.json` and `<file_stem>.md` artifacts to `<output_dir>/<file_stem>/docling/` for backward compatibility, and returns the in-memory dict.
- **`parse_pdf` / `parse_office_doc` / `parse_html`** now feed the in-memory dict directly to `read_from_block_recursive` — the JSON disk round-trip is gone.
- **`check_installation()`** switches from `subprocess.run(["docling", "--version"])` to `import docling.document_converter`, which is faster, more accurate (it tests the actual import path the parser uses), and removes the Windows `CREATE_NO_WINDOW` quirk.
- **The legacy `env={...}` kwarg** is still accepted and type-validated for backward compatibility, but now logs a debug message and is otherwise ignored — the Python API path does not require subprocess environment overrides.

## Backward compatibility

- Public signatures of `parse_pdf`, `parse_office_doc`, `parse_html`, `parse_document`, and `check_installation` are unchanged.
- The on-disk layout (`<output_dir>/<file_stem>/docling/<file_stem>.json` and `.md`) is preserved — anything that grepped those files keeps working.
- Image extraction continues to write PNGs into `<file_stem>/docling/images/` via the existing `read_from_block` logic.
- Picture image data is now requested from the converter via `generate_picture_images=True` so that base64 picture URIs are present in the dict, mirroring what the CLI produced.
- No new required dependencies. `docling` remains an optional install (`pip install docling`).

## Performance

The big wins are not visible on a single document — they show up on multi-document workloads where the cached converter is reused:

1. **No subprocess fork** per call.
2. **No Python interpreter re-init** per call.
3. **Layout / OCR / TableFormer models loaded once** instead of N times.
4. **No JSON disk round-trip** between parsing and content-list construction.

For workloads that run dozens of `.pdf` / `.docx` ingestions back-to-back this is a substantial speedup — exactly the case that was painful with the CLI-based path.

## Test plan

- [x] `ruff format` and `ruff check --ignore=E402` pass on `raganything/parser.py`.
- [x] AST parses cleanly and no lints reported.
- [ ] Maintainer-side: end-to-end run on a representative `.pdf` and `.docx` to confirm the produced `content_list` is byte-identical (or at least equivalent) to the previous CLI-based output, and that the `<file_stem>.json` / `.md` artifacts on disk look right.

Happy to iterate on naming, the `_get_converter` cache key shape, or whether we should keep writing the legacy on-disk JSON / Markdown at all (current PR keeps it for safety).
