### PR TITLE
fix(__init__): remove duplicate `__all__` assignment

### DIFF
--- a/raganything/__init__.py
+++ b/raganything/__init__.py
@@ -61,8 +61,6 @@ __version__ = "1.2.10"
 __author__ = "Zirui Guo"
 __url__ = "https://github.com/HKUDS/RAG-Anything"
 
-__all__ = ["RAGAnything", "RAGAnythingConfig"]
-
 __all__ = [
     "RAGAnything",
     "RAGAnythingConfig",


### PR DESCRIPTION
## Summary

Removes the dead-code first `__all__` assignment that is immediately overwritten by the second, more complete one.

Static-analysis tools (ruff, mypy) flag this reassignment as a warning, and it causes unnecessary confusion for contributors reading the file.

## Changes

- `raganything/__init__.py`: remove the redundant `__all__ = ["RAGAnything", "RAGAnythingConfig"]` line (keeping the second, full definition).

Closes #267

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>