### PR TITLE
Fix content-list duplicate detection

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -2141,12 +2141,6 @@ class ProcessorMixin:
             doc_id = self._generate_content_based_doc_id(content_list)
 
         file_ref = self._get_file_reference(file_path)
-        await self._upsert_doc_status(
-            doc_id,
-            file_ref,
-            status=DocStatus.HANDLING,
-            error_msg="",
-        )
 
         # Display content statistics if requested
         if display_stats:
@@ -2167,6 +2161,18 @@ class ProcessorMixin:
 
         # Step 1: Separate text and multimodal content
         text_content, multimodal_items = separate_content(content_list)
+
+        # LightRAG creates the initial doc_status entry during text insertion.
+        # Pre-registering the same doc_id here makes LightRAG treat a fresh
+        # content-list insert as a duplicate, so only create the record up front
+        # for multimodal-only content that will not call ainsert().
+        if not text_content.strip():
+            await self._upsert_doc_status(
+                doc_id,
+                file_ref,
+                status=DocStatus.HANDLING,
+                error_msg="",
+            )
 
         # Step 1.5: Set content source for context extraction in multimodal processing
         if hasattr(self, "set_content_source_for_context") and multimodal_items:
@@ -2194,6 +2200,12 @@ class ProcessorMixin:
                 split_by_character=split_by_character,
                 split_by_character_only=split_by_character_only,
                 ids=doc_id,
+            )
+            await self._upsert_doc_status(
+                doc_id,
+                file_ref,
+                status=DocStatus.HANDLING,
+                error_msg="",
             )
             if callback_manager is not None:
                 insert_duration = time.time() - insert_start

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1708,15 +1708,20 @@ class ProcessorMixin:
             if doc_id is None:
                 doc_id = content_based_doc_id
 
-            await self._upsert_doc_status(
-                doc_id,
-                file_name,
-                status=DocStatus.HANDLING,
-                error_msg="",
-            )
-
             # Step 2: Separate text and multimodal content
             text_content, multimodal_items = separate_content(content_list)
+
+            # LightRAG creates the initial doc_status entry during text insertion.
+            # Pre-registering the same doc_id here makes LightRAG treat a fresh
+            # document insert as a duplicate, so only create the record up front
+            # for multimodal-only content that will not call ainsert().
+            if not text_content.strip():
+                await self._upsert_doc_status(
+                    doc_id,
+                    file_name,
+                    status=DocStatus.HANDLING,
+                    error_msg="",
+                )
 
             # Step 2.5: Set content source for context extraction in multimodal processing
             if hasattr(self, "set_content_source_for_context") and multimodal_items:
@@ -1745,6 +1750,12 @@ class ProcessorMixin:
                     split_by_character=split_by_character,
                     split_by_character_only=split_by_character_only,
                     ids=doc_id,
+                )
+                await self._upsert_doc_status(
+                    doc_id,
+                    file_name,
+                    status=DocStatus.HANDLING,
+                    error_msg="",
                 )
                 if callback_manager is not None:
                     insert_duration = time.time() - insert_start

--- a/tests/test_insert_content_list.py
+++ b/tests/test_insert_content_list.py
@@ -24,7 +24,9 @@ def _install_minimal_lightrag_stubs():
     fake_lightrag.LightRAG = object
     fake_lightrag_utils = types.ModuleType("lightrag.utils")
     fake_lightrag_utils.compute_mdhash_id = lambda content, prefix="": f"{prefix}fake"
-    fake_lightrag_utils.get_env_value = lambda key, default=None, value_type=str: default
+    fake_lightrag_utils.get_env_value = (
+        lambda key, default=None, value_type=str: default
+    )
     fake_lightrag_utils.logger = FakeLogger()
     sys.modules["lightrag"] = fake_lightrag
     sys.modules["lightrag.utils"] = fake_lightrag_utils
@@ -136,9 +138,12 @@ def test_insert_content_list_defers_status_until_after_text_insert():
     assert processor.lightrag.doc_status.records["doc-content-list"]["status"] == (
         DocStatus.PROCESSED
     )
-    assert processor.lightrag.doc_status.records["doc-content-list"][
-        "multimodal_processed"
-    ] is True
+    assert (
+        processor.lightrag.doc_status.records["doc-content-list"][
+            "multimodal_processed"
+        ]
+        is True
+    )
 
 
 def test_insert_content_list_keeps_status_for_multimodal_only_content():

--- a/tests/test_insert_content_list.py
+++ b/tests/test_insert_content_list.py
@@ -106,12 +106,20 @@ class DummyProcessor(ProcessorMixin):
         self.config = SimpleNamespace(
             content_format="mineru",
             display_content_stats=False,
+            parse_method="auto",
+            parser_output_dir="./output",
             use_full_path=False,
         )
         self.callback_manager = None
+        self.parsed_content_list = []
 
     async def _ensure_lightrag_initialized(self):
         return {"success": True}
+
+    async def parse_document(
+        self, file_path, output_dir, parse_method, display_stats, **kwargs
+    ):
+        return self.parsed_content_list, "doc-complete"
 
     def _generate_content_based_doc_id(self, content_list):
         return "doc-content-list"
@@ -144,6 +152,45 @@ def test_insert_content_list_defers_status_until_after_text_insert():
         ]
         is True
     )
+
+
+def test_process_document_complete_defers_status_until_after_text_insert():
+    processor = DummyProcessor()
+    processor.parsed_content_list = [
+        {"type": "text", "text": "hello from parsed document", "page_idx": 0}
+    ]
+
+    asyncio.run(processor.process_document_complete("/tmp/source.pdf"))
+
+    assert processor.events[0] == (
+        "ainsert",
+        "doc-complete",
+        "hello from parsed document",
+    )
+    assert processor.lightrag.doc_status.records["doc-complete"]["status"] == (
+        DocStatus.PROCESSED
+    )
+    assert (
+        processor.lightrag.doc_status.records["doc-complete"]["multimodal_processed"]
+        is True
+    )
+
+
+def test_process_document_complete_keeps_status_for_multimodal_only_content():
+    processor = DummyProcessor()
+    processor.parsed_content_list = [
+        {"type": "image", "img_path": "/tmp/image.png", "page_idx": 0}
+    ]
+
+    asyncio.run(processor.process_document_complete("/tmp/source.pdf"))
+
+    assert processor.events[0] == ("doc_status", "doc-complete", DocStatus.READY)
+    assert processor.events[1] == (
+        "doc_status",
+        "doc-complete",
+        DocStatus.HANDLING,
+    )
+    assert processor.events[2] == ("multimodal", "doc-complete", "source.pdf")
 
 
 def test_insert_content_list_keeps_status_for_multimodal_only_content():

--- a/tests/test_insert_content_list.py
+++ b/tests/test_insert_content_list.py
@@ -1,0 +1,164 @@
+from types import SimpleNamespace
+from pathlib import Path
+import asyncio
+import sys
+import types
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+def _install_minimal_lightrag_stubs():
+    fake_lightrag = types.ModuleType("lightrag")
+    fake_lightrag.LightRAG = object
+    fake_lightrag_utils = types.ModuleType("lightrag.utils")
+    fake_lightrag_utils.compute_mdhash_id = lambda content, prefix="": f"{prefix}fake"
+    fake_lightrag_utils.get_env_value = lambda key, default=None, value_type=str: default
+    fake_lightrag_utils.logger = FakeLogger()
+    sys.modules["lightrag"] = fake_lightrag
+    sys.modules["lightrag.utils"] = fake_lightrag_utils
+
+    fake_raganything = types.ModuleType("raganything")
+    fake_raganything.__path__ = [
+        str(Path(__file__).resolve().parents[1] / "raganything")
+    ]
+    sys.modules["raganything"] = fake_raganything
+
+
+try:
+    from raganything.base import DocStatus
+    from raganything.processor import ProcessorMixin
+except ModuleNotFoundError as exc:
+    if exc.name != "lightrag":
+        raise
+    for module_name in list(sys.modules):
+        if module_name == "raganything" or module_name.startswith("raganything."):
+            sys.modules.pop(module_name, None)
+    _install_minimal_lightrag_stubs()
+    from raganything.base import DocStatus  # noqa: E402
+    from raganything.processor import ProcessorMixin  # noqa: E402
+
+
+class FakeDocStatus:
+    def __init__(self, events):
+        self.records = {}
+        self.events = events
+
+    async def get_by_id(self, doc_id):
+        return self.records.get(doc_id)
+
+    async def upsert(self, payload):
+        for doc_id, record in payload.items():
+            self.events.append(("doc_status", doc_id, record.get("status")))
+            self.records[doc_id] = record
+
+    async def index_done_callback(self):
+        pass
+
+
+class FakeLightRAG:
+    def __init__(self, events):
+        self.events = events
+        self.doc_status = FakeDocStatus(events)
+
+    async def ainsert(self, **kwargs):
+        doc_id = kwargs["ids"]
+        if await self.doc_status.get_by_id(doc_id):
+            raise AssertionError("doc_status existed before LightRAG insertion")
+
+        self.events.append(("ainsert", doc_id, kwargs["input"]))
+        await self.doc_status.upsert(
+            {
+                doc_id: {
+                    "status": DocStatus.PROCESSED,
+                    "content": kwargs["input"],
+                    "content_summary": "",
+                    "content_length": len(kwargs["input"]),
+                    "error_msg": "",
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                    "created_at": "",
+                    "updated_at": "",
+                    "file_path": kwargs["file_paths"],
+                }
+            }
+        )
+
+
+class DummyProcessor(ProcessorMixin):
+    def __init__(self):
+        self.events = []
+        self.lightrag = FakeLightRAG(self.events)
+        self.logger = FakeLogger()
+        self.config = SimpleNamespace(
+            content_format="mineru",
+            display_content_stats=False,
+            use_full_path=False,
+        )
+        self.callback_manager = None
+
+    async def _ensure_lightrag_initialized(self):
+        return {"success": True}
+
+    def _generate_content_based_doc_id(self, content_list):
+        return "doc-content-list"
+
+    async def _process_multimodal_content(self, multimodal_items, file_ref, doc_id):
+        self.events.append(("multimodal", doc_id, file_ref))
+
+
+def test_insert_content_list_defers_status_until_after_text_insert():
+    processor = DummyProcessor()
+
+    asyncio.run(
+        processor.insert_content_list(
+            [{"type": "text", "text": "hello from content list", "page_idx": 0}],
+            file_path="/tmp/source.pdf",
+        )
+    )
+
+    assert processor.events[0] == (
+        "ainsert",
+        "doc-content-list",
+        "hello from content list",
+    )
+    assert processor.lightrag.doc_status.records["doc-content-list"]["status"] == (
+        DocStatus.PROCESSED
+    )
+    assert processor.lightrag.doc_status.records["doc-content-list"][
+        "multimodal_processed"
+    ] is True
+
+
+def test_insert_content_list_keeps_status_for_multimodal_only_content():
+    processor = DummyProcessor()
+
+    asyncio.run(
+        processor.insert_content_list(
+            [{"type": "image", "img_path": "/tmp/image.png", "page_idx": 0}],
+            file_path="/tmp/source.pdf",
+        )
+    )
+
+    assert processor.events[0] == (
+        "doc_status",
+        "doc-content-list",
+        DocStatus.READY,
+    )
+    assert processor.events[1] == (
+        "doc_status",
+        "doc-content-list",
+        DocStatus.HANDLING,
+    )
+    assert processor.events[2] == ("multimodal", "doc-content-list", "source.pdf")


### PR DESCRIPTION
## Summary
- defer doc_status creation for text-bearing insert_content_list calls until after LightRAG ainsert runs
- keep early doc_status creation for multimodal-only content that does not call ainsert
- add regression coverage for both paths

Fixes #277

## Tests
- PYTHONPATH=. pytest tests/test_insert_content_list.py -q
- PYTHONPATH=. pytest tests/testparser_wiring.py tests/testparser_kwargs.py tests/test_insert_content_list.py -q
- python -m ruff check raganything/processor.py tests/test_insert_content_list.py
- python -m compileall raganything/processor.py tests/test_insert_content_list.py
- git diff --check