### PR TITLE
fix: forward system_prompt parameter in aquery_with_multimodal

### DIFF
--- a/raganything/query.py
+++ b/raganything/query.py
@@ -165,6 +165,7 @@ class QueryMixin:
         query: str,
         multimodal_content: List[Dict[str, Any]] = None,
         mode: str = "mix",
+        system_prompt: str | None = None,
         **kwargs,
     ) -> str:
         """
@@ -212,7 +213,7 @@ class QueryMixin:
         # If no multimodal content, fallback to pure text query
         if not multimodal_content:
             self.logger.info("No multimodal content provided, executing text query")
-            return await self.aquery(query, mode=mode, **kwargs)
+            return await self.aquery(query, mode=mode, system_prompt=system_prompt, **kwargs)
 
         # Generate cache key for multimodal query
         cache_key = self._generate_multimodal_cache_key(
@@ -254,7 +255,7 @@ class QueryMixin:
         )
 
         # Execute enhanced query
-        result = await self.aquery(enhanced_query, mode=mode, **kwargs)
+        result = await self.aquery(enhanced_query, mode=mode, system_prompt=system_prompt, **kwargs)
 
         # Save to cache if available and enabled
         if (


### PR DESCRIPTION
## Bug Description

The `aquery_with_multimodal` method in `raganything/query.py` lacks an explicit `system_prompt` parameter. While `**kwargs` captures extra arguments, `system_prompt` is never forwarded to the inner `aquery()` calls within the method. This means callers cannot use a custom system prompt with the multimodal variant.

## Steps to Reproduce

```python
result = await rag.aquery_with_multimodal(
    "Describe this image",
    multimodal_content=[{"type": "image", "img_path": "./img.png"}],
    system_prompt="You are an expert image analyst."
)
# system_prompt is silently ignored
```

## Fix

Add `system_prompt: str | None = None` to the `aquery_with_multimodal` method signature and explicitly forward it to all inner `aquery()` calls:

1. Line ~165: Added `system_prompt: str | None = None` parameter
2. Line ~215: Forward to fallback `aquery()` call when no multimodal content
3. Line ~258: Forward to main `aquery()` call after processing multimodal content

Fixes #257

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithOutRoof