### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/examples/minimax_integration_example.py
+++ b/examples/minimax_integration_example.py
@@ -36,17 +36,18 @@ API Reference:
 import os
 import uuid
 import asyncio
-from typing import List, Dict, Optional
+import inspect
+from typing import Dict, List, Optional
 
 from dotenv import load_dotenv
-
-# Load environment variables
-load_dotenv()
 
 # RAG-Anything imports
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag.utils import EmbeddingFunc
 from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+
+# Load environment variables
+load_dotenv()
 
 # MiniMax configuration
 MINIMAX_BASE_URL = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
@@ -56,9 +57,33 @@ MINIMAX_LLM_MODEL = os.getenv("MINIMAX_LLM_MODEL", "MiniMax-M2.7")
 # Embedding configuration (MiniMax does not provide an embedding model;
 # configure a separate embedding service below)
 EMBEDDING_BASE_URL = os.getenv("EMBEDDING_BINDING_HOST", "https://api.openai.com/v1")
-EMBEDDING_API_KEY = os.getenv("EMBEDDING_BINDING_API_KEY", os.getenv("OPENAI_API_KEY", ""))
+EMBEDDING_API_KEY = os.getenv(
+    "EMBEDDING_BINDING_API_KEY", os.getenv("OPENAI_API_KEY", "")
+)
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
 EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1536"))
+
+
+def _require_minimax_api_key() -> str:
+    """Return the MiniMax API key or fail before LightRAG falls back to OpenAI."""
+    if not MINIMAX_API_KEY:
+        raise ValueError(
+            "MINIMAX_API_KEY is required for MiniMax. "
+            "Set it with: export MINIMAX_API_KEY=your-api-key"
+        )
+    return MINIMAX_API_KEY
+
+
+def _normalize_minimax_temperature(value):
+    """MiniMax accepts temperatures in (0.0, 1.0]; use 1.0 for invalid values."""
+    if value is None:
+        return 1.0
+    try:
+        if value <= 0 or value > 1:
+            return 1.0
+    except TypeError:
+        return 1.0
+    return value
 
 
 async def minimax_llm_model_func(
@@ -72,8 +97,7 @@ async def minimax_llm_model_func(
     MiniMax temperature must be in (0.0, 1.0]; defaults to 1.0.
     """
     # Ensure temperature is within MiniMax's accepted range (0.0, 1.0]
-    if "temperature" in kwargs and (kwargs["temperature"] <= 0 or kwargs["temperature"] > 1):
-        kwargs["temperature"] = 1.0
+    kwargs["temperature"] = _normalize_minimax_temperature(kwargs.get("temperature"))
     kwargs.setdefault("temperature", 1.0)
 
     return await openai_complete_if_cache(
@@ -82,7 +106,7 @@ async def minimax_llm_model_func(
         system_prompt=system_prompt,
         history_messages=history_messages or [],
         base_url=MINIMAX_BASE_URL,
-        api_key=MINIMAX_API_KEY,
+        api_key=_require_minimax_api_key(),
         **kwargs,
     )
 
@@ -124,26 +148,44 @@ class MiniMaxRAGIntegration:
         self.rag = None
 
     async def test_connection(self) -> bool:
-        """Test MiniMax API connection."""
+        """Best-effort MiniMax API key and endpoint check."""
         if not self.api_key:
             print("❌ MINIMAX_API_KEY is not set")
             print("   Set it with: export MINIMAX_API_KEY=your-api-key")
             return False
 
         try:
-            print(f"🔌 Testing MiniMax connection at: {self.base_url}")
             from openai import AsyncOpenAI
 
+            print(f"🔌 Testing MiniMax endpoint at: {self.base_url}")
             client = AsyncOpenAI(base_url=self.base_url, api_key=self.api_key)
-            models = await client.models.list()
-            available = [m.id for m in models.data]
-            print(f"✅ Connected successfully! Found {len(available)} models")
-            for model_id in available[:5]:
-                marker = "🎯" if model_id == self.model_name else "  "
-                print(f"{marker} {model_id}")
-            if len(available) > 5:
-                print(f"  ... and {len(available) - 5} more")
-            await client.close()
+            try:
+                models = await client.models.list()
+            except Exception as model_error:
+                print(
+                    "⚠️  Could not list MiniMax models; continuing because many "
+                    f"OpenAI-compatible providers do not expose /v1/models: {model_error}"
+                )
+            else:
+                available = [m.id for m in models.data]
+                print(f"✅ Model endpoint returned {len(available)} model(s)")
+                for model_id in available[:5]:
+                    marker = "🎯" if model_id == self.model_name else "  "
+                    print(f"{marker} {model_id}")
+                if len(available) > 5:
+                    print(f"  ... and {len(available) - 5} more")
+            finally:
+                close = getattr(client, "close", None) or getattr(
+                    client, "aclose", None
+                )
+                if close:
+                    close_result = close()
+                    if inspect.isawaitable(close_result):
+                        await close_result
+
+            print(
+                "✅ MiniMax API key is configured; chat completion will verify access."
+            )
             return True
         except Exception as e:
             print(f"❌ Connection failed: {e}")
@@ -157,7 +199,7 @@ class MiniMaxRAGIntegration:
             result = await minimax_llm_model_func(
                 "Say 'RAG-Anything MiniMax integration test passed' in one sentence."
             )
-            print(f"✅ Chat test successful!")
+            print("✅ Chat test successful!")
             print(f"   Response: {result.strip()[:120]}")
             return True
         except Exception as e:

--- a/examples/minimax_integration_example.py
+++ b/examples/minimax_integration_example.py
@@ -1,0 +1,280 @@
+"""
+MiniMax Integration Example with RAG-Anything
+
+This example demonstrates how to integrate MiniMax with RAG-Anything for
+cloud-based text document processing and querying using MiniMax's
+OpenAI-compatible API.
+
+MiniMax provides high-quality language models accessible via an API that is
+fully compatible with the OpenAI chat completions protocol.
+
+Requirements:
+- RAG-Anything installed: pip install raganything
+- A MiniMax API key (https://www.minimaxi.com/)
+- An embedding service (OpenAI, Ollama, or any OpenAI-compatible endpoint)
+  Note: MiniMax does not provide an embedding model, so a separate embedding
+  service is required.
+
+Environment Setup:
+Create a .env file with:
+MINIMAX_API_KEY=your-minimax-api-key
+
+# For embeddings, use any OpenAI-compatible service, e.g.:
+EMBEDDING_BINDING_HOST=https://api.openai.com/v1
+EMBEDDING_BINDING_API_KEY=your-openai-api-key
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIM=1536
+
+Quick start:
+    export MINIMAX_API_KEY=your-api-key
+    python examples/minimax_integration_example.py
+
+API Reference:
+- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
+"""
+
+import os
+import uuid
+import asyncio
+from typing import List, Dict, Optional
+
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+# RAG-Anything imports
+from raganything import RAGAnything, RAGAnythingConfig
+from lightrag.utils import EmbeddingFunc
+from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+
+# MiniMax configuration
+MINIMAX_BASE_URL = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY", "")
+MINIMAX_LLM_MODEL = os.getenv("MINIMAX_LLM_MODEL", "MiniMax-M2.7")
+
+# Embedding configuration (MiniMax does not provide an embedding model;
+# configure a separate embedding service below)
+EMBEDDING_BASE_URL = os.getenv("EMBEDDING_BINDING_HOST", "https://api.openai.com/v1")
+EMBEDDING_API_KEY = os.getenv("EMBEDDING_BINDING_API_KEY", os.getenv("OPENAI_API_KEY", ""))
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1536"))
+
+
+async def minimax_llm_model_func(
+    prompt: str,
+    system_prompt: Optional[str] = None,
+    history_messages: List[Dict] = None,
+    **kwargs,
+) -> str:
+    """Top-level LLM function using MiniMax's OpenAI-compatible endpoint.
+
+    MiniMax temperature must be in (0.0, 1.0]; defaults to 1.0.
+    """
+    # Ensure temperature is within MiniMax's accepted range (0.0, 1.0]
+    if "temperature" in kwargs and (kwargs["temperature"] <= 0 or kwargs["temperature"] > 1):
+        kwargs["temperature"] = 1.0
+    kwargs.setdefault("temperature", 1.0)
+
+    return await openai_complete_if_cache(
+        model=MINIMAX_LLM_MODEL,
+        prompt=prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages or [],
+        base_url=MINIMAX_BASE_URL,
+        api_key=MINIMAX_API_KEY,
+        **kwargs,
+    )
+
+
+async def embedding_func_async(texts: List[str]) -> List[List[float]]:
+    """Top-level embedding function (pickle-safe).
+
+    Uses a separate OpenAI-compatible embedding service since MiniMax
+    does not provide an embedding model.
+    """
+    embeddings = await openai_embed(
+        texts=texts,
+        model=EMBEDDING_MODEL,
+        base_url=EMBEDDING_BASE_URL,
+        api_key=EMBEDDING_API_KEY,
+    )
+    return embeddings.tolist()
+
+
+class MiniMaxRAGIntegration:
+    """Integration class for MiniMax with RAG-Anything."""
+
+    def __init__(self):
+        self.base_url = MINIMAX_BASE_URL
+        self.api_key = MINIMAX_API_KEY
+        self.model_name = MINIMAX_LLM_MODEL
+
+        # RAG-Anything configuration
+        self.config = RAGAnythingConfig(
+            working_dir=f"./rag_storage_minimax/{uuid.uuid4()}",
+            parser="mineru",
+            parse_method="auto",
+            enable_image_processing=False,
+            enable_table_processing=True,
+            enable_equation_processing=True,
+        )
+        print(f"📁 Using working_dir: {self.config.working_dir}")
+
+        self.rag = None
+
+    async def test_connection(self) -> bool:
+        """Test MiniMax API connection."""
+        if not self.api_key:
+            print("❌ MINIMAX_API_KEY is not set")
+            print("   Set it with: export MINIMAX_API_KEY=your-api-key")
+            return False
+
+        try:
+            print(f"🔌 Testing MiniMax connection at: {self.base_url}")
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(base_url=self.base_url, api_key=self.api_key)
+            models = await client.models.list()
+            available = [m.id for m in models.data]
+            print(f"✅ Connected successfully! Found {len(available)} models")
+            for model_id in available[:5]:
+                marker = "🎯" if model_id == self.model_name else "  "
+                print(f"{marker} {model_id}")
+            if len(available) > 5:
+                print(f"  ... and {len(available) - 5} more")
+            await client.close()
+            return True
+        except Exception as e:
+            print(f"❌ Connection failed: {e}")
+            print("💡 Check your MINIMAX_API_KEY and network access to api.minimax.io")
+            return False
+
+    async def test_chat_completion(self) -> bool:
+        """Test a basic chat completion with MiniMax."""
+        try:
+            print(f"💬 Testing chat with model: {self.model_name}")
+            result = await minimax_llm_model_func(
+                "Say 'RAG-Anything MiniMax integration test passed' in one sentence."
+            )
+            print(f"✅ Chat test successful!")
+            print(f"   Response: {result.strip()[:120]}")
+            return True
+        except Exception as e:
+            print(f"❌ Chat test failed: {e}")
+            return False
+
+    def _make_embedding_func(self) -> EmbeddingFunc:
+        return EmbeddingFunc(
+            embedding_dim=EMBEDDING_DIM,
+            max_token_size=8192,
+            func=embedding_func_async,
+        )
+
+    async def initialize_rag(self) -> bool:
+        """Initialize RAG-Anything with MiniMax as the LLM backend."""
+        print("\nInitializing RAG-Anything with MiniMax ...")
+        try:
+            self.rag = RAGAnything(
+                config=self.config,
+                llm_model_func=minimax_llm_model_func,
+                embedding_func=self._make_embedding_func(),
+            )
+            print("✅ RAG-Anything initialized successfully!")
+            return True
+        except Exception as e:
+            print(f"❌ Initialization failed: {e}")
+            return False
+
+    async def process_document(self, file_path: str):
+        """Process a document using MiniMax as the LLM backend."""
+        if not self.rag:
+            print("❌ Call initialize_rag() first")
+            return
+
+        print(f"📄 Processing document: {file_path}")
+        await self.rag.process_document_complete(
+            file_path=file_path,
+            output_dir="./output_minimax",
+            parse_method="auto",
+            display_stats=True,
+        )
+        print("✅ Document processing complete")
+
+    async def simple_query_example(self):
+        """Insert sample text and run a demonstration query."""
+        if not self.rag:
+            print("❌ Call initialize_rag() first")
+            return
+
+        content_list = [
+            {
+                "type": "text",
+                "text": (
+                    "MiniMax Integration with RAG-Anything\n\n"
+                    "This integration connects MiniMax's powerful language models "
+                    "with RAG-Anything's multimodal document processing pipeline.\n\n"
+                    "Key features:\n"
+                    "- MiniMax-M2.7: Peak Performance. Ultimate Value. Master the Complex.\n"
+                    "- MiniMax-M2.7-highspeed: Same performance, faster and more agile.\n"
+                    "- OpenAI-compatible API — no SDK changes required.\n"
+                    "- Supports text, table, and equation modalities.\n\n"
+                    "Configuration:\n"
+                    "  MINIMAX_API_KEY=your-api-key\n"
+                    "  MINIMAX_BASE_URL=https://api.minimax.io/v1  (default)\n"
+                    "  MINIMAX_LLM_MODEL=MiniMax-M2.7  (default)\n"
+                ),
+                "page_idx": 0,
+            }
+        ]
+
+        print("\nInserting sample content ...")
+        await self.rag.insert_content_list(
+            content_list=content_list,
+            file_path="minimax_integration_demo.txt",
+            doc_id=f"demo-{uuid.uuid4()}",
+            display_stats=True,
+        )
+        print("✅ Content inserted")
+
+        print("\n🔍 Running sample query ...")
+        result = await self.rag.aquery(
+            "What MiniMax models are available and what are their characteristics?",
+            mode="hybrid",
+        )
+        print(f"Answer: {result[:400]}")
+
+
+async def main():
+    print("=" * 70)
+    print("MiniMax + RAG-Anything Integration Example")
+    print("=" * 70)
+
+    integration = MiniMaxRAGIntegration()
+
+    if not await integration.test_connection():
+        return False
+
+    print()
+    if not await integration.test_chat_completion():
+        return False
+
+    print("\n" + "─" * 50)
+    if not await integration.initialize_rag():
+        return False
+
+    # Uncomment to process a real document:
+    # await integration.process_document("path/to/your/document.pdf")
+
+    await integration.simple_query_example()
+
+    print("\n" + "=" * 70)
+    print("Integration example completed successfully!")
+    print("=" * 70)
+    return True
+
+
+if __name__ == "__main__":
+    print("🚀 Starting MiniMax integration example ...")
+    success = asyncio.run(main())
+    exit(0 if success else 1)

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -15,7 +15,7 @@ import os
 import sys
 import types
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +72,9 @@ def _load_example(extra_env=None):
     import importlib.util
     from pathlib import Path
 
-    module_path = Path(__file__).parent.parent / "examples" / "minimax_integration_example.py"
+    module_path = (
+        Path(__file__).parent.parent / "examples" / "minimax_integration_example.py"
+    )
 
     env = {
         "MINIMAX_API_KEY": "test-key",
@@ -93,12 +95,16 @@ def _load_example(extra_env=None):
         if key == "minimax_integration_example":
             del sys.modules[key]
 
-    spec = importlib.util.spec_from_file_location("minimax_integration_example", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "minimax_integration_example", module_path
+    )
     mod = importlib.util.module_from_spec(spec)
 
-    with patch.dict(os.environ, env, clear=False), \
-         patch.dict(sys.modules, stubs, clear=False), \
-         patch("dotenv.load_dotenv"):
+    with (
+        patch.dict(os.environ, env, clear=False),
+        patch.dict(sys.modules, stubs, clear=False),
+        patch("dotenv.load_dotenv"),
+    ):
         spec.loader.exec_module(mod)
 
     return mod, stubs
@@ -114,27 +120,33 @@ class TestMiniMaxConstants:
 
     def test_default_base_url(self):
         # os.getenv default is used only when the var is absent, not when it is ""
-        env = {k: v for k, v in {
-            "MINIMAX_API_KEY": "test-key",
-            "MINIMAX_LLM_MODEL": "MiniMax-M2.7",
-            "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
-            "EMBEDDING_BINDING_API_KEY": "test-embed-key",
-            "EMBEDDING_MODEL": "text-embedding-3-small",
-            "EMBEDDING_DIM": "1536",
-        }.items()}
+        env = {
+            k: v
+            for k, v in {
+                "MINIMAX_API_KEY": "test-key",
+                "MINIMAX_LLM_MODEL": "MiniMax-M2.7",
+                "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
+                "EMBEDDING_BINDING_API_KEY": "test-embed-key",
+                "EMBEDDING_MODEL": "text-embedding-3-small",
+                "EMBEDDING_DIM": "1536",
+            }.items()
+        }
         with patch.dict(os.environ, env, clear=True):
             mod, _ = _load_example()
         assert mod.MINIMAX_BASE_URL == "https://api.minimax.io/v1"
 
     def test_default_model(self):
-        env = {k: v for k, v in {
-            "MINIMAX_API_KEY": "test-key",
-            "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
-            "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
-            "EMBEDDING_BINDING_API_KEY": "test-embed-key",
-            "EMBEDDING_MODEL": "text-embedding-3-small",
-            "EMBEDDING_DIM": "1536",
-        }.items()}
+        env = {
+            k: v
+            for k, v in {
+                "MINIMAX_API_KEY": "test-key",
+                "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
+                "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
+                "EMBEDDING_BINDING_API_KEY": "test-embed-key",
+                "EMBEDDING_MODEL": "text-embedding-3-small",
+                "EMBEDDING_DIM": "1536",
+            }.items()
+        }
         with patch.dict(os.environ, env, clear=True):
             mod, _ = _load_example()
         assert mod.MINIMAX_LLM_MODEL == "MiniMax-M2.7"
@@ -240,6 +252,32 @@ class TestTemperatureEnforcement:
         await mod.minimax_llm_model_func("hello", temperature=1.5)
         assert captured["temperature"] == 1.0
 
+    @pytest.mark.asyncio
+    async def test_none_temperature_replaced(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello", temperature=None)
+        assert captured["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_temperature_replaced(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello", temperature="hot")
+        assert captured["temperature"] == 1.0
+
 
 # ---------------------------------------------------------------------------
 # LLM function parameter tests
@@ -315,6 +353,16 @@ class TestMiniMaxLLMFunc:
         await mod.minimax_llm_model_func("test")
         assert captured["api_key"] == "sk-secret"
 
+    @pytest.mark.asyncio
+    async def test_missing_minimax_api_key_raises_before_openai_fallback(self):
+        mod, _ = _load_example({"MINIMAX_API_KEY": ""})
+        mod.openai_complete_if_cache = AsyncMock()
+
+        with pytest.raises(ValueError, match="MINIMAX_API_KEY is required"):
+            await mod.minimax_llm_model_func("test")
+
+        mod.openai_complete_if_cache.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Integration class tests
@@ -351,3 +399,30 @@ class TestMiniMaxRAGIntegration:
         integration.api_key = ""
         result = await integration.test_connection()
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_connection_succeeds_when_models_endpoint_is_missing(self):
+        mod, _ = _load_example()
+
+        class _Models:
+            async def list(self):
+                raise RuntimeError("models endpoint unavailable")
+
+        class _AsyncOpenAI:
+            def __init__(self, base_url, api_key):
+                self.base_url = base_url
+                self.api_key = api_key
+                self.models = _Models()
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        openai_mod = types.ModuleType("openai")
+        openai_mod.AsyncOpenAI = _AsyncOpenAI
+
+        with patch.dict(sys.modules, {"openai": openai_mod}):
+            integration = mod.MiniMaxRAGIntegration()
+            result = await integration.test_connection()
+
+        assert result is True

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for the MiniMax integration example.
+
+Tests verify:
+- Default configuration values
+- Temperature enforcement (MiniMax requires (0.0, 1.0])
+- Base URL and model name handling
+- LLM function parameter passing
+
+These tests are self-contained and do not require lightrag or raganything
+to be installed — heavy dependencies are mocked at the sys.modules level.
+"""
+
+import os
+import sys
+import types
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs so we can import the example without heavy deps
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_modules():
+    """Create minimal stub modules for lightrag and raganything."""
+    # lightrag stub
+    lightrag_mod = types.ModuleType("lightrag")
+    lightrag_llm = types.ModuleType("lightrag.llm")
+    lightrag_llm_openai = types.ModuleType("lightrag.llm.openai")
+    lightrag_llm_openai.openai_complete_if_cache = AsyncMock(return_value="stub")
+    lightrag_llm_openai.openai_embed = AsyncMock(return_value=[[0.1, 0.2]])
+    lightrag_utils = types.ModuleType("lightrag.utils")
+
+    class _EmbeddingFunc:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    lightrag_utils.EmbeddingFunc = _EmbeddingFunc
+    lightrag_mod.llm = lightrag_llm
+    lightrag_mod.utils = lightrag_utils
+
+    # raganything stub
+    rag_mod = types.ModuleType("raganything")
+
+    class _RAGAnythingConfig:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class _RAGAnything:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    rag_mod.RAGAnything = _RAGAnything
+    rag_mod.RAGAnythingConfig = _RAGAnythingConfig
+
+    return {
+        "lightrag": lightrag_mod,
+        "lightrag.llm": lightrag_llm,
+        "lightrag.llm.openai": lightrag_llm_openai,
+        "lightrag.utils": lightrag_utils,
+        "raganything": rag_mod,
+    }
+
+
+def _load_example(extra_env=None):
+    """Load the example module with stubs injected and optional env overrides."""
+    import importlib.util
+    from pathlib import Path
+
+    module_path = Path(__file__).parent.parent / "examples" / "minimax_integration_example.py"
+
+    env = {
+        "MINIMAX_API_KEY": "test-key",
+        "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
+        "MINIMAX_LLM_MODEL": "MiniMax-M2.7",
+        "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
+        "EMBEDDING_BINDING_API_KEY": "test-embed-key",
+        "EMBEDDING_MODEL": "text-embedding-3-small",
+        "EMBEDDING_DIM": "1536",
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    stubs = _make_stub_modules()
+
+    # Remove cached module if present
+    for key in list(sys.modules.keys()):
+        if key == "minimax_integration_example":
+            del sys.modules[key]
+
+    spec = importlib.util.spec_from_file_location("minimax_integration_example", module_path)
+    mod = importlib.util.module_from_spec(spec)
+
+    with patch.dict(os.environ, env, clear=False), \
+         patch.dict(sys.modules, stubs, clear=False), \
+         patch("dotenv.load_dotenv"):
+        spec.loader.exec_module(mod)
+
+    return mod, stubs
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxConstants:
+    """Verify module-level defaults resolve correctly from environment."""
+
+    def test_default_base_url(self):
+        # os.getenv default is used only when the var is absent, not when it is ""
+        env = {k: v for k, v in {
+            "MINIMAX_API_KEY": "test-key",
+            "MINIMAX_LLM_MODEL": "MiniMax-M2.7",
+            "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
+            "EMBEDDING_BINDING_API_KEY": "test-embed-key",
+            "EMBEDDING_MODEL": "text-embedding-3-small",
+            "EMBEDDING_DIM": "1536",
+        }.items()}
+        with patch.dict(os.environ, env, clear=True):
+            mod, _ = _load_example()
+        assert mod.MINIMAX_BASE_URL == "https://api.minimax.io/v1"
+
+    def test_default_model(self):
+        env = {k: v for k, v in {
+            "MINIMAX_API_KEY": "test-key",
+            "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
+            "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
+            "EMBEDDING_BINDING_API_KEY": "test-embed-key",
+            "EMBEDDING_MODEL": "text-embedding-3-small",
+            "EMBEDDING_DIM": "1536",
+        }.items()}
+        with patch.dict(os.environ, env, clear=True):
+            mod, _ = _load_example()
+        assert mod.MINIMAX_LLM_MODEL == "MiniMax-M2.7"
+
+    def test_custom_model_env(self):
+        mod, _ = _load_example({"MINIMAX_LLM_MODEL": "MiniMax-M2.7-highspeed"})
+        assert mod.MINIMAX_LLM_MODEL == "MiniMax-M2.7-highspeed"
+
+    def test_api_key_read_from_env(self):
+        mod, _ = _load_example({"MINIMAX_API_KEY": "sk-custom-123"})
+        assert mod.MINIMAX_API_KEY == "sk-custom-123"
+
+    def test_embedding_dim_read_from_env(self):
+        mod, _ = _load_example({"EMBEDDING_DIM": "3072"})
+        assert mod.EMBEDDING_DIM == 3072
+
+
+# ---------------------------------------------------------------------------
+# Temperature enforcement tests
+# ---------------------------------------------------------------------------
+
+
+class TestTemperatureEnforcement:
+    """MiniMax requires temperature in (0.0, 1.0]."""
+
+    @pytest.mark.asyncio
+    async def test_zero_temperature_replaced_with_one(self):
+        mod, stubs = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        stubs["lightrag.llm.openai"].openai_complete_if_cache = mock_complete
+        mod.openai_complete_if_cache = mock_complete
+
+        await mod.minimax_llm_model_func("hello", temperature=0)
+        assert captured["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_negative_temperature_replaced(self):
+        mod, stubs = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello", temperature=-0.5)
+        assert captured["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_valid_temperature_preserved(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello", temperature=0.7)
+        assert captured["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_temperature_one_preserved(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello", temperature=1.0)
+        assert captured["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_default_temperature_is_one(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello")
+        assert captured["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_temperature_above_one_replaced(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("hello", temperature=1.5)
+        assert captured["temperature"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# LLM function parameter tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxLLMFunc:
+    """Verify correct parameters are passed to openai_complete_if_cache."""
+
+    @pytest.mark.asyncio
+    async def test_correct_base_url(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "response"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("test")
+        assert captured["base_url"] == "https://api.minimax.io/v1"
+
+    @pytest.mark.asyncio
+    async def test_correct_model_name(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured["model"] = model
+            return "response"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("test")
+        assert captured["model"] == "MiniMax-M2.7"
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_passed_through(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "response"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("user msg", system_prompt="Be concise.")
+        assert captured["system_prompt"] == "Be concise."
+
+    @pytest.mark.asyncio
+    async def test_history_messages_defaults_to_empty(self):
+        mod, _ = _load_example()
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "response"
+
+        mod.openai_complete_if_cache = mock_complete
+        await mod.minimax_llm_model_func("test")
+        assert captured["history_messages"] == []
+
+    @pytest.mark.asyncio
+    async def test_api_key_passed(self):
+        mod, _ = _load_example({"MINIMAX_API_KEY": "sk-secret"})
+        captured = {}
+
+        async def mock_complete(model, prompt, **kwargs):
+            captured.update(kwargs)
+            return "response"
+
+        mod.openai_complete_if_cache = mock_complete
+        mod.MINIMAX_API_KEY = "sk-secret"
+        await mod.minimax_llm_model_func("test")
+        assert captured["api_key"] == "sk-secret"
+
+
+# ---------------------------------------------------------------------------
+# Integration class tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxRAGIntegration:
+    """Tests for the MiniMaxRAGIntegration helper class."""
+
+    def test_default_model_name(self):
+        mod, _ = _load_example()
+        integration = mod.MiniMaxRAGIntegration()
+        assert integration.model_name == "MiniMax-M2.7"
+
+    def test_default_base_url(self):
+        mod, _ = _load_example()
+        integration = mod.MiniMaxRAGIntegration()
+        assert integration.base_url == "https://api.minimax.io/v1"
+
+    def test_config_is_created(self):
+        mod, _ = _load_example()
+        integration = mod.MiniMaxRAGIntegration()
+        assert integration.config is not None
+
+    def test_rag_starts_as_none(self):
+        mod, _ = _load_example()
+        integration = mod.MiniMaxRAGIntegration()
+        assert integration.rag is None
+
+    @pytest.mark.asyncio
+    async def test_connection_fails_without_api_key(self):
+        mod, _ = _load_example()
+        integration = mod.MiniMaxRAGIntegration()
+        integration.api_key = ""
+        result = await integration.test_connection()
+        assert result is False


### PR DESCRIPTION
## Summary

- Add `examples/minimax_integration_example.py` showing how to use MiniMax as the LLM backend for RAG-Anything, following the same pattern as the existing Ollama and LM Studio examples
- Support **MiniMax-M2.7** and **MiniMax-M2.7-highspeed** models via MiniMax's OpenAI-compatible API (`https://api.minimax.io/v1`)
- Enforce MiniMax's temperature constraint `(0.0, 1.0]` (defaults to `1.0`)
- Add unit tests (`tests/test_minimax_integration.py`) covering configuration, temperature enforcement, model/URL defaults, and API parameter passing

## Usage

```python
from raganything import RAGAnything, RAGAnythingConfig
from lightrag.llm.openai import openai_complete_if_cache, openai_embed
from lightrag.utils import EmbeddingFunc

async def minimax_llm_model_func(prompt, system_prompt=None, history_messages=[], **kwargs):
    kwargs.setdefault("temperature", 1.0)  # MiniMax requires (0.0, 1.0]
    return await openai_complete_if_cache(
        model="MiniMax-M2.7",
        prompt=prompt,
        system_prompt=system_prompt,
        history_messages=history_messages,
        base_url="https://api.minimax.io/v1",
        api_key=os.getenv("MINIMAX_API_KEY"),
        **kwargs,
    )
```

Or run the complete example:

```bash
export MINIMAX_API_KEY=your-api-key
python examples/minimax_integration_example.py
```

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `MINIMAX_API_KEY` | — | MiniMax API key (required) |
| `MINIMAX_BASE_URL` | `https://api.minimax.io/v1` | API base URL |
| `MINIMAX_LLM_MODEL` | `MiniMax-M2.7` | Model ID |

> **Note**: MiniMax does not provide an embedding model. A separate embedding service (e.g. OpenAI, Ollama) is required for the embedding function.

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api