### PR TITLE
feat(omml): add OMML equation extraction utility for DOCX documents (closes #259)

### DIFF
--- a/raganything/omml_extractor.py
+++ b/raganything/omml_extractor.py
@@ -1,0 +1,729 @@
+"""
+OMML (Office Math Markup Language) equation extraction for DOCX documents.
+
+Word stores equations as ``<m:oMath>`` elements inside ``word/document.xml``.
+When a DOCX is converted to PDF (e.g. via LibreOffice for the MinerU parser
+or via Docling's native pipeline), inline math is typically rasterized to an
+image or replaced with a placeholder, so the structured math content is lost
+to the downstream RAG pipeline.
+
+This module provides a zero-dependency, pure-stdlib utility to:
+
+1. Open a DOCX as a ZIP archive,
+2. Locate every ``<m:oMath>`` / ``<m:oMathPara>`` element in document order,
+3. Convert each one to a LaTeX string using a recursive transformer that
+   handles the most common OMML constructs (runs, fractions, scripts,
+   radicals, n-ary operators, functions, delimiters, matrices, accents,
+   and grouping characters), and
+4. Optionally merge the extracted equations into an already-parsed
+   ``content_list`` (the MinerU-compatible list of content blocks produced
+   by :class:`raganything.parser.MineruParser` / :class:`DoclingParser`)
+   as ``{"type": "equation", "text": "<latex>", "text_format": "latex", ...}``
+   blocks so that downstream multimodal processors can index them.
+
+The LaTeX produced by :func:`omml_to_latex` is intended to be searchable and
+human-readable rather than typographically perfect; for unhandled constructs
+the converter falls back to the concatenated text content of the element
+rather than failing. This is deliberate: the priority for RAG is recall, not
+pixel-accurate rendering.
+
+Example
+-------
+>>> from raganything.omml_extractor import extract_omml_equations
+>>> equations = extract_omml_equations("paper.docx")  # doctest: +SKIP
+>>> for eq in equations:                              # doctest: +SKIP
+...     print(eq["index"], eq["text"])
+0 \\frac{a}{b}
+1 \\sum_{i=1}^{n} x_{i}^{2}
+"""
+
+from __future__ import annotations
+
+import logging
+import zipfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from xml.etree import ElementTree as ET
+
+logger = logging.getLogger(__name__)
+
+# --- XML namespaces used in WordprocessingML / OMML ----------------------
+# These are the namespace URIs declared by every Word document part. We use
+# them to construct fully qualified tag names so that lookups are robust to
+# arbitrary namespace prefix choices in the source XML.
+NS = {
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
+
+_M = "{" + NS["m"] + "}"
+_W = "{" + NS["w"] + "}"
+
+# OMML "n-ary" operator characters and their LaTeX equivalents. Word stores
+# the operator as a Unicode codepoint inside m:naryPr/m:chr; if the chr
+# attribute is absent it defaults to the integral sign (\u222b).
+_NARY_OPERATORS: Dict[str, str] = {
+    "\u2211": r"\sum",  # SUMMATION
+    "\u220f": r"\prod",  # PRODUCT
+    "\u2210": r"\coprod",  # COPRODUCT
+    "\u222b": r"\int",  # INTEGRAL
+    "\u222c": r"\iint",  # DOUBLE INTEGRAL
+    "\u222d": r"\iiint",  # TRIPLE INTEGRAL
+    "\u222e": r"\oint",  # CONTOUR INTEGRAL
+    "\u222f": r"\oiint",  # SURFACE INTEGRAL
+    "\u22c3": r"\bigcup",  # N-ARY UNION
+    "\u22c2": r"\bigcap",  # N-ARY INTERSECTION
+    "\u2a00": r"\bigodot",
+    "\u2a01": r"\bigoplus",
+    "\u2a02": r"\bigotimes",
+}
+
+# A small mapping of Unicode math symbols Word likes to use in m:t runs.
+# The set is intentionally minimal; anything not in the table is passed
+# through unchanged so that ``\alpha`` and ``α`` both remain searchable.
+_SYMBOL_TO_LATEX: Dict[str, str] = {
+    "\u00b1": r"\pm",
+    "\u00d7": r"\times",
+    "\u00f7": r"\div",
+    "\u2202": r"\partial",
+    "\u2207": r"\nabla",
+    "\u221a": r"\sqrt{}",  # bare radical sign (rare; m:rad handles real ones)
+    "\u221e": r"\infty",
+    "\u2248": r"\approx",
+    "\u2260": r"\neq",
+    "\u2264": r"\leq",
+    "\u2265": r"\geq",
+    "\u2192": r"\to",
+    "\u21d2": r"\Rightarrow",
+    "\u21d4": r"\Leftrightarrow",
+    "\u2208": r"\in",
+    "\u2209": r"\notin",
+    "\u2282": r"\subset",
+    "\u2286": r"\subseteq",
+    "\u22c5": r"\cdot",
+    "\u2026": r"\dots",
+}
+
+
+# --- Public API ----------------------------------------------------------
+
+
+def extract_omml_equations(
+    docx_path: Union[str, Path],
+) -> List[Dict[str, Any]]:
+    """Extract every OMML equation from a DOCX file in document order.
+
+    Parameters
+    ----------
+    docx_path:
+        Path to a ``.docx`` file. The file is opened read-only as a ZIP
+        archive; the path itself is not modified.
+
+    Returns
+    -------
+    list of dict
+        One dict per equation, in document order, with the following keys:
+
+        - ``index`` (int): zero-based position in the equation sequence.
+        - ``text`` (str): LaTeX representation of the equation.
+        - ``text_format`` (str): always ``"latex"``.
+        - ``raw_omml`` (str): the original ``<m:oMath>`` XML, useful for
+          callers that want to plug in their own converter.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``docx_path`` does not exist.
+    ValueError
+        If the file is not a valid DOCX (no ``word/document.xml``) or its
+        XML cannot be parsed.
+
+    Notes
+    -----
+    Both top-level ``<m:oMath>`` elements and the ``<m:oMath>`` children of
+    ``<m:oMathPara>`` (display equations) are returned. Nested ``<m:oMath>``
+    elements inside another ``<m:oMath>`` (which Word does not actually
+    produce) are skipped to avoid duplicate extraction.
+    """
+    path = Path(docx_path)
+    if not path.exists():
+        raise FileNotFoundError(f"DOCX file does not exist: {path}")
+
+    try:
+        with zipfile.ZipFile(path, "r") as archive:
+            try:
+                xml_bytes = archive.read("word/document.xml")
+            except KeyError as e:
+                raise ValueError(
+                    f"{path} does not contain word/document.xml; "
+                    "is it a valid DOCX file?"
+                ) from e
+    except zipfile.BadZipFile as e:
+        raise ValueError(f"{path} is not a valid ZIP/DOCX archive") from e
+
+    try:
+        root = ET.fromstring(xml_bytes)
+    except ET.ParseError as e:
+        raise ValueError(f"Could not parse word/document.xml in {path}: {e}") from e
+
+    results: List[Dict[str, Any]] = []
+    # iter() walks the entire tree in document order, which is exactly what
+    # we want: the resulting list is ordered the same way Word renders the
+    # equations on screen.
+    seen: set = set()
+    for elem in root.iter(_M + "oMath"):
+        elem_id = id(elem)
+        if elem_id in seen:
+            continue
+        # Skip nested oMath inside another oMath (defensive; Word does not
+        # nest oMath, but custom XML manipulation could).
+        parent_is_omath = False
+        for ancestor in root.iter(_M + "oMath"):
+            if ancestor is elem:
+                continue
+            for child in ancestor.iter(_M + "oMath"):
+                if child is elem:
+                    parent_is_omath = True
+                    break
+            if parent_is_omath:
+                break
+        if parent_is_omath:
+            continue
+
+        seen.add(elem_id)
+        try:
+            latex = omml_to_latex(elem).strip()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to convert OMML equation #%d to LaTeX: %s. "
+                "Falling back to text content.",
+                len(results),
+                e,
+            )
+            latex = "".join(elem.itertext()).strip()
+
+        results.append(
+            {
+                "index": len(results),
+                "text": latex,
+                "text_format": "latex",
+                "raw_omml": ET.tostring(elem, encoding="unicode"),
+            }
+        )
+
+    logger.debug("Extracted %d OMML equations from %s", len(results), path)
+    return results
+
+
+def enrich_content_list_with_docx_equations(
+    content_list: List[Dict[str, Any]],
+    docx_path: Union[str, Path],
+    *,
+    page_idx_key: str = "page_idx",
+    deduplicate_existing_equations: bool = True,
+) -> List[Dict[str, Any]]:
+    """Merge OMML equations extracted from ``docx_path`` into a parsed content list.
+
+    The DOCX → PDF conversion that both the MinerU and Docling parsers rely on
+    typically loses inline math. This helper extracts the original OMML
+    equations directly from the DOCX file and inserts equation-typed blocks
+    into ``content_list`` so they participate in downstream RAG indexing.
+
+    Parameters
+    ----------
+    content_list:
+        A list of MinerU-compatible content blocks as produced by
+        :class:`raganything.parser.MineruParser` or
+        :class:`raganything.parser.DoclingParser`. The list is *not* mutated;
+        a new list is returned.
+    docx_path:
+        Path to the original ``.docx`` source.
+    page_idx_key:
+        Name of the page-index field on each block. Defaults to ``"page_idx"``,
+        which matches both built-in parsers.
+    deduplicate_existing_equations:
+        When ``True`` (the default), equations already present in
+        ``content_list`` (typically as ``"type": "equation"`` placeholders
+        inserted by the parser) whose ``text`` matches an extracted OMML
+        equation are kept and skipped. When ``False``, every extracted
+        equation is appended even if a duplicate already exists.
+
+    Returns
+    -------
+    list of dict
+        A new content list with the extracted equations appended at the end
+        (with ``page_idx`` copied from the last existing block, or 0 if the
+        list is empty). Callers that need precise positional placement can
+        re-sort or splice the returned list using ``raw_omml`` as a key.
+
+    Notes
+    -----
+    Positioning equations within a PDF-derived content list is intrinsically
+    lossy: the original DOCX paragraphs do not carry page numbers. For now
+    the helper appends equations in document order at the tail of the list
+    with a synthetic page index. This is sufficient for retrieval (the
+    equations become indexable LaTeX text) but not for visual reconstruction.
+    Callers needing positional accuracy can post-process the list using the
+    ``raw_omml`` field returned by :func:`extract_omml_equations`.
+    """
+    extracted = extract_omml_equations(docx_path)
+    if not extracted:
+        return list(content_list)
+
+    existing_equations: set = set()
+    if deduplicate_existing_equations:
+        for block in content_list:
+            if block.get("type") == "equation":
+                text = (block.get("text") or "").strip()
+                if text:
+                    existing_equations.add(text)
+
+    last_page_idx = 0
+    if content_list:
+        try:
+            last_page_idx = int(content_list[-1].get(page_idx_key, 0) or 0)
+        except (TypeError, ValueError):
+            last_page_idx = 0
+
+    enriched: List[Dict[str, Any]] = list(content_list)
+    appended = 0
+    for eq in extracted:
+        latex = eq["text"].strip()
+        if not latex:
+            continue
+        if deduplicate_existing_equations and latex in existing_equations:
+            continue
+        enriched.append(
+            {
+                "type": "equation",
+                "img_path": "",
+                "text": latex,
+                "text_format": "latex",
+                page_idx_key: last_page_idx,
+                "_source": "omml_extractor",
+            }
+        )
+        appended += 1
+
+    logger.info(
+        "Enriched content list with %d/%d OMML equations from %s",
+        appended,
+        len(extracted),
+        docx_path,
+    )
+    return enriched
+
+
+# --- OMML → LaTeX recursive transformer ----------------------------------
+
+
+def omml_to_latex(element: ET.Element) -> str:
+    """Convert a single ``<m:oMath>`` element (or any of its children) to LaTeX.
+
+    The function is a small recursive descent transformer. For each known OMML
+    construct it emits the canonical LaTeX form; unknown elements fall through
+    to their concatenated text content so that callers always get *some*
+    searchable representation.
+
+    Parameters
+    ----------
+    element:
+        An :class:`xml.etree.ElementTree.Element` from the OMML namespace.
+        Typically the root ``<m:oMath>`` returned by
+        :func:`extract_omml_equations`, but any descendant works too.
+
+    Returns
+    -------
+    str
+        A LaTeX string. The result is *not* wrapped in math delimiters
+        (``$ ... $`` or ``\\[ ... \\]``); the caller chooses the context.
+    """
+    return _convert(element)
+
+
+def _convert(element: Optional[ET.Element]) -> str:
+    if element is None:
+        return ""
+
+    tag = _local_name(element.tag)
+    handler = _HANDLERS.get(tag)
+    if handler is not None:
+        return handler(element)
+
+    # Generic fallback: concatenate child conversions, then own text.
+    parts = [_text_for(element)]
+    for child in element:
+        parts.append(_convert(child))
+        if child.tail:
+            parts.append(_escape_text(child.tail))
+    return "".join(p for p in parts if p)
+
+
+def _local_name(qname: str) -> str:
+    if "}" in qname:
+        return qname.split("}", 1)[1]
+    return qname
+
+
+def _text_for(element: ET.Element) -> str:
+    if element.text is None:
+        return ""
+    return _escape_text(element.text)
+
+
+def _escape_text(text: str) -> str:
+    """Map common Word math symbols to LaTeX commands; pass through the rest."""
+    if not text:
+        return ""
+    out = []
+    for ch in text:
+        replacement = _SYMBOL_TO_LATEX.get(ch)
+        out.append(replacement if replacement is not None else ch)
+    return "".join(out)
+
+
+def _children_by_tag(element: ET.Element, tag: str) -> List[ET.Element]:
+    full = _M + tag
+    return [c for c in element if c.tag == full]
+
+
+def _first_child(element: ET.Element, tag: str) -> Optional[ET.Element]:
+    children = _children_by_tag(element, tag)
+    return children[0] if children else None
+
+
+def _convert_children(element: ET.Element) -> str:
+    parts = []
+    for child in element:
+        parts.append(_convert(child))
+        if child.tail:
+            parts.append(_escape_text(child.tail))
+    return "".join(parts)
+
+
+# --- Per-element handlers -------------------------------------------------
+#
+# Each handler is responsible for producing the LaTeX equivalent of one OMML
+# construct and for recursing into its semantically meaningful children.
+
+
+def _h_omath(element: ET.Element) -> str:
+    return _convert_children(element)
+
+
+def _h_omath_para(element: ET.Element) -> str:
+    # Display math container; we just join inner equations with a space.
+    return " ".join(_convert(c) for c in _children_by_tag(element, "oMath"))
+
+
+def _h_run(element: ET.Element) -> str:
+    # m:r is a math "run" containing m:t text nodes.
+    parts = []
+    for t in _children_by_tag(element, "t"):
+        parts.append(_text_for(t))
+    return "".join(parts)
+
+
+def _h_text(element: ET.Element) -> str:
+    return _text_for(element)
+
+
+def _h_fraction(element: ET.Element) -> str:
+    num = _first_child(element, "num")
+    den = _first_child(element, "den")
+    return r"\frac{" + _convert_children(num) + "}{" + _convert_children(den) + "}"
+
+
+def _h_superscript(element: ET.Element) -> str:
+    base = _first_child(element, "e")
+    sup = _first_child(element, "sup")
+    return "{" + _convert_children(base) + "}^{" + _convert_children(sup) + "}"
+
+
+def _h_subscript(element: ET.Element) -> str:
+    base = _first_child(element, "e")
+    sub = _first_child(element, "sub")
+    return "{" + _convert_children(base) + "}_{" + _convert_children(sub) + "}"
+
+
+def _h_sub_superscript(element: ET.Element) -> str:
+    base = _first_child(element, "e")
+    sub = _first_child(element, "sub")
+    sup = _first_child(element, "sup")
+    return (
+        "{"
+        + _convert_children(base)
+        + "}_{"
+        + _convert_children(sub)
+        + "}^{"
+        + _convert_children(sup)
+        + "}"
+    )
+
+
+def _h_pre_sub_superscript(element: ET.Element) -> str:
+    # m:sPre — a pre-script: prescripts to the left of the base.
+    base = _first_child(element, "e")
+    sub = _first_child(element, "sub")
+    sup = _first_child(element, "sup")
+    return (
+        "{}_{"
+        + _convert_children(sub)
+        + "}^{"
+        + _convert_children(sup)
+        + "}{"
+        + _convert_children(base)
+        + "}"
+    )
+
+
+def _h_radical(element: ET.Element) -> str:
+    deg = _first_child(element, "deg")
+    base = _first_child(element, "e")
+    base_latex = _convert_children(base)
+    if deg is not None and list(deg):
+        return r"\sqrt[" + _convert_children(deg) + "]{" + base_latex + "}"
+    return r"\sqrt{" + base_latex + "}"
+
+
+def _h_nary(element: ET.Element) -> str:
+    # m:nary — n-ary operator (sum, integral, etc.). The operator character
+    # lives in m:naryPr/m:chr/@m:val; defaults to the integral sign per ECMA-376.
+    pr = _first_child(element, "naryPr")
+    op = r"\int"
+    if pr is not None:
+        chr_elem = _first_child(pr, "chr")
+        if chr_elem is not None:
+            val = chr_elem.get(_M + "val")
+            if val:
+                op = _NARY_OPERATORS.get(val, op)
+    sub = _first_child(element, "sub")
+    sup = _first_child(element, "sup")
+    base = _first_child(element, "e")
+    out = op
+    if sub is not None and list(sub):
+        out += "_{" + _convert_children(sub) + "}"
+    if sup is not None and list(sup):
+        out += "^{" + _convert_children(sup) + "}"
+    if base is not None:
+        body = _convert_children(base)
+        if body:
+            out += " " + body
+    return out
+
+
+def _h_function(element: ET.Element) -> str:
+    # m:func — applied function such as sin, cos, log, ln. fName provides
+    # the function name (typically a m:r run); m:e provides the argument.
+    fname = _first_child(element, "fName")
+    arg = _first_child(element, "e")
+    name = _convert_children(fname).strip() if fname is not None else ""
+    arg_latex = _convert_children(arg) if arg is not None else ""
+    # If the name matches a known LaTeX command, keep it as a control sequence.
+    known = {
+        "sin",
+        "cos",
+        "tan",
+        "csc",
+        "sec",
+        "cot",
+        "sinh",
+        "cosh",
+        "tanh",
+        "arcsin",
+        "arccos",
+        "arctan",
+        "log",
+        "ln",
+        "exp",
+        "lim",
+        "max",
+        "min",
+        "sup",
+        "inf",
+        "det",
+        "dim",
+        "ker",
+    }
+    if name in known:
+        return f"\\{name}{{{arg_latex}}}"
+    return f"{name}({arg_latex})"
+
+
+def _h_delimiter(element: ET.Element) -> str:
+    # m:d — delimited expression. m:dPr/@begChr and @endChr give the actual
+    # opening/closing characters; defaults are parentheses.
+    pr = _first_child(element, "dPr")
+    beg, end, sep = "(", ")", ","
+    if pr is not None:
+        beg_elem = _first_child(pr, "begChr")
+        end_elem = _first_child(pr, "endChr")
+        sep_elem = _first_child(pr, "sepChr")
+        if beg_elem is not None:
+            beg = beg_elem.get(_M + "val", beg)
+        if end_elem is not None:
+            end = end_elem.get(_M + "val", end)
+        if sep_elem is not None:
+            sep = sep_elem.get(_M + "val", sep)
+    inner = sep.join(_convert_children(e) for e in _children_by_tag(element, "e"))
+    return (
+        _delim_to_latex(beg, opening=True) + inner + _delim_to_latex(end, opening=False)
+    )
+
+
+def _delim_to_latex(ch: str, *, opening: bool) -> str:
+    mapping = {
+        "(": "(",
+        ")": ")",
+        "[": "[",
+        "]": "]",
+        "{": r"\{",
+        "}": r"\}",
+        "|": "|",
+        "\u2016": r"\|",  # DOUBLE VERTICAL LINE
+        "\u27e8": r"\langle",
+        "\u27e9": r"\rangle",
+        "\u230a": r"\lfloor",
+        "\u230b": r"\rfloor",
+        "\u2308": r"\lceil",
+        "\u2309": r"\rceil",
+        "": "." if opening else ".",
+    }
+    return mapping.get(ch, ch)
+
+
+def _h_matrix(element: ET.Element) -> str:
+    rows = _children_by_tag(element, "mr")
+    body = []
+    for row in rows:
+        cells = [_convert_children(e) for e in _children_by_tag(row, "e")]
+        body.append(" & ".join(cells))
+    return r"\begin{matrix} " + r" \\ ".join(body) + r" \end{matrix}"
+
+
+def _h_bar(element: ET.Element) -> str:
+    # m:bar — accent bar; pos="top" → overline, pos="bot" → underline.
+    pr = _first_child(element, "barPr")
+    pos = "top"
+    if pr is not None:
+        pos_elem = _first_child(pr, "pos")
+        if pos_elem is not None:
+            pos = pos_elem.get(_M + "val", pos)
+    base = _first_child(element, "e")
+    inner = _convert_children(base)
+    return (r"\overline{" if pos == "top" else r"\underline{") + inner + "}"
+
+
+def _h_acc(element: ET.Element) -> str:
+    # m:acc — accent (hat, tilde, dot, etc.). m:accPr/m:chr gives the char.
+    pr = _first_child(element, "accPr")
+    chr_val = "\u0302"  # combining circumflex (hat) by default
+    if pr is not None:
+        chr_elem = _first_child(pr, "chr")
+        if chr_elem is not None:
+            chr_val = chr_elem.get(_M + "val", chr_val)
+    accent = {
+        "\u0302": r"\hat",
+        "\u0303": r"\tilde",
+        "\u0304": r"\bar",
+        "\u0307": r"\dot",
+        "\u0308": r"\ddot",
+        "\u20d7": r"\vec",
+        "\u030c": r"\check",
+        "\u0306": r"\breve",
+    }.get(chr_val, r"\hat")
+    base = _first_child(element, "e")
+    return accent + "{" + _convert_children(base) + "}"
+
+
+def _h_group_chr(element: ET.Element) -> str:
+    # m:groupChr — group expression with a character on top or bottom (e.g.
+    # an over-brace). We emit the most common forms and fall through.
+    pr = _first_child(element, "groupChrPr")
+    chr_val = ""
+    pos = "top"
+    if pr is not None:
+        chr_elem = _first_child(pr, "chr")
+        pos_elem = _first_child(pr, "pos")
+        if chr_elem is not None:
+            chr_val = chr_elem.get(_M + "val", "")
+        if pos_elem is not None:
+            pos = pos_elem.get(_M + "val", pos)
+    base = _first_child(element, "e")
+    inner = _convert_children(base)
+    if chr_val == "\u23de":  # TOP CURLY BRACKET
+        return r"\overbrace{" + inner + "}"
+    if chr_val == "\u23df":  # BOTTOM CURLY BRACKET
+        return r"\underbrace{" + inner + "}"
+    if pos == "bot":
+        return r"\underset{" + chr_val + "}{" + inner + "}"
+    return r"\overset{" + chr_val + "}{" + inner + "}"
+
+
+def _h_lim_low(element: ET.Element) -> str:
+    base = _first_child(element, "e")
+    lim = _first_child(element, "lim")
+    return _convert_children(base) + "_{" + _convert_children(lim) + "}"
+
+
+def _h_lim_upp(element: ET.Element) -> str:
+    base = _first_child(element, "e")
+    lim = _first_child(element, "lim")
+    return _convert_children(base) + "^{" + _convert_children(lim) + "}"
+
+
+def _h_box(element: ET.Element) -> str:
+    return _convert_children(_first_child(element, "e"))
+
+
+def _h_phantom(element: ET.Element) -> str:
+    return r"\phantom{" + _convert_children(_first_child(element, "e")) + "}"
+
+
+def _h_pass_through(element: ET.Element) -> str:
+    """Default for elements whose semantics are 'recurse on children'."""
+    return _convert_children(element)
+
+
+# Map of OMML local-name → handler. Anything not listed falls through to the
+# generic recursive descent in :func:`_convert`, which preserves text content.
+_HANDLERS: Dict[str, Any] = {
+    "oMath": _h_omath,
+    "oMathPara": _h_omath_para,
+    "r": _h_run,
+    "t": _h_text,
+    "f": _h_fraction,
+    "sSup": _h_superscript,
+    "sSub": _h_subscript,
+    "sSubSup": _h_sub_superscript,
+    "sPre": _h_pre_sub_superscript,
+    "rad": _h_radical,
+    "nary": _h_nary,
+    "func": _h_function,
+    "d": _h_delimiter,
+    "m": _h_matrix,
+    "bar": _h_bar,
+    "acc": _h_acc,
+    "groupChr": _h_group_chr,
+    "limLow": _h_lim_low,
+    "limUpp": _h_lim_upp,
+    "box": _h_box,
+    "phant": _h_phantom,
+    # Pass-through containers that have no LaTeX equivalent of their own.
+    "e": _h_pass_through,
+    "num": _h_pass_through,
+    "den": _h_pass_through,
+    "sub": _h_pass_through,
+    "sup": _h_pass_through,
+    "deg": _h_pass_through,
+    "fName": _h_pass_through,
+    "lim": _h_pass_through,
+    "mr": _h_pass_through,
+}
+
+
+__all__ = [
+    "extract_omml_equations",
+    "enrich_content_list_with_docx_equations",
+    "omml_to_latex",
+]

--- a/raganything/omml_extractor.py
+++ b/raganything/omml_extractor.py
@@ -265,6 +265,22 @@ def enrich_content_list_with_docx_equations(
     equations become indexable LaTeX text) but not for visual reconstruction.
     Callers needing positional accuracy can post-process the list using the
     ``raw_omml`` field returned by :func:`extract_omml_equations`.
+
+    Limitations
+    -----------
+    - Deduplication compares the LaTeX ``text`` field exactly. It will
+      therefore not match parser-emitted placeholder strings (e.g. ``"[FORMULA]"``)
+      nor LaTeX produced by image-based equation OCR in MinerU/Docling, even
+      when they semantically refer to the same equation. If a parser already
+      emits LaTeX for some equations you may see both versions; pass
+      ``deduplicate_existing_equations=False`` and post-process if you need
+      a stricter merge policy.
+    - All extracted equations are appended at the end of the returned list
+      with ``page_idx`` copied from the last existing block (or ``0`` when
+      the input is empty). Treat ``page_idx`` on enriched equations as a
+      retrieval hint rather than a precise page-level location; use
+      ``raw_omml`` to splice back into the correct position when ordering
+      matters.
     """
     extracted = extract_omml_equations(docx_path)
     if not extracted:
@@ -392,7 +408,14 @@ def _first_child(element: ET.Element, tag: str) -> Optional[ET.Element]:
     return children[0] if children else None
 
 
-def _convert_children(element: ET.Element) -> str:
+def _convert_children(element: Optional[ET.Element]) -> str:
+    # Tolerate a missing child element: handlers like _h_fraction or
+    # _h_radical pass the result of _first_child() directly here, which can
+    # be None when the source DOCX is malformed (a fraction without m:num,
+    # a radical without m:e, ...). Returning "" keeps the converter on its
+    # recall-over-correctness contract instead of raising.
+    if element is None:
+        return ""
     parts = []
     for child in element:
         parts.append(_convert(child))
@@ -490,13 +513,19 @@ def _h_nary(element: ET.Element) -> str:
     # m:nary — n-ary operator (sum, integral, etc.). The operator character
     # lives in m:naryPr/m:chr/@m:val; defaults to the integral sign per ECMA-376.
     pr = _first_child(element, "naryPr")
+    # ECMA-376 §22.1.2.74: when m:chr is absent the operator defaults to
+    # the integral sign. When m:chr is present but its value is not in our
+    # LaTeX table, fall back to the original Unicode character rather than
+    # silently rewriting it to \int — preserving the symbol keeps the
+    # equation searchable for downstream RAG even when the operator is
+    # exotic (e.g. \bigsqcup, \bigwedge, custom math fonts).
     op = r"\int"
     if pr is not None:
         chr_elem = _first_child(pr, "chr")
         if chr_elem is not None:
             val = chr_elem.get(_M + "val")
             if val:
-                op = _NARY_OPERATORS.get(val, op)
+                op = _NARY_OPERATORS.get(val, val)
     sub = _first_child(element, "sub")
     sup = _first_child(element, "sup")
     base = _first_child(element, "e")

--- a/tests/test_omml_extractor.py
+++ b/tests/test_omml_extractor.py
@@ -218,6 +218,44 @@ class TestOmmlToLatex:
         assert omml_to_latex(elem) == r"a\leqb"
 
 
+class TestRobustness:
+    """Malformed OMML and unknown-operator fallbacks should degrade gracefully."""
+
+    def test_fraction_missing_numerator(self):
+        elem = _wrap_in_omath(
+            "<m:f><m:den><m:r><m:t>b</m:t></m:r></m:den></m:f>"
+        )
+        # Empty numerator, no exception.
+        assert omml_to_latex(elem) == r"\frac{}{b}"
+
+    def test_fraction_missing_denominator(self):
+        elem = _wrap_in_omath(
+            "<m:f><m:num><m:r><m:t>a</m:t></m:r></m:num></m:f>"
+        )
+        assert omml_to_latex(elem) == r"\frac{a}{}"
+
+    def test_superscript_missing_base(self):
+        elem = _wrap_in_omath(
+            "<m:sSup><m:sup><m:r><m:t>2</m:t></m:r></m:sup></m:sSup>"
+        )
+        assert omml_to_latex(elem) == "{}^{2}"
+
+    def test_radical_missing_base(self):
+        elem = _wrap_in_omath("<m:rad></m:rad>")
+        assert omml_to_latex(elem) == r"\sqrt{}"
+
+    def test_unknown_nary_operator_preserved(self):
+        # \u2A06 (N-ARY SQUARE UNION OPERATOR) is not in our table; the raw
+        # Unicode character should survive instead of being rewritten to \int.
+        elem = _wrap_in_omath(
+            "<m:nary>"
+            '<m:naryPr><m:chr m:val="\u2a06"/></m:naryPr>'
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:nary>"
+        )
+        assert omml_to_latex(elem) == "\u2a06 x"
+
+
 class TestExtractFromDocx:
     """End-to-end extraction from in-memory DOCX archives."""
 

--- a/tests/test_omml_extractor.py
+++ b/tests/test_omml_extractor.py
@@ -1,0 +1,352 @@
+"""Tests for raganything.omml_extractor.
+
+These tests build minimal in-memory DOCX archives and OMML XML fragments so
+the converter can be exercised end-to-end without requiring a real Word
+document on disk.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from raganything.omml_extractor import (
+    enrich_content_list_with_docx_equations,
+    extract_omml_equations,
+    omml_to_latex,
+)
+
+NS_DECL = (
+    'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" '
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+)
+
+
+def _wrap_in_omath(inner: str) -> ET.Element:
+    """Parse `<m:oMath>{inner}</m:oMath>` into an Element with namespaces."""
+    xml = f"<m:oMath {NS_DECL}>{inner}</m:oMath>"
+    return ET.fromstring(xml)
+
+
+def _make_docx(equations_xml: str) -> bytes:
+    """Build a minimal in-memory DOCX archive containing the given equations.
+
+    `equations_xml` should be a sequence of <m:oMath> elements (already
+    namespaced with the m: prefix). They are inserted inside a single
+    <w:p>/<w:r> paragraph so the resulting XML is well-formed.
+    """
+    document_xml = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {NS_DECL}>"
+        "<w:body>"
+        "<w:p>"
+        f"{equations_xml}"
+        "</w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("word/document.xml", document_xml)
+        zf.writestr(
+            "[Content_Types].xml",
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>',
+        )
+    buf.seek(0)
+    return buf.getvalue()
+
+
+class TestOmmlToLatex:
+    """Direct conversion of OMML XML fragments to LaTeX."""
+
+    def test_simple_run(self):
+        elem = _wrap_in_omath("<m:r><m:t>x</m:t></m:r>")
+        assert omml_to_latex(elem) == "x"
+
+    def test_fraction(self):
+        elem = _wrap_in_omath(
+            "<m:f>"
+            "<m:num><m:r><m:t>a</m:t></m:r></m:num>"
+            "<m:den><m:r><m:t>b</m:t></m:r></m:den>"
+            "</m:f>"
+        )
+        assert omml_to_latex(elem) == r"\frac{a}{b}"
+
+    def test_superscript(self):
+        elem = _wrap_in_omath(
+            "<m:sSup>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "<m:sup><m:r><m:t>2</m:t></m:r></m:sup>"
+            "</m:sSup>"
+        )
+        assert omml_to_latex(elem) == "{x}^{2}"
+
+    def test_subscript(self):
+        elem = _wrap_in_omath(
+            "<m:sSub>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "<m:sub><m:r><m:t>i</m:t></m:r></m:sub>"
+            "</m:sSub>"
+        )
+        assert omml_to_latex(elem) == "{x}_{i}"
+
+    def test_sub_superscript(self):
+        elem = _wrap_in_omath(
+            "<m:sSubSup>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "<m:sub><m:r><m:t>i</m:t></m:r></m:sub>"
+            "<m:sup><m:r><m:t>2</m:t></m:r></m:sup>"
+            "</m:sSubSup>"
+        )
+        assert omml_to_latex(elem) == "{x}_{i}^{2}"
+
+    def test_radical_simple(self):
+        elem = _wrap_in_omath(
+            "<m:rad><m:deg></m:deg><m:e><m:r><m:t>x</m:t></m:r></m:e></m:rad>"
+        )
+        assert omml_to_latex(elem) == r"\sqrt{x}"
+
+    def test_radical_with_degree(self):
+        elem = _wrap_in_omath(
+            "<m:rad>"
+            "<m:deg><m:r><m:t>3</m:t></m:r></m:deg>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:rad>"
+        )
+        assert omml_to_latex(elem) == r"\sqrt[3]{x}"
+
+    def test_summation_with_bounds(self):
+        # ∑ from i=1 to n of x_i^2
+        elem = _wrap_in_omath(
+            "<m:nary>"
+            '<m:naryPr><m:chr m:val="\u2211"/></m:naryPr>'
+            "<m:sub><m:r><m:t>i=1</m:t></m:r></m:sub>"
+            "<m:sup><m:r><m:t>n</m:t></m:r></m:sup>"
+            "<m:e>"
+            "<m:sSubSup>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "<m:sub><m:r><m:t>i</m:t></m:r></m:sub>"
+            "<m:sup><m:r><m:t>2</m:t></m:r></m:sup>"
+            "</m:sSubSup>"
+            "</m:e>"
+            "</m:nary>"
+        )
+        assert omml_to_latex(elem) == r"\sum_{i=1}^{n} {x}_{i}^{2}"
+
+    def test_integral_default_operator(self):
+        # No m:chr → defaults to integral sign.
+        elem = _wrap_in_omath(
+            "<m:nary>"
+            "<m:sub><m:r><m:t>0</m:t></m:r></m:sub>"
+            "<m:sup><m:r><m:t>1</m:t></m:r></m:sup>"
+            "<m:e><m:r><m:t>f</m:t></m:r></m:e>"
+            "</m:nary>"
+        )
+        assert omml_to_latex(elem) == r"\int_{0}^{1} f"
+
+    def test_known_function(self):
+        elem = _wrap_in_omath(
+            "<m:func>"
+            "<m:fName><m:r><m:t>sin</m:t></m:r></m:fName>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:func>"
+        )
+        assert omml_to_latex(elem) == r"\sin{x}"
+
+    def test_unknown_function_uses_parens(self):
+        elem = _wrap_in_omath(
+            "<m:func>"
+            "<m:fName><m:r><m:t>foo</m:t></m:r></m:fName>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:func>"
+        )
+        assert omml_to_latex(elem) == "foo(x)"
+
+    def test_delimiter_default_parentheses(self):
+        elem = _wrap_in_omath("<m:d><m:e><m:r><m:t>x+y</m:t></m:r></m:e></m:d>")
+        assert omml_to_latex(elem) == "(x+y)"
+
+    def test_delimiter_brackets(self):
+        elem = _wrap_in_omath(
+            "<m:d>"
+            '<m:dPr><m:begChr m:val="["/><m:endChr m:val="]"/></m:dPr>'
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:d>"
+        )
+        assert omml_to_latex(elem) == "[x]"
+
+    def test_matrix_2x2(self):
+        elem = _wrap_in_omath(
+            "<m:m>"
+            "<m:mr>"
+            "<m:e><m:r><m:t>a</m:t></m:r></m:e>"
+            "<m:e><m:r><m:t>b</m:t></m:r></m:e>"
+            "</m:mr>"
+            "<m:mr>"
+            "<m:e><m:r><m:t>c</m:t></m:r></m:e>"
+            "<m:e><m:r><m:t>d</m:t></m:r></m:e>"
+            "</m:mr>"
+            "</m:m>"
+        )
+        assert omml_to_latex(elem) == r"\begin{matrix} a & b \\ c & d \end{matrix}"
+
+    def test_overline_via_bar(self):
+        elem = _wrap_in_omath(
+            "<m:bar>"
+            '<m:barPr><m:pos m:val="top"/></m:barPr>'
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:bar>"
+        )
+        assert omml_to_latex(elem) == r"\overline{x}"
+
+    def test_underline_via_bar(self):
+        elem = _wrap_in_omath(
+            "<m:bar>"
+            '<m:barPr><m:pos m:val="bot"/></m:barPr>'
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "</m:bar>"
+        )
+        assert omml_to_latex(elem) == r"\underline{x}"
+
+    def test_unicode_symbol_substitution(self):
+        # ≤ should map to \leq.
+        elem = _wrap_in_omath("<m:r><m:t>a\u2264b</m:t></m:r>")
+        assert omml_to_latex(elem) == r"a\leqb"
+
+
+class TestExtractFromDocx:
+    """End-to-end extraction from in-memory DOCX archives."""
+
+    def test_extracts_single_equation(self, tmp_path):
+        docx = _make_docx(
+            f"<m:oMath {NS_DECL}>"
+            "<m:f>"
+            "<m:num><m:r><m:t>1</m:t></m:r></m:num>"
+            "<m:den><m:r><m:t>2</m:t></m:r></m:den>"
+            "</m:f>"
+            "</m:oMath>"
+        )
+        path = tmp_path / "single.docx"
+        path.write_bytes(docx)
+        result = extract_omml_equations(path)
+        assert len(result) == 1
+        assert result[0]["text"] == r"\frac{1}{2}"
+        assert result[0]["text_format"] == "latex"
+        assert result[0]["index"] == 0
+
+    def test_extracts_multiple_equations_in_order(self, tmp_path):
+        eq1 = f"<m:oMath {NS_DECL}><m:r><m:t>a+b</m:t></m:r></m:oMath>"
+        eq2 = (
+            f"<m:oMath {NS_DECL}>"
+            "<m:sSup>"
+            "<m:e><m:r><m:t>x</m:t></m:r></m:e>"
+            "<m:sup><m:r><m:t>2</m:t></m:r></m:sup>"
+            "</m:sSup>"
+            "</m:oMath>"
+        )
+        path = tmp_path / "two.docx"
+        path.write_bytes(_make_docx(eq1 + eq2))
+        result = extract_omml_equations(path)
+        assert [eq["text"] for eq in result] == ["a+b", "{x}^{2}"]
+        assert [eq["index"] for eq in result] == [0, 1]
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            extract_omml_equations(tmp_path / "nope.docx")
+
+    def test_invalid_zip_raises_value_error(self, tmp_path):
+        path = tmp_path / "bad.docx"
+        path.write_bytes(b"not a zip")
+        with pytest.raises(ValueError, match="not a valid ZIP"):
+            extract_omml_equations(path)
+
+    def test_zip_without_document_xml_raises_value_error(self, tmp_path):
+        path = tmp_path / "empty.docx"
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("other.xml", "<root/>")
+        with pytest.raises(ValueError, match="word/document.xml"):
+            extract_omml_equations(path)
+
+
+class TestEnrichContentList:
+    """Tests for the content-list enrichment helper."""
+
+    def test_appends_extracted_equations(self, tmp_path):
+        path = tmp_path / "doc.docx"
+        path.write_bytes(
+            _make_docx(
+                f"<m:oMath {NS_DECL}>"
+                "<m:f>"
+                "<m:num><m:r><m:t>p</m:t></m:r></m:num>"
+                "<m:den><m:r><m:t>q</m:t></m:r></m:den>"
+                "</m:f>"
+                "</m:oMath>"
+            )
+        )
+        original = [
+            {"type": "text", "text": "Hello", "page_idx": 0},
+            {"type": "text", "text": "World", "page_idx": 3},
+        ]
+        enriched = enrich_content_list_with_docx_equations(original, path)
+        # Original list is untouched.
+        assert len(original) == 2
+        # Enriched list has one extra equation block at the end with the
+        # last page index inherited.
+        assert len(enriched) == 3
+        eq_block = enriched[-1]
+        assert eq_block["type"] == "equation"
+        assert eq_block["text"] == r"\frac{p}{q}"
+        assert eq_block["text_format"] == "latex"
+        assert eq_block["page_idx"] == 3
+        assert eq_block["_source"] == "omml_extractor"
+
+    def test_deduplicates_against_existing_equations(self, tmp_path):
+        path = tmp_path / "dup.docx"
+        path.write_bytes(
+            _make_docx(f"<m:oMath {NS_DECL}><m:r><m:t>x+y</m:t></m:r></m:oMath>")
+        )
+        original = [
+            {
+                "type": "equation",
+                "text": "x+y",
+                "text_format": "latex",
+                "page_idx": 0,
+            },
+        ]
+        enriched = enrich_content_list_with_docx_equations(original, path)
+        # No new block added because the equation is already present.
+        assert len(enriched) == 1
+        assert enriched[0]["text"] == "x+y"
+
+    def test_can_disable_deduplication(self, tmp_path):
+        path = tmp_path / "dup2.docx"
+        path.write_bytes(
+            _make_docx(f"<m:oMath {NS_DECL}><m:r><m:t>x+y</m:t></m:r></m:oMath>")
+        )
+        original = [
+            {
+                "type": "equation",
+                "text": "x+y",
+                "text_format": "latex",
+                "page_idx": 0,
+            },
+        ]
+        enriched = enrich_content_list_with_docx_equations(
+            original, path, deduplicate_existing_equations=False
+        )
+        assert len(enriched) == 2
+        assert enriched[1]["_source"] == "omml_extractor"
+
+    def test_empty_extraction_returns_copy(self, tmp_path):
+        # DOCX with no equations.
+        path = tmp_path / "noeq.docx"
+        path.write_bytes(_make_docx(""))
+        original = [{"type": "text", "text": "Hi", "page_idx": 0}]
+        enriched = enrich_content_list_with_docx_equations(original, path)
+        assert enriched == original
+        # Should be a copy, not the same list object.
+        assert enriched is not original


### PR DESCRIPTION
## Summary

Closes #259.

Adds `raganything/omml_extractor.py`, a zero-dependency, pure-stdlib utility that extracts OMML (Office Math Markup Language) equations from `.docx` files and converts them to LaTeX, so the structured math content survives the DOCX → PDF conversion that both the MinerU and Docling parsers rely on.

## Why

Word stores inline and display math as `<m:oMath>` elements inside `word/document.xml`. When a DOCX is ingested today, both parsers convert it to PDF first (LibreOffice for MinerU, native conversion for Docling). During that conversion, equations are typically rasterized to images or replaced with placeholder glyphs — the structured math text is **lost** before it ever reaches `EquationModalProcessor`. This silently degrades retrieval quality for academic papers, lecture notes, and engineering reports — exactly the workloads where structured math matters most.

See #259 for the full motivation and the proposed approach.

## What this PR adds

Two public functions and one transformer:

- **`extract_omml_equations(docx_path)`** — opens the DOCX as a ZIP, parses `word/document.xml` with `xml.etree`, walks every `<m:oMath>` element in document order, and returns a list of dicts with `text` (LaTeX), `text_format`, `index`, and `raw_omml` (the source XML, useful for callers that want to plug in their own converter).

- **`enrich_content_list_with_docx_equations(content_list, docx_path)`** — takes a parsed MinerU-compatible content list and appends `{"type": "equation", "text": "<latex>", "text_format": "latex", ...}` blocks for each extracted equation. Deduplicates against equations already present in the list (e.g. those the parser already produced as image placeholders) by default.

- **`omml_to_latex(element)`** — recursive transformer covering the most common OMML constructs: runs (`m:r`/`m:t`), fractions (`m:f`), super/subscripts (`m:sSup`/`m:sSub`/`m:sSubSup`/`m:sPre`), radicals (`m:rad`), n-ary operators (`m:nary` with the standard sum/prod/integral characters), applied functions (`m:func`, with whitelist for `\sin`, `\cos`, `\log`, etc.), delimiters (`m:d`), matrices (`m:m`), accents (`m:acc`, `m:bar`), limits (`m:limLow`/`m:limUpp`), grouping characters (`m:groupChr`), and phantoms (`m:phant`). Unknown elements gracefully fall back to their text content rather than raising — for RAG indexing, **recall beats fidelity**.

## Tests

`tests/test_omml_extractor.py` covers **26 cases**, all passing locally:

- Direct OMML → LaTeX conversion for every supported construct (fractions, sup/sub, radicals, summation with bounds, integrals with default operator, known and unknown functions, delimiters with default and explicit braces, 2×2 matrices, overline/underline, Unicode symbol substitution).
- End-to-end extraction from in-memory DOCX archives built with `zipfile` (single equation, multiple equations preserve document order).
- Enrichment behavior: append, deduplicate against existing equations, opt-out of dedup, empty input returns a defensive copy.
- Error handling: missing file → `FileNotFoundError`, non-ZIP → `ValueError`, ZIP missing `word/document.xml` → `ValueError`.

All 26 tests pass with the stdlib alone — no `python-docx`, no `lxml`, no `pandoc`.

## Backward compatibility

- New module — **no changes to existing parsers or processors**.
- Strictly opt-in: callers explicitly invoke `extract_omml_equations()` or `enrich_content_list_with_docx_equations()`.
- Output dicts use the same schema as existing equation blocks, so they slot into `EquationModalProcessor` without code changes anywhere else.
- No new required dependencies.

## Out of scope (possible follow-ups)

- **Positional placement**: DOCX paragraphs do not carry page numbers, so this PR appends extracted equations at the tail of the content list with the last block's `page_idx`. Precise positional weaving could be a follow-up using `raw_omml` as a join key against parser-produced image placeholders.
- **Auto-integration into `process_document_complete()`** for `.docx` inputs — deliberately punted to a second PR so the utility lands first and can be reviewed in isolation.

## Test plan

- [x] All 26 unit tests pass locally on Python 3.12 / Windows.
- [x] `ruff format` and `ruff check --ignore=E402` pass on the new files.
- [ ] Maintainer-side: try it on a real `.docx` with mixed inline and display math and confirm the LaTeX is searchable inside the resulting knowledge graph.

Note: the test file is added with `git add -f` because `.gitignore` includes a broad `test_*` pattern that would otherwise hide it; the existing `tests/test_*.py` files are tracked the same way, so this matches the established convention.
