### PR TITLE
Preserve content list aliases in multimodal chunks

### DIFF
--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -28,6 +28,12 @@ from lightrag.operate import extract_entities, merge_nodes_and_edges
 
 # Import prompt templates
 from raganything.prompt import PROMPTS
+from raganything.utils import (
+    format_table_body,
+    get_equation_text_and_format,
+    get_table_body,
+    normalize_caption_list,
+)
 
 
 @dataclass
@@ -1094,9 +1100,9 @@ class TableModalProcessor(BaseModalProcessor):
                 content_data = modal_content
 
             table_img_path = content_data.get("img_path")
-            table_caption = content_data.get("table_caption", [])
-            table_body = content_data.get("table_body", "")
-            table_footnote = content_data.get("table_footnote", [])
+            table_caption = normalize_caption_list(content_data.get("table_caption"))
+            table_body = format_table_body(get_table_body(content_data))
+            table_footnote = normalize_caption_list(content_data.get("table_footnote"))
 
             # Extract context for current item
             context = ""
@@ -1181,9 +1187,9 @@ class TableModalProcessor(BaseModalProcessor):
                 content_data = modal_content
 
             table_img_path = content_data.get("img_path")
-            table_caption = content_data.get("table_caption", [])
-            table_body = content_data.get("table_body", "")
-            table_footnote = content_data.get("table_footnote", [])
+            table_caption = normalize_caption_list(content_data.get("table_caption"))
+            table_body = format_table_body(get_table_body(content_data))
+            table_footnote = normalize_caption_list(content_data.get("table_footnote"))
 
             # Build complete table content
             modal_chunk = PROMPTS["table_chunk"].format(
@@ -1288,8 +1294,7 @@ class EquationModalProcessor(BaseModalProcessor):
             else:
                 content_data = modal_content
 
-            equation_text = content_data.get("text")
-            equation_format = content_data.get("text_format", "")
+            equation_text, equation_format = get_equation_text_and_format(content_data)
 
             # Extract context for current item
             context = ""
@@ -1369,8 +1374,7 @@ class EquationModalProcessor(BaseModalProcessor):
             else:
                 content_data = modal_content
 
-            equation_text = content_data.get("text")
-            equation_format = content_data.get("text_format", "")
+            equation_text, equation_format = get_equation_text_and_format(content_data)
 
             # Build complete equation content
             modal_chunk = PROMPTS["equation_chunk"].format(

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -18,6 +18,10 @@ from raganything.utils import (
     insert_text_content,
     insert_text_content_with_multimodal_content,
     get_processor_for_type,
+    format_table_body,
+    get_equation_text_and_format,
+    get_table_body,
+    normalize_caption_list,
 )
 import asyncio
 from lightrag.utils import compute_mdhash_id
@@ -756,7 +760,7 @@ class ProcessorMixin:
                     # Prepare item info for context extraction
                     item_info = {
                         "page_idx": item.get("page_idx", 0),
-                        "index": i,
+                        "index": item.get("_content_list_index", i),
                         "type": content_type,
                     }
 
@@ -934,7 +938,7 @@ class ProcessorMixin:
 
                     item_info = {
                         "page_idx": item.get("page_idx", 0),
-                        "index": index,
+                        "index": item.get("_content_list_index", index),
                         "type": content_type,
                     }
 
@@ -1119,11 +1123,15 @@ class ProcessorMixin:
         try:
             if content_type == "image":
                 image_path = original_item.get("img_path", "")
-                captions = original_item.get(
-                    "image_caption", original_item.get("img_caption", [])
+                captions = normalize_caption_list(
+                    original_item.get(
+                        "image_caption", original_item.get("img_caption", [])
+                    )
                 )
-                footnotes = original_item.get(
-                    "image_footnote", original_item.get("img_footnote", [])
+                footnotes = normalize_caption_list(
+                    original_item.get(
+                        "image_footnote", original_item.get("img_footnote", [])
+                    )
                 )
 
                 return PROMPTS["image_chunk"].format(
@@ -1135,9 +1143,13 @@ class ProcessorMixin:
 
             elif content_type == "table":
                 table_img_path = original_item.get("img_path", "")
-                table_caption = original_item.get("table_caption", [])
-                table_body = original_item.get("table_body", "")
-                table_footnote = original_item.get("table_footnote", [])
+                table_caption = normalize_caption_list(
+                    original_item.get("table_caption", [])
+                )
+                table_body = format_table_body(get_table_body(original_item))
+                table_footnote = normalize_caption_list(
+                    original_item.get("table_footnote", [])
+                )
 
                 return PROMPTS["table_chunk"].format(
                     table_img_path=table_img_path,
@@ -1150,8 +1162,9 @@ class ProcessorMixin:
                 )
 
             elif content_type == "equation":
-                equation_text = original_item.get("text", "")
-                equation_format = original_item.get("text_format", "")
+                equation_text, equation_format = get_equation_text_and_format(
+                    original_item
+                )
 
                 return PROMPTS["equation_chunk"].format(
                     equation_text=equation_text,

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -32,34 +32,58 @@ def get_table_body(item: Dict[str, Any]) -> Any:
 
 
 def format_table_body(table_body: Any) -> str:
-    """Serialize table content for prompts and chunks without dropping aliases."""
+    """Serialize table content for prompts and chunks without dropping aliases.
+
+    Strings are passed through unchanged. List-of-lists (the common
+    ``table_data`` shape from non-MinerU parsers) are rendered as a simple
+    Markdown table so the LLM sees structured rows instead of a Python repr.
+    Other shapes fall back to a newline-joined string of ``str(...)`` items.
+    """
     if isinstance(table_body, str):
         return table_body
+    if isinstance(table_body, list):
+        if not table_body:
+            return ""
+        if all(isinstance(row, (list, tuple)) for row in table_body):
+            rendered_rows = [
+                "| " + " | ".join(str(cell) for cell in row) + " |"
+                for row in table_body
+            ]
+            if len(rendered_rows) >= 1:
+                column_count = max(len(row) for row in table_body)
+                separator = "| " + " | ".join(["---"] * column_count) + " |"
+                rendered_rows.insert(1, separator)
+            return "\n".join(rendered_rows)
+        return "\n".join(str(row) for row in table_body)
     return str(table_body)
 
 
 def get_equation_text_and_format(item: Dict[str, Any]) -> Tuple[str, str]:
-    """Read equation content while preserving LaTeX aliases from content lists."""
+    """Read equation content while preserving LaTeX aliases from content lists.
+
+    Field priority follows MinerU first (``text`` + ``text_format``), then
+    falls back to ``latex`` and ``equation`` aliases used by other parsers.
+    The textual description is intentionally NOT concatenated into the
+    equation body: the ``equation_chunk`` template has a separate
+    ``enhanced_caption`` slot for that.
+    """
     text = str(item.get("text", "") or "").strip()
     latex = str(item.get("latex", "") or "").strip()
     equation = str(item.get("equation", "") or "").strip()
     equation_format = str(item.get("text_format", "") or "").strip()
 
-    parts = []
-    if latex:
-        parts.append(latex)
+    if text:
+        equation_text = text
+    elif latex:
+        equation_text = latex
         if not equation_format:
-            equation_format = "LaTeX"
+            equation_format = "latex"
     elif equation:
-        parts.append(equation)
+        equation_text = equation
+    else:
+        equation_text = ""
 
-    if text and text not in parts:
-        if parts:
-            parts.append(f"Description: {text}")
-        else:
-            parts.append(text)
-
-    return "\n".join(parts), equation_format
+    return equation_text, equation_format
 
 
 def separate_content(

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -11,6 +11,57 @@ from pathlib import Path
 from lightrag.utils import logger
 
 
+def normalize_caption_list(value: Any) -> List[str]:
+    """Return captions and footnotes as a clean list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def get_table_body(item: Dict[str, Any]) -> Any:
+    """Read table content across common content-list alias fields."""
+    if item.get("table_body") not in (None, ""):
+        return item.get("table_body")
+    if item.get("table_data") not in (None, ""):
+        return item.get("table_data")
+    return item.get("text", "")
+
+
+def format_table_body(table_body: Any) -> str:
+    """Serialize table content for prompts and chunks without dropping aliases."""
+    if isinstance(table_body, str):
+        return table_body
+    return str(table_body)
+
+
+def get_equation_text_and_format(item: Dict[str, Any]) -> Tuple[str, str]:
+    """Read equation content while preserving LaTeX aliases from content lists."""
+    text = str(item.get("text", "") or "").strip()
+    latex = str(item.get("latex", "") or "").strip()
+    equation = str(item.get("equation", "") or "").strip()
+    equation_format = str(item.get("text_format", "") or "").strip()
+
+    parts = []
+    if latex:
+        parts.append(latex)
+        if not equation_format:
+            equation_format = "LaTeX"
+    elif equation:
+        parts.append(equation)
+
+    if text and text not in parts:
+        if parts:
+            parts.append(f"Description: {text}")
+        else:
+            parts.append(text)
+
+    return "\n".join(parts), equation_format
+
+
 def separate_content(
     content_list: List[Dict[str, Any]],
 ) -> Tuple[str, List[Dict[str, Any]]]:
@@ -26,7 +77,7 @@ def separate_content(
     text_parts = []
     multimodal_items = []
 
-    for item in content_list:
+    for index, item in enumerate(content_list):
         content_type = item.get("type", "text")
 
         if content_type == "text":
@@ -36,7 +87,9 @@ def separate_content(
                 text_parts.append(text)
         else:
             # Multimodal content (image, table, equation, etc.)
-            multimodal_items.append(item)
+            multimodal_item = dict(item)
+            multimodal_item.setdefault("_content_list_index", index)
+            multimodal_items.append(multimodal_item)
 
     # Merge all text content
     text_content = "\n\n".join(text_parts)

--- a/tests/test_content_list_alias_handling.py
+++ b/tests/test_content_list_alias_handling.py
@@ -1,0 +1,132 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+def install_import_stubs():
+    lightrag_module = types.ModuleType("lightrag")
+    lightrag_utils = types.ModuleType("lightrag.utils")
+    lightrag_utils.logger = FakeLogger()
+    lightrag_utils.compute_mdhash_id = lambda value, prefix="": f"{prefix}test"
+
+    raganything_pkg = types.ModuleType("raganything")
+    raganything_pkg.__path__ = [str(PROJECT_ROOT / "raganything")]
+
+    raganything_base = types.ModuleType("raganything.base")
+
+    raganything_parser = types.ModuleType("raganything.parser")
+    raganything_parser.MineruParser = object
+    raganything_parser.MineruExecutionError = RuntimeError
+    raganything_parser.get_parser = lambda *args, **kwargs: None
+
+    sys.modules.setdefault("lightrag", lightrag_module)
+    sys.modules.setdefault("lightrag.utils", lightrag_utils)
+    sys.modules.setdefault("raganything", raganything_pkg)
+    sys.modules.setdefault("raganything.base", raganything_base)
+    sys.modules.setdefault("raganything.parser", raganything_parser)
+    raganything_base.DocStatus = types.SimpleNamespace(
+        READY="ready",
+        HANDLING="handling",
+        PENDING="pending",
+        PROCESSING="processing",
+        PROCESSED="processed",
+        FAILED="failed",
+    )
+
+
+def load_project_module(module_name, path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+install_import_stubs()
+utils_module = load_project_module(
+    "raganything.utils", PROJECT_ROOT / "raganything" / "utils.py"
+)
+processor_module = load_project_module(
+    "raganything.processor", PROJECT_ROOT / "raganything" / "processor.py"
+)
+
+ProcessorMixin = processor_module.ProcessorMixin
+format_table_body = utils_module.format_table_body
+get_equation_text_and_format = utils_module.get_equation_text_and_format
+get_table_body = utils_module.get_table_body
+normalize_caption_list = utils_module.normalize_caption_list
+separate_content = utils_module.separate_content
+
+
+class ContentListAliasHandlingTests(unittest.TestCase):
+    def test_separate_content_preserves_original_content_list_index(self):
+        content = [
+            {"type": "text", "text": "Before"},
+            {"type": "image", "img_path": "/tmp/figure.png"},
+            {"type": "text", "text": "After"},
+            {"type": "table", "table_body": "| A | B |"},
+        ]
+
+        _, multimodal = separate_content(content)
+
+        self.assertEqual([item["_content_list_index"] for item in multimodal], [1, 3])
+        self.assertNotIn("_content_list_index", content[1])
+
+    def test_table_alias_and_string_caption_feed_chunk_template(self):
+        processor = ProcessorMixin()
+        chunk = processor._apply_chunk_template(
+            "table",
+            {
+                "table_data": [["Method", "Score"], ["RAGAnything", "95.2"]],
+                "table_caption": "Performance table",
+                "table_footnote": "Synthetic example",
+            },
+            "The table compares scores.",
+        )
+
+        self.assertEqual(get_table_body({"table_data": [["A", "B"]]}), [["A", "B"]])
+        self.assertEqual(format_table_body([["A", "B"]]), "[['A', 'B']]")
+        self.assertEqual(normalize_caption_list("Performance table"), ["Performance table"])
+        self.assertIn("['Method', 'Score']", chunk)
+        self.assertIn("Performance table", chunk)
+        self.assertNotIn("P, e, r, f", chunk)
+        self.assertIn("Synthetic example", chunk)
+
+    def test_equation_latex_alias_is_not_dropped_from_chunk_template(self):
+        processor = ProcessorMixin()
+        item = {
+            "latex": "E = mc^2",
+            "text": "Mass-energy equivalence",
+        }
+
+        equation_text, equation_format = get_equation_text_and_format(item)
+        chunk = processor._apply_chunk_template("equation", item, "A physics equation.")
+
+        self.assertEqual(equation_text, "E = mc^2\nDescription: Mass-energy equivalence")
+        self.assertEqual(equation_format, "LaTeX")
+        self.assertIn("E = mc^2", chunk)
+        self.assertIn("Mass-energy equivalence", chunk)
+        self.assertIn("Format: LaTeX", chunk)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_content_list_alias_handling.py
+++ b/tests/test_content_list_alias_handling.py
@@ -104,28 +104,43 @@ class ContentListAliasHandlingTests(unittest.TestCase):
         )
 
         self.assertEqual(get_table_body({"table_data": [["A", "B"]]}), [["A", "B"]])
-        self.assertEqual(format_table_body([["A", "B"]]), "[['A', 'B']]")
-        self.assertEqual(normalize_caption_list("Performance table"), ["Performance table"])
-        self.assertIn("['Method', 'Score']", chunk)
+        self.assertEqual(
+            format_table_body([["A", "B"], ["C", "D"]]),
+            "| A | B |\n| --- | --- |\n| C | D |",
+        )
+        self.assertEqual(format_table_body("| A | B |"), "| A | B |")
+        self.assertEqual(
+            normalize_caption_list("Performance table"), ["Performance table"]
+        )
+        self.assertIn("| Method | Score |", chunk)
+        self.assertIn("| RAGAnything | 95.2 |", chunk)
         self.assertIn("Performance table", chunk)
         self.assertNotIn("P, e, r, f", chunk)
         self.assertIn("Synthetic example", chunk)
 
     def test_equation_latex_alias_is_not_dropped_from_chunk_template(self):
         processor = ProcessorMixin()
-        item = {
-            "latex": "E = mc^2",
-            "text": "Mass-energy equivalence",
-        }
 
-        equation_text, equation_format = get_equation_text_and_format(item)
-        chunk = processor._apply_chunk_template("equation", item, "A physics equation.")
+        text_item = {"text": "E = mc^2", "text_format": "latex"}
+        equation_text, equation_format = get_equation_text_and_format(text_item)
+        self.assertEqual(equation_text, "E = mc^2")
+        self.assertEqual(equation_format, "latex")
 
-        self.assertEqual(equation_text, "E = mc^2\nDescription: Mass-energy equivalence")
-        self.assertEqual(equation_format, "LaTeX")
+        latex_only_item = {"latex": "E = mc^2"}
+        equation_text, equation_format = get_equation_text_and_format(latex_only_item)
+        self.assertEqual(equation_text, "E = mc^2")
+        self.assertEqual(equation_format, "latex")
+
+        chunk = processor._apply_chunk_template(
+            "equation", latex_only_item, "A physics equation."
+        )
         self.assertIn("E = mc^2", chunk)
-        self.assertIn("Mass-energy equivalence", chunk)
-        self.assertIn("Format: LaTeX", chunk)
+        self.assertIn("Format: latex", chunk)
+        self.assertIn("A physics equation.", chunk)
+
+        equation_alias_item = {"equation": "x^2 + y^2 = 1"}
+        equation_text, _ = get_equation_text_and_format(equation_alias_item)
+        self.assertEqual(equation_text, "x^2 + y^2 = 1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR makes direct `content_list` multimodal processing preserve common alias fields instead of silently dropping or misformatting them.

Changes:

- preserve each multimodal item's original `content_list` index after text items are separated, so context lookup still points at the original surrounding items
- normalize string/list caption and footnote fields before joining them into image/table chunks
- read table content from `table_body`, `table_data`, or `text`
- read equation content from `text`, `latex`, or `equation`, and infer `LaTeX` format when only `latex` is provided
- add an offline regression test for these alias-handling cases

## Why

The direct `content_list` path can receive pre-parsed multimodal items whose field names differ slightly by source. In that path, a table that only has `table_data` can produce an empty table body, an equation that only has `latex` can lose its formula text, and a string caption can be joined character-by-character.

The same path also separates text and multimodal items before later context extraction. Without preserving the original item index, context lookup can point to the compacted multimodal list position instead of the original `content_list` position.

## Validation

From the repo root:

```bash
python3 -m py_compile raganything/utils.py raganything/processor.py raganything/modalprocessors.py tests/test_content_list_alias_handling.py
python3 -m unittest tests/test_content_list_alias_handling.py
git diff --check
```

The targeted unittest covers:

- original `content_list` index preservation
- string caption normalization for table chunks
- `table_data` alias preservation
- `latex` equation alias preservation

## Scope / limits

This PR does not change parsers, model calls, retrieval behavior, or prompt templates. It only normalizes already-parsed multimodal item fields before building prompts/chunks.
