### PR TITLE
docs + optional public asset URLs (failure modes, #272)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,23 @@ PARSE_METHOD=auto              # Parse method: auto, ocr, or txt
 
 > **Note**: API keys are only required for full RAG processing with LLM integration. The parsing test files (`office_document_test.py` and `image_format_test.py`) only test parser functionality and do not require API keys.
 
+### Troubleshooting and multimodal checklist
+
+- See **[docs/multimodal_rag_failure_modes.md](docs/multimodal_rag_failure_modes.md)** for a short checklist of common pipeline issues (OCR, tables, retrieval bias, debugging tips). Related: [#207](https://github.com/HKUDS/RAG-Anything/issues/207), [#213](https://github.com/HKUDS/RAG-Anything/issues/213).
+
+### Public media URLs (CDN / object storage)
+
+When ingestion runs on a server but your UI or another service needs **HTTPS** (or S3-style) links to figures, set:
+
+```bash
+# Base URL for assets (no trailing slash required)
+RAGANYTHING_PUBLIC_ASSET_BASE_URL=https://my-bucket.s3.us-east-1.amazonaws.com/prefix
+# Filesystem root that should be stripped from absolute paths under that tree
+RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX=/var/rag/output
+```
+
+After parsing, each non-empty `img_path`, `table_img_path`, or `equation_img_path` may gain a sibling field `*_public_url` while the original path stays on disk for local processing. See [#272](https://github.com/HKUDS/RAG-Anything/issues/272).
+
 ### Parser Configuration
 
 RAGAnything now supports multiple parsers, each with specific advantages:

--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,8 @@ RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX=/var/rag/output
 
 After parsing, each non-empty `img_path`, `table_img_path`, or `equation_img_path` may gain a sibling field `*_public_url` while the original path stays on disk for local processing. See [#272](https://github.com/HKUDS/RAG-Anything/issues/272).
 
+> **Scope today**: this mapping runs in the MinerU parser path only. Other parsers (e.g. Docling) keep working but will not produce `*_public_url` fields until the helper is wired into their content_list post-processing as well. If only one of the two env vars is set, RAG-Anything logs a warning and skips URL attachment.
+
 ### Parser Configuration
 
 RAGAnything now supports multiple parsers, each with specific advantages:

--- a/docs/multimodal_rag_failure_modes.md
+++ b/docs/multimodal_rag_failure_modes.md
@@ -1,0 +1,84 @@
+# Multimodal RAG: common failure modes and quick checks
+
+Real-world PDFs and Office files are noisy. RAG-Anything (MinerU / Docling / etc.) usually does the right thing, but when something feels “off”, this page is a **short sanity checklist** before opening an issue.
+
+It is meant to stay small and easy to maintain (see discussion in [#207](https://github.com/HKUDS/RAG-Anything/issues/207) and [#213](https://github.com/HKUDS/RAG-Anything/issues/213)).
+
+---
+
+## 1. OCR or layout silently corrupts text
+
+**Symptoms:** answers quote nonsense, wrong numbers, or mixed columns.
+
+**Quick checks:**
+
+- Open the parser’s Markdown or `*_content_list.json` for the same page and eyeball a few paragraphs.
+- Compare with the source PDF zoomed in (sometimes OCR confuses `l`/`1`, ligatures, or watermarks).
+
+---
+
+## 2. Table structure lost during preprocessing
+
+**Symptoms:** merged cells, tables shown as plain lines, or wrong row order.
+
+**Quick checks:**
+
+- Find the `type: table` blocks in `content_list` and see if `table_body` / structure fields look plausible.
+- If you only need retrieval, sometimes a **flattened** table is acceptable; if you need exact structure, try another parse method or parser (`PARSE_METHOD`, `PARSER` in `.env`).
+
+---
+
+## 3. Image ↔ caption misalignment
+
+**Symptoms:** captions match the wrong figure, or images appear in the wrong order.
+
+**Quick checks:**
+
+- Confirm `img_path` / captions exist in `content_list` and that page indices look consistent.
+- For DOCX pipelines, remember that exporting to PDF for OCR can **drop inline math**; OMML helpers in recent versions exist specifically to recover equations from the original Word file.
+
+---
+
+## 4. Retrieval biased toward text (image/table ignored)
+
+**Symptoms:** the answer clearly needs a figure or table, but only text chunks rank high.
+
+**Quick checks:**
+
+- Run a **probe question** that can only be answered from an image or table (not from surrounding text).
+- Inspect whether multimodal stages ran (`ENABLE_*_PROCESSING` flags) and whether your embedding path actually sees the enriched text (not only raw OCR).
+
+---
+
+## 5. “Everything’s slow” vs “stuck”
+
+**Symptoms:** long runs, high CPU/GPU.
+
+**Quick checks:**
+
+- [#48](https://github.com/HKUDS/RAG-Anything/issues/48) style: large PDFs and OCR are inherently heavy—batch size and hardware matter.
+- Distinguish **slow but progressing** from a **hang** (then check subprocess timeouts, MinerU/Docling logs, and disk space).
+
+---
+
+## 6. Images not loading in your UI after indexing
+
+**Symptoms:** chunks reference paths that only exist on the machine that ingested the data.
+
+**Quick checks:**
+
+- Absolute local paths are normal for processing on one host. For a browser or another server, set **public URL mapping** (environment variables `RAGANYTHING_PUBLIC_ASSET_BASE_URL` and `RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX` — see the main [README](../README.md)) so each chunk can carry an `*_public_url` field alongside the local path.
+
+---
+
+## When you open an issue
+
+Including the items below speeds up triage:
+
+- Which **modality** failed (text / image / table / equation).
+- Which **parser** and **`PARSE_METHOD`** you used.
+- A **minimal** file (or a redacted excerpt) and one **query** that misbehaves.
+
+---
+
+*This document is intentionally short. If you expand it, prefer adding links to reproducible examples rather than long narratives.*

--- a/docs/multimodal_rag_failure_modes.md
+++ b/docs/multimodal_rag_failure_modes.md
@@ -67,7 +67,7 @@ It is meant to stay small and easy to maintain (see discussion in [#207](https:/
 
 **Quick checks:**
 
-- Absolute local paths are normal for processing on one host. For a browser or another server, set **public URL mapping** (environment variables `RAGANYTHING_PUBLIC_ASSET_BASE_URL` and `RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX` — see the main [README](../README.md)) so each chunk can carry an `*_public_url` field alongside the local path.
+- Absolute local paths are normal for processing on one host. For a browser or another server, set **public URL mapping** (environment variables `RAGANYTHING_PUBLIC_ASSET_BASE_URL` and `RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX` — see the main [README](../README.md)) so each chunk can carry an `*_public_url` field alongside the local path. Today this mapping only runs in the MinerU parser path; other parsers will not yet produce `*_public_url`.
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -64,6 +64,11 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 # CONTEXT_FILTER_CONTENT_TYPES=text
 # CONTENT_FORMAT=minerU
 
+### Public media URLs (optional, for CDNs or S3-hosted assets after ingest)
+# Set both so parsed content_list items get *_public_url fields alongside local img_path.
+# RAGANYTHING_PUBLIC_ASSET_BASE_URL=https://my-bucket.s3.amazonaws.com/prefix
+# RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX=/absolute/path/to/sync/root
+
 ### Max nodes return from grap retrieval
 # MAX_GRAPH_NODES=1000
 

--- a/raganything/asset_urls.py
+++ b/raganything/asset_urls.py
@@ -4,12 +4,20 @@ Optional mapping of local absolute media paths to public URLs (HTTPS, CDN, S3, e
 Implements the environment-variable contract described in docs and README:
 when ingestion runs on a server but retrieval/UI runs elsewhere, stored paths
 must remain valid locally while a parallel public URL can be shown to clients.
+
+NOTE: ``attach_public_media_urls`` is currently invoked from the MinerU
+parser path only. Other parsers (e.g. Docling) will not yield
+``*_public_url`` fields until this helper is wired into their content_list
+post-processing too.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # content_list fields that hold filesystem paths to raster or figure assets
 MEDIA_PATH_FIELDS: tuple[str, ...] = (
@@ -17,6 +25,18 @@ MEDIA_PATH_FIELDS: tuple[str, ...] = (
     "table_img_path",
     "equation_img_path",
 )
+
+# Track which misconfiguration shape we have already warned about so we don't
+# spam the log once per content_list item. Reset whenever the env state goes
+# back to either "fully unset" or "fully set".
+_MISCONFIG_WARNED: set[str] = set()
+
+
+def _resolve_strip_prefix(strip_prefix: str) -> Path | None:
+    try:
+        return Path(strip_prefix).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return None
 
 
 def public_url_for_local_path(
@@ -31,9 +51,11 @@ def public_url_for_local_path(
     """
     if not local_abs or not base_url or not strip_prefix:
         return None
+    root = _resolve_strip_prefix(strip_prefix)
+    if root is None:
+        return None
     try:
         abs_path = Path(local_abs).resolve()
-        root = Path(strip_prefix).expanduser().resolve()
         rel = abs_path.relative_to(root)
     except (ValueError, OSError, RuntimeError):
         return None
@@ -48,11 +70,36 @@ def attach_public_media_urls(item: dict) -> None:
 
     Existing ``img_path`` / ``table_img_path`` / ``equation_img_path`` values
     are left unchanged so local file-based pipelines keep working.
+
+    If only one of the two env vars is set, the function logs a single
+    warning and returns without mutating ``item``.
     """
     base = os.environ.get("RAGANYTHING_PUBLIC_ASSET_BASE_URL", "").strip()
     strip = os.environ.get("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", "").strip()
-    if not base or not strip:
+
+    if not base and not strip:
+        _MISCONFIG_WARNED.clear()
         return
+    if base and not strip:
+        if "base_only" not in _MISCONFIG_WARNED:
+            logger.warning(
+                "RAGANYTHING_PUBLIC_ASSET_BASE_URL is set but "
+                "RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX is not; "
+                "skipping public URL attachment."
+            )
+            _MISCONFIG_WARNED.add("base_only")
+        return
+    if strip and not base:
+        if "strip_only" not in _MISCONFIG_WARNED:
+            logger.warning(
+                "RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX is set but "
+                "RAGANYTHING_PUBLIC_ASSET_BASE_URL is not; "
+                "skipping public URL attachment."
+            )
+            _MISCONFIG_WARNED.add("strip_only")
+        return
+    _MISCONFIG_WARNED.clear()
+
     if not isinstance(item, dict):
         return
 

--- a/raganything/asset_urls.py
+++ b/raganything/asset_urls.py
@@ -1,0 +1,70 @@
+"""
+Optional mapping of local absolute media paths to public URLs (HTTPS, CDN, S3, etc.).
+
+Implements the environment-variable contract described in docs and README:
+when ingestion runs on a server but retrieval/UI runs elsewhere, stored paths
+must remain valid locally while a parallel public URL can be shown to clients.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# content_list fields that hold filesystem paths to raster or figure assets
+MEDIA_PATH_FIELDS: tuple[str, ...] = (
+    "img_path",
+    "table_img_path",
+    "equation_img_path",
+)
+
+
+def public_url_for_local_path(
+    local_abs: str,
+    *,
+    base_url: str,
+    strip_prefix: str,
+) -> str | None:
+    """
+    Build ``https://.../relative/path`` from a local absolute path by stripping
+    a known filesystem root and appending the remainder to ``base_url``.
+    """
+    if not local_abs or not base_url or not strip_prefix:
+        return None
+    try:
+        abs_path = Path(local_abs).resolve()
+        root = Path(strip_prefix).expanduser().resolve()
+        rel = abs_path.relative_to(root)
+    except (ValueError, OSError, RuntimeError):
+        return None
+    return f"{base_url.rstrip('/')}/{rel.as_posix()}"
+
+
+def attach_public_media_urls(item: dict) -> None:
+    """
+    If ``RAGANYTHING_PUBLIC_ASSET_BASE_URL`` and
+    ``RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX`` are both set, add
+    ``<field>_public_url`` for each non-empty media path field.
+
+    Existing ``img_path`` / ``table_img_path`` / ``equation_img_path`` values
+    are left unchanged so local file-based pipelines keep working.
+    """
+    base = os.environ.get("RAGANYTHING_PUBLIC_ASSET_BASE_URL", "").strip()
+    strip = os.environ.get("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", "").strip()
+    if not base or not strip:
+        return
+    if not isinstance(item, dict):
+        return
+
+    for field in MEDIA_PATH_FIELDS:
+        raw = item.get(field)
+        if not raw or not isinstance(raw, str):
+            continue
+        s = raw.strip()
+        if not s:
+            continue
+        if s.startswith(("http://", "https://", "s3://")):
+            continue
+        url = public_url_for_local_path(s, base_url=base, strip_prefix=strip)
+        if url:
+            item[f"{field}_public_url"] = url

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -49,6 +49,8 @@ from typing import (
     Iterator,
 )
 
+from raganything.asset_urls import attach_public_media_urls
+
 _IS_WINDOWS: bool = platform.system() == "Windows"
 
 
@@ -1065,6 +1067,8 @@ class MineruParser(Parser):
                                     continue
 
                                 item[field_name] = str(absolute_img_path)
+
+                        attach_public_media_urls(item)
 
             except Exception as e:
                 cls.logger.warning(f"Could not read JSON file {json_file}: {e}")

--- a/tests/test_asset_urls.py
+++ b/tests/test_asset_urls.py
@@ -1,0 +1,75 @@
+"""Tests for optional public URL mapping of local media paths."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "asset_urls",
+    _ROOT / "raganything" / "asset_urls.py",
+)
+assert _SPEC and _SPEC.loader
+_asset_urls = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_asset_urls)
+
+attach_public_media_urls = _asset_urls.attach_public_media_urls
+public_url_for_local_path = _asset_urls.public_url_for_local_path
+MEDIA_PATH_FIELDS = _asset_urls.MEDIA_PATH_FIELDS
+
+
+def test_public_url_builds_from_strip_prefix(tmp_path: Path):
+    root = tmp_path / "out"
+    root.mkdir()
+    img = root / "doc" / "images" / "a.png"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(b"x")
+
+    url = public_url_for_local_path(
+        str(img.resolve()),
+        base_url="https://cdn.example.com/assets",
+        strip_prefix=str(root),
+    )
+    assert url == "https://cdn.example.com/assets/doc/images/a.png"
+
+
+def test_attach_respects_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    root = tmp_path / "bundle"
+    root.mkdir()
+    img = root / "fig.png"
+    img.write_bytes(b"x")
+
+    monkeypatch.setenv(
+        "RAGANYTHING_PUBLIC_ASSET_BASE_URL", "https://bucket.s3.amazonaws.com/proj"
+    )
+    monkeypatch.setenv(
+        "RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", str(root.resolve())
+    )
+
+    item: dict = {"type": "image", "img_path": str(img.resolve())}
+    attach_public_media_urls(item)
+
+    assert item["img_path"] == str(img.resolve())
+    assert (
+        item["img_path_public_url"]
+        == "https://bucket.s3.amazonaws.com/proj/fig.png"
+    )
+
+
+def test_skips_when_already_http(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "RAGANYTHING_PUBLIC_ASSET_BASE_URL", "https://x.com"
+    )
+    monkeypatch.setenv("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", "/var")
+
+    item = {"img_path": "https://cdn/a.png"}
+    attach_public_media_urls(item)
+    assert "img_path_public_url" not in item
+
+
+def test_all_media_fields_documented():
+    # Guardrail so new parser fields stay in sync with attach_public_media_urls
+    assert "img_path" in MEDIA_PATH_FIELDS

--- a/tests/test_asset_urls.py
+++ b/tests/test_asset_urls.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,14 @@ _SPEC.loader.exec_module(_asset_urls)
 attach_public_media_urls = _asset_urls.attach_public_media_urls
 public_url_for_local_path = _asset_urls.public_url_for_local_path
 MEDIA_PATH_FIELDS = _asset_urls.MEDIA_PATH_FIELDS
+_MISCONFIG_WARNED = _asset_urls._MISCONFIG_WARNED
+
+
+@pytest.fixture(autouse=True)
+def _clear_misconfig_state():
+    _MISCONFIG_WARNED.clear()
+    yield
+    _MISCONFIG_WARNED.clear()
 
 
 def test_public_url_builds_from_strip_prefix(tmp_path: Path):
@@ -45,24 +54,17 @@ def test_attach_respects_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setenv(
         "RAGANYTHING_PUBLIC_ASSET_BASE_URL", "https://bucket.s3.amazonaws.com/proj"
     )
-    monkeypatch.setenv(
-        "RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", str(root.resolve())
-    )
+    monkeypatch.setenv("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", str(root.resolve()))
 
     item: dict = {"type": "image", "img_path": str(img.resolve())}
     attach_public_media_urls(item)
 
     assert item["img_path"] == str(img.resolve())
-    assert (
-        item["img_path_public_url"]
-        == "https://bucket.s3.amazonaws.com/proj/fig.png"
-    )
+    assert item["img_path_public_url"] == "https://bucket.s3.amazonaws.com/proj/fig.png"
 
 
 def test_skips_when_already_http(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv(
-        "RAGANYTHING_PUBLIC_ASSET_BASE_URL", "https://x.com"
-    )
+    monkeypatch.setenv("RAGANYTHING_PUBLIC_ASSET_BASE_URL", "https://x.com")
     monkeypatch.setenv("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", "/var")
 
     item = {"img_path": "https://cdn/a.png"}
@@ -73,3 +75,51 @@ def test_skips_when_already_http(monkeypatch: pytest.MonkeyPatch):
 def test_all_media_fields_documented():
     # Guardrail so new parser fields stay in sync with attach_public_media_urls
     assert "img_path" in MEDIA_PATH_FIELDS
+
+
+def test_warns_once_when_only_base_url_is_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    monkeypatch.setenv("RAGANYTHING_PUBLIC_ASSET_BASE_URL", "https://x.com")
+    monkeypatch.delenv("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", raising=False)
+
+    item = {"img_path": "/var/rag/out/a.png"}
+    with caplog.at_level(logging.WARNING, logger="raganything.asset_urls"):
+        attach_public_media_urls(item)
+        attach_public_media_urls(item)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "STRIP_PREFIX" in warnings[0].getMessage()
+    assert "img_path_public_url" not in item
+
+
+def test_warns_once_when_only_strip_prefix_is_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    monkeypatch.delenv("RAGANYTHING_PUBLIC_ASSET_BASE_URL", raising=False)
+    monkeypatch.setenv("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", "/var")
+
+    item = {"img_path": "/var/a.png"}
+    with caplog.at_level(logging.WARNING, logger="raganything.asset_urls"):
+        attach_public_media_urls(item)
+        attach_public_media_urls(item)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "BASE_URL" in warnings[0].getMessage()
+    assert "img_path_public_url" not in item
+
+
+def test_silent_when_neither_env_is_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    monkeypatch.delenv("RAGANYTHING_PUBLIC_ASSET_BASE_URL", raising=False)
+    monkeypatch.delenv("RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX", raising=False)
+
+    item = {"img_path": "/var/a.png"}
+    with caplog.at_level(logging.WARNING, logger="raganything.asset_urls"):
+        attach_public_media_urls(item)
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert "img_path_public_url" not in item


### PR DESCRIPTION
## What this does

- Adds a short **multimodal RAG failure modes** checklist ([#207](https://github.com/HKUDS/RAG-Anything/issues/207), [#213](https://github.com/HKUDS/RAG-Anything/issues/213)) and links it from the README + \env.example\.
- Implements optional **public HTTPS / CDN / S3-style URLs** alongside local MinerU paths ([#272](https://github.com/HKUDS/RAG-Anything/issues/272)): set \RAGANYTHING_PUBLIC_ASSET_BASE_URL\ and \RAGANYTHING_PUBLIC_ASSET_STRIP_PREFIX\ → content list items can get \*_public_url\ fields; filesystem paths stay unchanged for local processing.
- Small unit tests for the URL helper.

Happy to rename fields or adjust the env contract if you prefer another pattern — just say the word.
