### PR TITLE
fix(examples): preserve embedding kwargs with partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Models are downloaded automatically on first use. For manual download, refer to 
 
 ```python
 import asyncio
+from functools import partial
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
@@ -409,8 +410,8 @@ async def main():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed.func(
-            texts,
+        func=partial(
+            openai_embed.func,
             model="text-embedding-3-large",
             api_key=api_key,
             base_url=base_url,
@@ -460,6 +461,7 @@ if __name__ == "__main__":
 
 ```python
 import asyncio
+from functools import partial
 from lightrag import LightRAG
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
@@ -485,8 +487,8 @@ async def process_multimodal_content():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model="text-embedding-3-large",
                 api_key=api_key,
                 base_url=base_url,
@@ -675,6 +677,7 @@ equation_result = await rag.aquery_with_multimodal(
 
 ```python
 import asyncio
+from functools import partial
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag import LightRAG
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
@@ -711,8 +714,8 @@ async def load_existing_lightrag():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model="text-embedding-3-large",
                 api_key=api_key,
                 base_url=base_url,
@@ -804,6 +807,7 @@ For scenarios where you already have a pre-parsed content list (e.g., from exter
 
 ```python
 import asyncio
+from functools import partial
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
@@ -874,8 +878,8 @@ async def insert_content_list_example():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed.func(
-            texts,
+        func=partial(
+            openai_embed.func,
             model="text-embedding-3-large",
             api_key=api_key,
             base_url=base_url,

--- a/README_zh.md
+++ b/README_zh.md
@@ -304,6 +304,7 @@ python -c "from raganything import RAGAnything; rag = RAGAnything(); print('✅ 
 
 ```python
 import asyncio
+from functools import partial
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
@@ -389,8 +390,8 @@ async def main():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed.func(
-            texts,
+        func=partial(
+            openai_embed.func,
             model="text-embedding-3-large",
             api_key=api_key,
             base_url=base_url,
@@ -442,6 +443,7 @@ if __name__ == "__main__":
 
 ```python
 import asyncio
+from functools import partial
 from lightrag import LightRAG
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
@@ -467,8 +469,8 @@ async def process_multimodal_content():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model="text-embedding-3-large",
                 api_key=api_key,
                 base_url=base_url,
@@ -657,6 +659,7 @@ equation_result = await rag.aquery_with_multimodal(
 
 ```python
 import asyncio
+from functools import partial
 from raganything import RAGAnything
 from lightrag import LightRAG
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
@@ -692,8 +695,8 @@ async def load_existing_lightrag():
         embedding_func=EmbeddingFunc(
             embedding_dim=3072,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model="text-embedding-3-large",
                 api_key=api_key,
                 base_url=base_url,
@@ -785,6 +788,7 @@ if __name__ == "__main__":
 
 ```python
 import asyncio
+from functools import partial
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
@@ -855,8 +859,8 @@ async def insert_content_list_example():
     embedding_func = EmbeddingFunc(
         embedding_dim=3072,
         max_token_size=8192,
-        func=lambda texts: openai_embed.func(
-            texts,
+        func=partial(
+            openai_embed.func,
             model="text-embedding-3-large",
             api_key=api_key,
             base_url=base_url,

--- a/examples/insert_content_list_example.py
+++ b/examples/insert_content_list_example.py
@@ -15,6 +15,7 @@ import argparse
 import asyncio
 import logging
 import logging.config
+from functools import partial
 from pathlib import Path
 
 # Add project root directory to Python path
@@ -252,8 +253,8 @@ async def demo_insert_content_list(
         embedding_func = EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model=embedding_model,
                 api_key=api_key,
                 base_url=base_url,

--- a/examples/modalprocessors_example.py
+++ b/examples/modalprocessors_example.py
@@ -6,6 +6,7 @@ This example demonstrates how to use RAG-Anything's modal processors directly wi
 
 import asyncio
 import argparse
+from functools import partial
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
 from lightrag.utils import EmbeddingFunc
 from lightrag.kg.shared_storage import initialize_pipeline_status
@@ -175,8 +176,8 @@ async def initialize_rag(api_key: str, base_url: str = None):
         embedding_func=EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model=embedding_model,
                 api_key=api_key,
                 base_url=base_url,

--- a/examples/raganything_example.py
+++ b/examples/raganything_example.py
@@ -14,6 +14,7 @@ import argparse
 import asyncio
 import logging
 import logging.config
+from functools import partial
 from pathlib import Path
 
 # Add project root directory to Python path
@@ -189,8 +190,8 @@ async def process_with_rag(
         embedding_func = EmbeddingFunc(
             embedding_dim=embedding_dim,
             max_token_size=8192,
-            func=lambda texts: openai_embed.func(
-                texts,
+            func=partial(
+                openai_embed.func,
                 model=embedding_model,
                 api_key=api_key,
                 base_url=base_url,

--- a/tests/test_embedding_examples.py
+++ b/tests/test_embedding_examples.py
@@ -1,0 +1,49 @@
+import asyncio
+from functools import partial
+
+import numpy as np
+from lightrag.utils import EmbeddingFunc
+
+
+def test_partial_embedding_wrapper_accepts_forwarded_dimensions():
+    captured = {}
+
+    async def fake_openai_embed(
+        texts,
+        model,
+        api_key,
+        base_url=None,
+        embedding_dim=None,
+        max_token_size=None,
+    ):
+        captured["texts"] = texts
+        captured["model"] = model
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        captured["embedding_dim"] = embedding_dim
+        captured["max_token_size"] = max_token_size
+        return np.zeros((len(texts), embedding_dim), dtype=float)
+
+    embedding_func = EmbeddingFunc(
+        embedding_dim=4,
+        max_token_size=32,
+        send_dimensions=True,
+        func=partial(
+            fake_openai_embed,
+            model="text-embedding-v4",
+            api_key="test-key",
+            base_url="https://example.com/v1",
+        ),
+    )
+
+    result = asyncio.run(embedding_func(["hello", "world"]))
+
+    assert result.shape == (2, 4)
+    assert captured == {
+        "texts": ["hello", "world"],
+        "model": "text-embedding-v4",
+        "api_key": "test-key",
+        "base_url": "https://example.com/v1",
+        "embedding_dim": 4,
+        "max_token_size": 32,
+    }


### PR DESCRIPTION
## Description
- replace the kwarg-dropping `lambda texts: openai_embed.func(...)` wrappers with `functools.partial(openai_embed.func, ...)` in the OpenAI examples and copied README snippets
- add a regression test covering `EmbeddingFunc(..., send_dimensions=True)` with the same partial wrapper pattern

## Related Issues
- Fixes #212

## Changes Made
- updated the runnable OpenAI examples to preserve forwarded embedding kwargs
- updated the English and Chinese README snippets to show the same safe wrapper pattern
- added a targeted test for forwarded `embedding_dim` and `max_token_size`

## Checklist
- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Validation
- `python -m pytest tests/test_embedding_examples.py tests/test_raganything_example.py`
- `git diff --check`