### PR TITLE
feat: audio & video modal processors (integrated, end-to-end tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,8 @@ The `content_list` should follow the standard format with each item being a dict
 - **Table content**: `{"type": "table", "table_body": "markdown table", "table_caption": ["caption"], "table_footnote": ["note"], "page_idx": 2}`
 - **Equation content**: `{"type": "equation", "latex": "LaTeX formula", "text": "description", "page_idx": 3}`
 - **Generic content**: `{"type": "custom_type", "content": "any content", "page_idx": 4}`
+- **Audio content**: `{"type": "audio", "audio_path": "/absolute/path/to/talk.wav", "audio_caption": ["caption"], "page_idx": 5}` — transcribed locally with faster-whisper (timestamped segments); long recordings are windowed into ordered chunks
+- **Video content**: `{"type": "video", "video_path": "/absolute/path/to/demo.mp4", "video_caption": ["caption"], "page_idx": 6}` — SceneDetect scene boundaries + keyframe VLM description + audio-track transcription, merged by timestamp
 
 **Important Notes:**
 - **`img_path`**: Must be an absolute path to the image file (e.g., `/home/user/images/chart.jpg` or `C:\Users\user\images\chart.jpg`)
@@ -1219,6 +1221,8 @@ Different content types require specific optional dependencies:
 
 - **Office Documents** (.doc, .docx, .ppt, .pptx, .xls, .xlsx): Install [LibreOffice](https://www.libreoffice.org/download/download/)
 - **Extended Image Formats** (.bmp, .tiff, .gif, .webp): Install with `pip install raganything[image]`
+- **Audio** (.mp3, .wav, .flac, .m4a, .ogg): Install with `pip install raganything[audio]` and set `enable_audio_processing=True` (env `ENABLE_AUDIO_PROCESSING`); local transcription via faster-whisper, model picked by `WHISPER_MODEL`
+- **Video** (.mp4, .mov, .webm, .avi, .mkv): Install with `pip install raganything[video]` (also needs ffmpeg on PATH) and set `enable_video_processing=True` (env `ENABLE_VIDEO_PROCESSING`); dual-channel: SceneDetect + keyframe VLM description + audio-track transcription
 - **Text Files** (.txt, .md): Install with `pip install raganything[text]`. Parsed directly (no PDF/OCR round trip); markdown image references (`![alt](path)`) that point to readable local files become image blocks and flow through the same multimodal pipeline as images extracted from PDFs — URLs and missing files stay as plain text
 - **PaddleOCR Parser** (`parser="paddleocr"`): Install with `pip install raganything[paddleocr]`, then install `paddlepaddle` for your platform
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -964,6 +964,8 @@ if __name__ == "__main__":
 - **表格内容**: `{"type": "table", "table_body": "markdown表格", "table_caption": ["标题"], "table_footnote": ["注释"], "page_idx": 2}`
 - **公式内容**: `{"type": "equation", "latex": "LaTeX公式", "text": "描述", "page_idx": 3}`
 - **通用内容**: `{"type": "custom_type", "content": "任何内容", "page_idx": 4}`
+- **音频内容**: `{"type": "audio", "audio_path": "/绝对路径/talk.wav", "audio_caption": ["说明"], "page_idx": 5}` — faster-whisper 本地转写（带时间戳分段），长录音自动切分为有序分块
+- **视频内容**: `{"type": "video", "video_path": "/绝对路径/demo.mp4", "video_caption": ["说明"], "page_idx": 6}` — SceneDetect 场景边界 + 关键帧 VLM 描述 + 音轨转写，按时间戳合并
 
 **重要说明：**
 - **`img_path`**: 必须是图像文件的绝对路径（例如：`/home/user/images/chart.jpg` 或 `C:\Users\user\images\chart.jpg`）
@@ -1158,6 +1160,8 @@ MinerU 将 v2 标记为持续演进的输出 schema。RAG-Anything 会记录并�
 
 - **Office文档** (.doc, .docx, .ppt, .pptx, .xls, .xlsx): 安装并配置 [LibreOffice](https://www.libreoffice.org/download/download/)
 - **扩展图像格式** (.bmp, .tiff, .gif, .webp): 使用 `pip install raganything[image]` 安装
+- **音频** (.mp3, .wav, .flac, .m4a, .ogg): 使用 `pip install raganything[audio]` 安装，并设置 `enable_audio_processing=True`（环境变量 `ENABLE_AUDIO_PROCESSING`）；由 faster-whisper 本地转写（`WHISPER_MODEL` 选模型），长音频自动切分为有序分块
+- **视频** (.mp4, .mov, .webm, .avi, .mkv): 使用 `pip install raganything[video]` 安装（另需系统 ffmpeg），并设置 `enable_video_processing=True`（环境变量 `ENABLE_VIDEO_PROCESSING`）；双通道处理：SceneDetect 场景切分 + 关键帧 VLM 描述 + 音轨转写，按时间戳合并
 - **文本文件** (.txt, .md): 使用 `pip install raganything[text]` 安装。直接解析，不再经过 PDF/OCR 中转；markdown 中指向本地可读文件的图片引用（`![alt](path)`）会生成图像块，与 PDF 中提取的图片走同一条多模态管线——URL 与不存在的文件保持为纯文本
 
 > **📋 快速安装**: 使用 `pip install raganything[all]` 启用所有格式支持（仅Python依赖 - LibreOffice仍需单独安装）

--- a/env.example
+++ b/env.example
@@ -49,10 +49,22 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 # ENABLE_IMAGE_PROCESSING=true
 # ENABLE_TABLE_PROCESSING=true
 # ENABLE_EQUATION_PROCESSING=true
+# ENABLE_AUDIO_PROCESSING=false      # Requires: pip install raganything[audio]
+# ENABLE_VIDEO_PROCESSING=false      # Requires: pip install raganything[video]
+
+### Audio Processing Configuration (requires: pip install raganything[audio])
+# WHISPER_MODEL=base                 # tiny/base/small/medium/large-v3
+# WHISPER_LANGUAGE=                  # Auto-detect if empty. Set to "zh", "en", etc.
+
+### Video Processing Configuration (requires: pip install raganything[video])
+### Uses SceneDetect for scene boundaries + VLM for visual description + Whisper for audio
+# VIDEO_SCENE_THRESHOLD=27.0         # SceneDetect sensitivity (lower = more scenes)
+# VIDEO_MIN_SCENE_DURATION=5.0       # Minimum scene duration in seconds
+# VIDEO_MAX_SCENES=50                # Maximum scenes to process per video
 
 ### Batch Processing Configuration
 # MAX_CONCURRENT_FILES=1
-# SUPPORTED_FILE_EXTENSIONS=.pdf,.jpg,.jpeg,.png,.bmp,.tiff,.tif,.gif,.webp,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.txt,.md
+# SUPPORTED_FILE_EXTENSIONS=.pdf,.jpg,.jpeg,.png,.bmp,.tiff,.tif,.gif,.webp,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.txt,.md,.mp3,.wav,.flac,.m4a,.ogg,.mp4,.mov,.webm,.avi,.mkv
 # RECURSIVE_FOLDER_PROCESSING=true
 
 ### Context Extraction Configuration

--- a/env.example
+++ b/env.example
@@ -60,7 +60,10 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 ### Uses SceneDetect for scene boundaries + VLM for visual description + Whisper for audio
 # VIDEO_SCENE_THRESHOLD=27.0         # SceneDetect sensitivity (lower = more scenes)
 # VIDEO_MIN_SCENE_DURATION=5.0       # Minimum scene duration in seconds
-# VIDEO_MAX_SCENES=50                # Maximum scenes to process per video
+# VIDEO_MAX_SCENES=50                # Scenes per chunk/window (NOT a cap; long videos
+#                                    # spill into multiple ordered chunks, no data dropped)
+# VIDEO_MAX_WINDOWS=100              # Safety cap on chunks per video; scenes are
+#                                    # redistributed into this many windows if exceeded
 
 ### Batch Processing Configuration
 # MAX_CONCURRENT_FILES=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ markdown = [
     "weasyprint>=60.0",
     "pygments>=2.10.0",
 ]
+audio = ["faster-whisper>=1.0.0"]
+video = [
+    "scenedetect[opencv]>=0.6.0",
+    "moviepy>=2.0.0",
+    "faster-whisper>=1.0.0",
+    "opencv-python>=4.8.0",
+]
 all = [
     "Pillow>=10.0.0",
     "reportlab>=4.0.0",
@@ -48,6 +55,10 @@ all = [
     "markdown>=3.4.0",
     "weasyprint>=60.0",
     "pygments>=2.10.0",
+    "faster-whisper>=1.0.0",
+    "scenedetect[opencv]>=0.6.0",
+    "moviepy>=2.0.0",
+    "opencv-python>=4.8.0",
 ]
 
 [project.urls]

--- a/raganything/__init__.py
+++ b/raganything/__init__.py
@@ -43,6 +43,26 @@ except ModuleNotFoundError:
 except ImportError:
     pass
 
+# Optional: audio modal processor (requires faster-whisper).
+try:
+    from .modalprocessors_audio import (
+        AudioModalProcessor as AudioModalProcessor,
+        is_audio_file as is_audio_file,
+    )
+except ImportError:
+    # faster-whisper not installed; audio processing unavailable.
+    pass
+
+# Optional: video modal processor (requires scenedetect + moviepy + faster-whisper + opencv).
+try:
+    from .modalprocessors_video import (
+        VideoModalProcessor as VideoModalProcessor,
+        is_video_file as is_video_file,
+    )
+except ImportError:
+    # Video dependencies not installed; video processing unavailable.
+    pass
+
 # Optional: multilingual prompt manager.
 try:
     from .prompt_manager import (
@@ -105,6 +125,22 @@ if "set_prompt_language" in globals():
             "reset_prompts",
             "register_prompt_language",
             "get_available_languages",
+        ]
+    )
+
+if "AudioModalProcessor" in globals():
+    __all__.extend(
+        [
+            "AudioModalProcessor",
+            "is_audio_file",
+        ]
+    )
+
+if "VideoModalProcessor" in globals():
+    __all__.extend(
+        [
+            "VideoModalProcessor",
+            "is_video_file",
         ]
     )
 

--- a/raganything/config.py
+++ b/raganything/config.py
@@ -51,6 +51,18 @@ class RAGAnythingConfig:
     )
     """Enable equation content processing."""
 
+    enable_audio_processing: bool = field(
+        default=get_env_value("ENABLE_AUDIO_PROCESSING", False, bool)
+    )
+    """Enable audio content processing. Requires optional 'audio' dependencies
+    (``pip install raganything[audio]``); disabled by default."""
+
+    enable_video_processing: bool = field(
+        default=get_env_value("ENABLE_VIDEO_PROCESSING", False, bool)
+    )
+    """Enable video content processing. Requires optional 'video' dependencies
+    (``pip install raganything[video]``); disabled by default."""
+
     # Batch Processing Configuration
     # ---
     max_concurrent_files: int = field(
@@ -63,7 +75,7 @@ class RAGAnythingConfig:
             x.strip()
             for x in get_env_value(
                 "SUPPORTED_FILE_EXTENSIONS",
-                ".pdf,.jpg,.jpeg,.png,.bmp,.tiff,.tif,.gif,.webp,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.txt,.md",
+                ".pdf,.jpg,.jpeg,.png,.bmp,.tiff,.tif,.gif,.webp,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.txt,.md,.mp3,.wav,.flac,.m4a,.ogg,.wma,.aac,.opus,.mp4,.mov,.webm,.avi,.mkv,.flv,.wmv,.m4v",
                 str,
             ).split(",")
         ]

--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -468,6 +468,63 @@ class BaseModalProcessor:
         # Subclasses must implement this method
         raise NotImplementedError("Subclasses must implement this method")
 
+    async def generate_chunk_sections(
+        self,
+        modal_content,
+        content_type: str,
+        item_info: Dict[str, Any] = None,
+        entity_name: str = None,
+    ) -> List[Dict[str, Any]]:
+        """Generate one or more chunk sections for a single modal item.
+
+        This is the 1->N counterpart of :meth:`generate_description_only`. Most
+        processors map one item to exactly one chunk, so the default simply wraps
+        ``generate_description_only`` in a single-element list. Processors that may
+        emit several ordered chunks for one item (e.g. long audio/video split into
+        time windows) override this to return multiple sections.
+
+        Each section is a dict with keys:
+            - ``description``: the section text
+            - ``entity_info``: the entity dict for this section
+            - ``window_meta``: optional ``{"start", "end", "part", "total"}`` used
+              by the chunk template / entity naming; ``None`` for single-section items.
+
+        Returns:
+            List of section dicts (at least one element).
+        """
+        description, entity_info = await self.generate_description_only(
+            modal_content, content_type, item_info, entity_name
+        )
+        return [
+            {
+                "description": description,
+                "entity_info": entity_info,
+                "window_meta": None,
+            }
+        ]
+
+    def _count_tokens(self, text: str) -> int:
+        """Best-effort token count, falling back to a char-based estimate."""
+        if self.tokenizer is not None:
+            try:
+                return len(self.tokenizer.encode(text))
+            except Exception:
+                pass
+        # Rough fallback (~4 chars/token) when no tokenizer is available
+        return max(1, len(text) // 4)
+
+    def _chunk_token_budget(self, default: int = 1200) -> int:
+        """Token budget per modal chunk, derived from LightRAG's chunk size."""
+        try:
+            value = self.global_config.get("chunk_token_size", default)
+        except AttributeError:
+            value = default
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            value = default
+        return value if value > 0 else default
+
     async def _create_entity_and_chunk(
         self,
         modal_chunk: str,

--- a/raganything/modalprocessors_audio.py
+++ b/raganything/modalprocessors_audio.py
@@ -8,12 +8,16 @@ Supports:
 - Speech-to-text transcription with timestamps
 - Meeting recordings, phone calls, podcasts, lectures
 - Multiple languages (auto-detect or specify)
+- Long recordings are split into multiple token-bounded chunks (see
+  ``generate_chunk_sections``)
 
 Dependencies:
     pip install raganything[audio]
     # or: pip install faster-whisper
 """
 
+import asyncio
+import importlib.util
 import json
 import logging
 import os
@@ -33,6 +37,11 @@ AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".m4a", ".ogg", ".wma", ".aac", ".o
 def is_audio_file(file_path: str) -> bool:
     """Check if a file is a supported audio format."""
     return Path(file_path).suffix.lower() in AUDIO_EXTENSIONS
+
+
+def audio_deps_available() -> bool:
+    """Return True if the optional audio dependencies are importable."""
+    return importlib.util.find_spec("faster_whisper") is not None
 
 
 class AudioModalProcessor(BaseModalProcessor):
@@ -69,7 +78,7 @@ class AudioModalProcessor(BaseModalProcessor):
         whisper_device: str = "auto",
         whisper_compute_type: str = "auto",
         language: str = None,
-        segment_min_length: int = 30,
+        segment_min_length: int = 0,
     ):
         """Initialize audio processor.
 
@@ -82,7 +91,10 @@ class AudioModalProcessor(BaseModalProcessor):
             whisper_device: Device for inference ("auto", "cpu", "cuda")
             whisper_compute_type: Compute type ("auto", "float16", "int8")
             language: Language code (e.g., "zh", "en"). None for auto-detect.
-            segment_min_length: Minimum segment length in characters to keep
+            segment_min_length: Minimum segment length in characters to keep.
+                Defaults to 0 (keep every non-empty segment); raising it drops
+                short utterances such as "Yes." or "Revenue grew 23%.", so only
+                increase it when you explicitly want to filter noise.
         """
         super().__init__(lightrag, modal_caption_func, context_extractor)
 
@@ -119,8 +131,23 @@ class AudioModalProcessor(BaseModalProcessor):
             )
         return self._whisper_model
 
+    @staticmethod
+    def _resolve_audio_path(modal_content) -> str:
+        """Extract the audio path from dict/JSON/string modal content."""
+        if isinstance(modal_content, str):
+            try:
+                content_data = json.loads(modal_content)
+            except json.JSONDecodeError:
+                return modal_content
+        else:
+            content_data = modal_content
+        return content_data.get("audio_path") or content_data.get("img_path") or ""
+
     def transcribe(self, audio_path: str) -> List[Dict[str, Any]]:
         """Transcribe audio file to timestamped segments.
+
+        Note: this is a blocking call; async callers should wrap it with
+        ``asyncio.to_thread`` so it does not block the event loop.
 
         Args:
             audio_path: Path to the audio file
@@ -176,6 +203,35 @@ class AudioModalProcessor(BaseModalProcessor):
             lines.append(f"[{start_str}-{end_str}] {seg['text']}")
         return "\n".join(lines)
 
+    def _group_segments_by_tokens(
+        self, segments: List[Dict[str, Any]]
+    ) -> List[List[Dict[str, Any]]]:
+        """Group ordered segments into windows bounded by the chunk token budget.
+
+        Segments are never split mid-utterance, so timestamp alignment is kept.
+        A single oversized segment becomes its own window.
+        """
+        if not segments:
+            return []
+
+        budget = self._chunk_token_budget()
+        windows: List[List[Dict[str, Any]]] = []
+        current: List[Dict[str, Any]] = []
+        current_tokens = 0
+
+        for seg in segments:
+            seg_tokens = self._count_tokens(seg["text"])
+            if current and current_tokens + seg_tokens > budget:
+                windows.append(current)
+                current = []
+                current_tokens = 0
+            current.append(seg)
+            current_tokens += seg_tokens
+
+        if current:
+            windows.append(current)
+        return windows
+
     async def generate_description_only(
         self,
         modal_content,
@@ -183,42 +239,28 @@ class AudioModalProcessor(BaseModalProcessor):
         item_info: Dict[str, Any] = None,
         entity_name: str = None,
     ) -> Tuple[str, Dict[str, Any]]:
-        """Generate audio transcription and entity info.
+        """Generate the full audio transcription and entity info (single description).
 
-        Args:
-            modal_content: Audio content dict with 'audio_path' key
-            content_type: Type of modal content ("audio")
-            item_info: Item information for context extraction
-            entity_name: Optional predefined entity name
+        Returns the whole recording as one description. For long recordings the
+        batch pipeline uses :meth:`generate_chunk_sections` instead, which splits
+        the transcription into multiple token-bounded chunks.
 
         Returns:
             Tuple of (transcription_text, entity_info)
         """
         try:
-            # Parse audio content
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"audio_path": modal_content}
-            else:
-                content_data = modal_content
-
-            audio_path = content_data.get("audio_path") or content_data.get("img_path")
+            audio_path = self._resolve_audio_path(modal_content)
             if not audio_path:
                 raise ValueError(
                     f"No audio path provided in modal_content: {modal_content}"
                 )
 
-            # Transcribe
-            segments = self.transcribe(audio_path)
+            segments = await asyncio.to_thread(self.transcribe, audio_path)
             if not segments:
                 raise RuntimeError(f"No speech detected in audio: {audio_path}")
 
-            # Format transcription
             transcription = self._segments_to_text(segments)
 
-            # Generate entity info
             filename = Path(audio_path).stem
             duration = segments[-1]["end"] if segments else 0
             entity_info = {
@@ -245,6 +287,104 @@ class AudioModalProcessor(BaseModalProcessor):
             }
             return str(modal_content), fallback_entity
 
+    @staticmethod
+    def _section_entity_name(
+        entity_name: str, filename: str, part: int, total: int
+    ) -> str:
+        """Build a unique entity name per section."""
+        base = entity_name if entity_name else f"audio_{filename}"
+        return base if total == 1 else f"{base}_part{part}"
+
+    async def generate_chunk_sections(
+        self,
+        modal_content,
+        content_type: str,
+        item_info: Dict[str, Any] = None,
+        entity_name: str = None,
+    ) -> List[Dict[str, Any]]:
+        """Transcribe the audio and split it into one or more token-bounded sections.
+
+        Short recordings yield a single section (equivalent to the legacy single
+        chunk). Long recordings are split into multiple ordered sections so the
+        transcription is not stored as one oversized chunk.
+        """
+        try:
+            audio_path = self._resolve_audio_path(modal_content)
+            if not audio_path:
+                raise ValueError(
+                    f"No audio path provided in modal_content: {modal_content}"
+                )
+
+            segments = await asyncio.to_thread(self.transcribe, audio_path)
+            if not segments:
+                raise RuntimeError(f"No speech detected in audio: {audio_path}")
+
+            filename = Path(audio_path).stem
+            windows = self._group_segments_by_tokens(segments)
+            total = len(windows)
+
+            sections: List[Dict[str, Any]] = []
+            for k, window in enumerate(windows, start=1):
+                text = self._segments_to_text(window)
+                start = window[0]["start"]
+                end = window[-1]["end"]
+                name = self._section_entity_name(entity_name, filename, k, total)
+                part_label = "" if total == 1 else f" part {k}/{total}"
+                entity_info = {
+                    "entity_name": name,
+                    "entity_type": "audio",
+                    "summary": (
+                        f"Audio recording{part_label} "
+                        f"({self._format_timestamp(start)}-{self._format_timestamp(end)}). "
+                        f"Transcription: {window[0]['text'][:100]}..."
+                    ),
+                }
+                window_meta = (
+                    None
+                    if total == 1
+                    else {"start": start, "end": end, "part": k, "total": total}
+                )
+                sections.append(
+                    {
+                        "description": text,
+                        "entity_info": entity_info,
+                        "window_meta": window_meta,
+                    }
+                )
+
+            return sections
+
+        except Exception as e:
+            logger.error(f"Error generating audio sections: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                if entity_name
+                else f"audio_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "audio",
+                "summary": f"Audio content: {str(modal_content)[:100]}",
+            }
+            return [
+                {
+                    "description": str(modal_content),
+                    "entity_info": fallback_entity,
+                    "window_meta": None,
+                }
+            ]
+
+    @staticmethod
+    def _build_audio_chunk(audio_path: str, section: Dict[str, Any]) -> str:
+        """Format a single audio section into chunk text."""
+        meta = section.get("window_meta")
+        header = "[Audio Content]"
+        if meta:
+            header += f" — part {meta['part']}/{meta['total']}"
+        return (
+            f"{header}\n"
+            f"Source: {audio_path}\n"
+            f"Entity: {section['entity_info']['entity_name']}\n"
+            f"Transcription:\n{section['description']}"
+        )
+
     async def process_multimodal_content(
         self,
         modal_content,
@@ -255,57 +395,52 @@ class AudioModalProcessor(BaseModalProcessor):
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], List[Any]]:
         """Process audio content: transcribe and insert into knowledge graph.
 
-        Args:
-            modal_content: Audio content dict with 'audio_path' key
-            content_type: Type of modal content ("audio")
-            file_path: Source file path for attribution
-            entity_name: Optional entity name
-            item_info: Item info for context
-            batch_mode: Whether in batch processing mode
-            doc_id: Document ID
-            chunk_order_index: Chunk ordering index
+        Long recordings produce multiple ordered chunks; each section is stored
+        with a sequential ``chunk_order_index`` starting at the supplied value.
 
         Returns:
-            Tuple of (chunk_text, entity_info)
+            Tuple of (primary_summary, primary_entity_info, all_chunk_results)
         """
         try:
-            # Generate transcription and entity info
-            transcription, entity_info = await self.generate_description_only(
+            sections = await self.generate_chunk_sections(
                 modal_content, content_type, item_info, entity_name
             )
+            audio_path = self._resolve_audio_path(modal_content)
 
-            # Parse audio path for chunk formatting
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"audio_path": modal_content}
-            else:
-                content_data = modal_content
+            all_chunk_results: List[Any] = []
+            section_chunk_ids: List[str] = []
+            primary_summary = None
+            primary_entity = None
 
-            audio_path = content_data.get("audio_path") or content_data.get(
-                "img_path", ""
-            )
+            for offset, section in enumerate(sections):
+                modal_chunk = self._build_audio_chunk(audio_path, section)
+                (
+                    summary,
+                    entity_ret,
+                    chunk_results,
+                ) = await self._create_entity_and_chunk(
+                    modal_chunk,
+                    section["entity_info"],
+                    file_path,
+                    batch_mode,
+                    doc_id,
+                    chunk_order_index + offset,
+                )
+                all_chunk_results.extend(chunk_results)
+                if entity_ret.get("chunk_id"):
+                    section_chunk_ids.append(entity_ret["chunk_id"])
+                if primary_summary is None:
+                    primary_summary = summary
+                    primary_entity = entity_ret
 
-            # Build audio chunk text
-            modal_chunk = (
-                f"[Audio Content]\n"
-                f"Source: {audio_path}\n"
-                f"Entity: {entity_info['entity_name']}\n"
-                f"Transcription:\n{transcription}"
-            )
+            # Expose every section's chunk id so the caller can register them all
+            if primary_entity is not None:
+                primary_entity["chunk_ids"] = section_chunk_ids
 
-            return await self._create_entity_and_chunk(
-                modal_chunk,
-                entity_info,
-                file_path,
-                batch_mode,
-                doc_id,
-                chunk_order_index,
-            )
+            return primary_summary, primary_entity, all_chunk_results
 
         except Exception as e:
             logger.error(f"Error processing audio content: {e}")
@@ -316,4 +451,4 @@ class AudioModalProcessor(BaseModalProcessor):
                 "entity_type": "audio",
                 "summary": f"Audio content: {str(modal_content)[:100]}",
             }
-            return str(modal_content), fallback_entity
+            return str(modal_content), fallback_entity, []

--- a/raganything/modalprocessors_audio.py
+++ b/raganything/modalprocessors_audio.py
@@ -1,0 +1,321 @@
+"""
+Audio Modal Processor for RAG-Anything
+
+Processes audio files (MP3, WAV, FLAC, M4A, OGG) by transcribing speech to text
+using faster-whisper, then feeding the transcribed text into LightRAG's knowledge graph.
+
+Supports:
+- Speech-to-text transcription with timestamps
+- Meeting recordings, phone calls, podcasts, lectures
+- Multiple languages (auto-detect or specify)
+
+Dependencies:
+    pip install raganything[audio]
+    # or: pip install faster-whisper
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from lightrag.utils import compute_mdhash_id
+
+from .modalprocessors import BaseModalProcessor
+
+logger = logging.getLogger(__name__)
+
+# Supported audio file extensions
+AUDIO_EXTENSIONS = {".mp3", ".wav", ".flac", ".m4a", ".ogg", ".wma", ".aac", ".opus"}
+
+
+def is_audio_file(file_path: str) -> bool:
+    """Check if a file is a supported audio format."""
+    return Path(file_path).suffix.lower() in AUDIO_EXTENSIONS
+
+
+class AudioModalProcessor(BaseModalProcessor):
+    """Processor for audio content using faster-whisper for transcription.
+
+    Transcribes audio files into timestamped text segments, then processes
+    them through LightRAG for knowledge graph construction and retrieval.
+
+    Suitable for:
+    - Meeting recordings
+    - Phone call recordings
+    - Podcasts and interviews
+    - Lectures and presentations
+    - Voice memos
+
+    Example:
+        >>> processor = AudioModalProcessor(
+        ...     lightrag=rag_instance,
+        ...     modal_caption_func=caption_func,
+        ...     whisper_model="large-v3",
+        ... )
+        >>> result = await processor.process_multimodal_content(
+        ...     modal_content={"audio_path": "/path/to/meeting.mp3"},
+        ...     content_type="audio",
+        ... )
+    """
+
+    def __init__(
+        self,
+        lightrag,
+        modal_caption_func,
+        context_extractor=None,
+        whisper_model: str = None,
+        whisper_device: str = "auto",
+        whisper_compute_type: str = "auto",
+        language: str = None,
+        segment_min_length: int = 30,
+    ):
+        """Initialize audio processor.
+
+        Args:
+            lightrag: LightRAG instance
+            modal_caption_func: Function for generating descriptions
+            context_extractor: Context extractor instance
+            whisper_model: Whisper model size (tiny/base/small/medium/large-v3)
+                          Defaults to env WHISPER_MODEL or "base"
+            whisper_device: Device for inference ("auto", "cpu", "cuda")
+            whisper_compute_type: Compute type ("auto", "float16", "int8")
+            language: Language code (e.g., "zh", "en"). None for auto-detect.
+            segment_min_length: Minimum segment length in characters to keep
+        """
+        super().__init__(lightrag, modal_caption_func, context_extractor)
+
+        self.whisper_model_name = whisper_model or os.environ.get(
+            "WHISPER_MODEL", "base"
+        )
+        self.whisper_device = whisper_device
+        self.whisper_compute_type = whisper_compute_type
+        self.language = language or os.environ.get("WHISPER_LANGUAGE", None)
+        self.segment_min_length = segment_min_length
+        self._whisper_model = None
+
+    @property
+    def whisper(self):
+        """Lazy-load whisper model on first use."""
+        if self._whisper_model is None:
+            try:
+                from faster_whisper import WhisperModel
+            except ImportError:
+                raise ImportError(
+                    "faster-whisper is required for audio processing. "
+                    "Install it with: pip install raganything[audio] "
+                    "or: pip install faster-whisper"
+                )
+
+            logger.info(
+                f"Loading whisper model: {self.whisper_model_name} "
+                f"(device={self.whisper_device})"
+            )
+            self._whisper_model = WhisperModel(
+                self.whisper_model_name,
+                device=self.whisper_device,
+                compute_type=self.whisper_compute_type,
+            )
+        return self._whisper_model
+
+    def transcribe(self, audio_path: str) -> List[Dict[str, Any]]:
+        """Transcribe audio file to timestamped segments.
+
+        Args:
+            audio_path: Path to the audio file
+
+        Returns:
+            List of segments with start, end (seconds) and text
+        """
+        if not Path(audio_path).exists():
+            raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+        logger.info(f"Transcribing audio: {audio_path}")
+
+        segments_iter, info = self.whisper.transcribe(
+            audio_path,
+            language=self.language,
+            vad_filter=True,  # Filter out silence
+            vad_parameters=dict(min_silence_duration_ms=500),
+        )
+
+        segments = []
+        for segment in segments_iter:
+            text = segment.text.strip()
+            if len(text) >= self.segment_min_length:
+                segments.append(
+                    {
+                        "start": segment.start,
+                        "end": segment.end,
+                        "text": text,
+                    }
+                )
+
+        logger.info(
+            f"Transcription complete: {len(segments)} segments, "
+            f"language={info.language}, duration={info.duration:.1f}s"
+        )
+        return segments
+
+    def _format_timestamp(self, seconds: float) -> str:
+        """Format seconds to HH:MM:SS or MM:SS."""
+        h = int(seconds // 3600)
+        m = int((seconds % 3600) // 60)
+        s = int(seconds % 60)
+        if h > 0:
+            return f"{h}:{m:02d}:{s:02d}"
+        return f"{m}:{s:02d}"
+
+    def _segments_to_text(self, segments: List[Dict[str, Any]]) -> str:
+        """Convert transcription segments to formatted text with timestamps."""
+        lines = []
+        for seg in segments:
+            start_str = self._format_timestamp(seg["start"])
+            end_str = self._format_timestamp(seg["end"])
+            lines.append(f"[{start_str}-{end_str}] {seg['text']}")
+        return "\n".join(lines)
+
+    async def generate_description_only(
+        self,
+        modal_content,
+        content_type: str,
+        item_info: Dict[str, Any] = None,
+        entity_name: str = None,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Generate audio transcription and entity info.
+
+        Args:
+            modal_content: Audio content dict with 'audio_path' key
+            content_type: Type of modal content ("audio")
+            item_info: Item information for context extraction
+            entity_name: Optional predefined entity name
+
+        Returns:
+            Tuple of (transcription_text, entity_info)
+        """
+        try:
+            # Parse audio content
+            if isinstance(modal_content, str):
+                try:
+                    content_data = json.loads(modal_content)
+                except json.JSONDecodeError:
+                    content_data = {"audio_path": modal_content}
+            else:
+                content_data = modal_content
+
+            audio_path = content_data.get("audio_path") or content_data.get("img_path")
+            if not audio_path:
+                raise ValueError(
+                    f"No audio path provided in modal_content: {modal_content}"
+                )
+
+            # Transcribe
+            segments = self.transcribe(audio_path)
+            if not segments:
+                raise RuntimeError(f"No speech detected in audio: {audio_path}")
+
+            # Format transcription
+            transcription = self._segments_to_text(segments)
+
+            # Generate entity info
+            filename = Path(audio_path).stem
+            duration = segments[-1]["end"] if segments else 0
+            entity_info = {
+                "entity_name": entity_name
+                if entity_name
+                else f"audio_{filename}",
+                "entity_type": "audio",
+                "summary": (
+                    f"Audio recording ({self._format_timestamp(duration)} duration). "
+                    f"Transcription: {segments[0]['text'][:100]}..."
+                    if segments
+                    else "Empty audio"
+                ),
+            }
+
+            return transcription, entity_info
+
+        except Exception as e:
+            logger.error(f"Error generating audio transcription: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                if entity_name
+                else f"audio_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "audio",
+                "summary": f"Audio content: {str(modal_content)[:100]}",
+            }
+            return str(modal_content), fallback_entity
+
+    async def process_multimodal_content(
+        self,
+        modal_content,
+        content_type: str,
+        file_path: str = "manual_creation",
+        entity_name: str = None,
+        item_info: Dict[str, Any] = None,
+        batch_mode: bool = False,
+        doc_id: str = None,
+        chunk_order_index: int = 0,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Process audio content: transcribe and insert into knowledge graph.
+
+        Args:
+            modal_content: Audio content dict with 'audio_path' key
+            content_type: Type of modal content ("audio")
+            file_path: Source file path for attribution
+            entity_name: Optional entity name
+            item_info: Item info for context
+            batch_mode: Whether in batch processing mode
+            doc_id: Document ID
+            chunk_order_index: Chunk ordering index
+
+        Returns:
+            Tuple of (chunk_text, entity_info)
+        """
+        try:
+            # Generate transcription and entity info
+            transcription, entity_info = await self.generate_description_only(
+                modal_content, content_type, item_info, entity_name
+            )
+
+            # Parse audio path for chunk formatting
+            if isinstance(modal_content, str):
+                try:
+                    content_data = json.loads(modal_content)
+                except json.JSONDecodeError:
+                    content_data = {"audio_path": modal_content}
+            else:
+                content_data = modal_content
+
+            audio_path = content_data.get("audio_path") or content_data.get(
+                "img_path", ""
+            )
+
+            # Build audio chunk text
+            modal_chunk = (
+                f"[Audio Content]\n"
+                f"Source: {audio_path}\n"
+                f"Entity: {entity_info['entity_name']}\n"
+                f"Transcription:\n{transcription}"
+            )
+
+            return await self._create_entity_and_chunk(
+                modal_chunk,
+                entity_info,
+                file_path,
+                batch_mode,
+                doc_id,
+                chunk_order_index,
+            )
+
+        except Exception as e:
+            logger.error(f"Error processing audio content: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                if entity_name
+                else f"audio_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "audio",
+                "summary": f"Audio content: {str(modal_content)[:100]}",
+            }
+            return str(modal_content), fallback_entity

--- a/raganything/modalprocessors_audio.py
+++ b/raganything/modalprocessors_audio.py
@@ -222,9 +222,7 @@ class AudioModalProcessor(BaseModalProcessor):
             filename = Path(audio_path).stem
             duration = segments[-1]["end"] if segments else 0
             entity_info = {
-                "entity_name": entity_name
-                if entity_name
-                else f"audio_{filename}",
+                "entity_name": entity_name if entity_name else f"audio_{filename}",
                 "entity_type": "audio",
                 "summary": (
                     f"Audio recording ({self._format_timestamp(duration)} duration). "

--- a/raganything/modalprocessors_video.py
+++ b/raganything/modalprocessors_video.py
@@ -8,6 +8,9 @@ Processes video files (MP4, MOV, WebM, AVI, MKV) with dual-channel analysis:
 Results are merged by timestamp, producing rich text descriptions like:
     [0:00-0:30] 画面：展示Q3营收图表 | 语音：本季度同比增长23%...
 
+Long videos are split into multiple ordered chunks ("windows") so that no scene
+or audio is silently dropped (see ``generate_chunk_sections``).
+
 Supports:
 - Meeting recordings (screen share + voice)
 - Lectures/tutorials (slides + narration)
@@ -20,6 +23,9 @@ Dependencies:
     # or: pip install scenedetect[opencv] moviepy faster-whisper opencv-python
 """
 
+import asyncio
+import base64
+import importlib.util
 import json
 import logging
 import os
@@ -54,6 +60,14 @@ def _load_cv2():
 def is_video_file(file_path: str) -> bool:
     """Check if a file is a supported video format."""
     return Path(file_path).suffix.lower() in VIDEO_EXTENSIONS
+
+
+def video_deps_available() -> bool:
+    """Return True if all optional video dependencies are importable."""
+    return all(
+        importlib.util.find_spec(mod) is not None
+        for mod in ("cv2", "scenedetect", "moviepy", "faster_whisper")
+    )
 
 
 class VideoModalProcessor(BaseModalProcessor):
@@ -97,6 +111,8 @@ class VideoModalProcessor(BaseModalProcessor):
         min_scene_duration: float = 5.0,
         max_scenes: int = 50,
         scene_threshold: float = 27.0,
+        max_windows: int = 100,
+        audio_processor: "AudioModalProcessor" = None,
     ):
         """Initialize video processor.
 
@@ -109,8 +125,13 @@ class VideoModalProcessor(BaseModalProcessor):
             whisper_compute_type: Compute type ("auto", "float16", "int8")
             language: Language code for ASR (None for auto-detect)
             min_scene_duration: Minimum scene duration in seconds to keep
-            max_scenes: Maximum number of scenes to process
+            max_scenes: Maximum scenes per window (controls chunk size, not a hard
+                cap on the whole video — extra scenes spill into further windows)
             scene_threshold: ContentDetector threshold (lower = more sensitive)
+            max_windows: Safety cap on the number of chunks produced for one video;
+                if exceeded, scenes are redistributed into this many windows.
+            audio_processor: Optional shared AudioModalProcessor to reuse a single
+                whisper model when both audio and video processing are enabled.
         """
         super().__init__(lightrag, modal_caption_func, context_extractor)
 
@@ -123,13 +144,14 @@ class VideoModalProcessor(BaseModalProcessor):
         self.min_scene_duration = min_scene_duration
         self.max_scenes = max_scenes
         self.scene_threshold = scene_threshold
+        self.max_windows = max_windows
 
-        # Lazy-loaded audio processor (shares whisper model config)
-        self._audio_processor = None
+        # Reuse a shared audio processor when provided, otherwise lazily create one.
+        self._audio_processor = audio_processor
 
     @property
     def audio_processor(self) -> AudioModalProcessor:
-        """Get or create audio processor for transcription."""
+        """Get or create audio processor for transcription (shares whisper model)."""
         if self._audio_processor is None:
             self._audio_processor = AudioModalProcessor(
                 lightrag=self.lightrag,
@@ -138,12 +160,28 @@ class VideoModalProcessor(BaseModalProcessor):
                 whisper_device=self.whisper_device,
                 whisper_compute_type=self.whisper_compute_type,
                 language=self.language,
-                segment_min_length=10,
+                segment_min_length=0,
             )
         return self._audio_processor
 
+    @staticmethod
+    def _resolve_video_path(modal_content) -> str:
+        """Extract the video path from dict/JSON/string modal content."""
+        if isinstance(modal_content, str):
+            try:
+                content_data = json.loads(modal_content)
+            except json.JSONDecodeError:
+                return modal_content
+        else:
+            content_data = modal_content
+        return content_data.get("video_path") or content_data.get("img_path") or ""
+
     def _detect_scenes(self, video_path: str) -> List[Tuple[float, float]]:
         """Detect scene boundaries using SceneDetect.
+
+        Returns ALL scenes (no hard cap); window planning bounds the per-chunk
+        scene count later. This is a blocking call; async callers wrap it with
+        ``asyncio.to_thread``.
 
         Args:
             video_path: Path to video file
@@ -184,11 +222,14 @@ class VideoModalProcessor(BaseModalProcessor):
                 total_duration = total_frames / fps
                 scenes = [(0, total_duration)]
 
-        # Limit number of scenes
-        return scenes[: self.max_scenes]
+        return scenes
 
     def _extract_frame_at(self, video_path: str, timestamp: float) -> Optional[str]:
         """Extract a single frame at the given timestamp.
+
+        Note: ``CAP_PROP_POS_FRAMES`` seeking snaps to the nearest keyframe for
+        many codecs, so the captured frame may be slightly off ``timestamp``.
+        This is an acceptable approximation for scene-level description.
 
         Args:
             video_path: Path to video file
@@ -212,11 +253,9 @@ class VideoModalProcessor(BaseModalProcessor):
         if not ret:
             return None
 
-        # Save to temp file
-        frame_path = os.path.join(
-            tempfile.gettempdir(),
-            f"raganything_vframe_{os.getpid()}_{timestamp:.1f}.jpg",
-        )
+        # Unique temp name so concurrent extractions never collide
+        fd, frame_path = tempfile.mkstemp(suffix=".jpg", prefix="raganything_vframe_")
+        os.close(fd)
         cv2.imwrite(frame_path, frame)
         return frame_path
 
@@ -238,21 +277,23 @@ class VideoModalProcessor(BaseModalProcessor):
                 "or: pip install moviepy"
             )
 
-        audio_path = os.path.join(
-            tempfile.gettempdir(),
-            f"raganything_vaudio_{os.getpid()}.wav",
-        )
+        # Unique temp name so concurrent video processing never overwrites it
+        fd, audio_path = tempfile.mkstemp(suffix=".wav", prefix="raganything_vaudio_")
+        os.close(fd)
 
         try:
             clip = VideoFileClip(video_path)
             if clip.audio is None:
                 clip.close()
+                os.remove(audio_path)
                 return None
             clip.audio.write_audiofile(audio_path, logger=None)
             clip.close()
             return audio_path
         except Exception as e:
             logger.warning(f"Failed to extract audio from {video_path}: {e}")
+            if os.path.exists(audio_path):
+                os.remove(audio_path)
             return None
 
     def _format_timestamp(self, seconds: float) -> str:
@@ -281,49 +322,77 @@ class VideoModalProcessor(BaseModalProcessor):
     async def _describe_scenes(
         self, video_path: str, scenes: List[Tuple[float, float]]
     ) -> List[Dict[str, Any]]:
-        """Generate VLM descriptions for each scene.
+        """Generate VLM descriptions for each scene with bounded concurrency.
 
         Args:
             video_path: Path to video file
             scenes: List of (start, end) tuples
 
         Returns:
-            List of scene dicts with start, end, visual description
+            List of scene dicts with start, end, visual description (ordered)
         """
-        results = []
-        for start, end in scenes:
-            # Extract frame from middle of scene
-            mid_time = (start + end) / 2
-            frame_path = self._extract_frame_at(video_path, mid_time)
+        concurrency = max(1, getattr(self.lightrag, "max_parallel_insert", 2))
+        semaphore = asyncio.Semaphore(concurrency)
 
-            visual_desc = ""
-            if frame_path:
-                try:
-                    # Encode frame to base64 for VLM
-                    import base64
+        async def describe_one(start: float, end: float) -> Dict[str, Any]:
+            async with semaphore:
+                mid_time = (start + end) / 2
+                frame_path = await asyncio.to_thread(
+                    self._extract_frame_at, video_path, mid_time
+                )
 
-                    with open(frame_path, "rb") as f:
-                        image_base64 = base64.b64encode(f.read()).decode("utf-8")
+                visual_desc = ""
+                if frame_path:
+                    try:
+                        with open(frame_path, "rb") as f:
+                            image_base64 = base64.b64encode(f.read()).decode("utf-8")
 
-                    prompt = (
-                        f"Describe this video frame in detail. "
-                        f"This is from a video at approximately "
-                        f"{self._format_timestamp(mid_time)}. "
-                        f"Include: what is shown, any text/UI visible, "
-                        f"people/objects present, and the overall context."
-                    )
-                    visual_desc = await self.modal_caption_func(
-                        prompt, image_data=image_base64
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to describe frame at {mid_time:.1f}s: {e}")
-                finally:
-                    if os.path.exists(frame_path):
-                        os.remove(frame_path)
+                        prompt = (
+                            f"Describe this video frame in detail. "
+                            f"This is from a video at approximately "
+                            f"{self._format_timestamp(mid_time)}. "
+                            f"Include: what is shown, any text/UI visible, "
+                            f"people/objects present, and the overall context."
+                        )
+                        visual_desc = await self.modal_caption_func(
+                            prompt, image_data=image_base64
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to describe frame at {mid_time:.1f}s: {e}"
+                        )
+                    finally:
+                        if os.path.exists(frame_path):
+                            os.remove(frame_path)
 
-            results.append({"start": start, "end": end, "visual": visual_desc})
+                return {"start": start, "end": end, "visual": visual_desc}
 
-        return results
+        results = await asyncio.gather(
+            *(describe_one(start, end) for start, end in scenes),
+            return_exceptions=True,
+        )
+
+        scene_segments = []
+        for result in results:
+            if isinstance(result, Exception):
+                logger.warning(f"Scene description task failed: {result}")
+                continue
+            scene_segments.append(result)
+        return scene_segments
+
+    async def _transcribe_audio_track(self, video_path: str) -> List[Dict[str, Any]]:
+        """Extract and transcribe the audio track once (off the event loop)."""
+        audio_path = await asyncio.to_thread(self._extract_audio_track, video_path)
+        if not audio_path:
+            return []
+        try:
+            return await asyncio.to_thread(self.audio_processor.transcribe, audio_path)
+        except Exception as e:
+            logger.warning(f"Audio transcription failed: {e}")
+            return []
+        finally:
+            if os.path.exists(audio_path):
+                os.remove(audio_path)
 
     def _merge_channels(
         self,
@@ -361,6 +430,57 @@ class VideoModalProcessor(BaseModalProcessor):
 
         return "\n\n".join(lines)
 
+    def _plan_windows(
+        self, visual_segments: List[Dict[str, Any]]
+    ) -> List[List[Dict[str, Any]]]:
+        """Group ordered scene descriptions into windows.
+
+        A window is bounded by both ``max_scenes`` (scene count) and the chunk
+        token budget. If the number of windows would exceed ``max_windows``, the
+        scenes are redistributed evenly into ``max_windows`` groups so the chunk
+        count stays bounded without dropping any scene.
+        """
+        if not visual_segments:
+            return []
+
+        budget = self._chunk_token_budget()
+        windows: List[List[Dict[str, Any]]] = []
+        current: List[Dict[str, Any]] = []
+        current_tokens = 0
+
+        for seg in visual_segments:
+            seg_tokens = self._count_tokens(seg.get("visual", "") or "")
+            too_many = len(current) >= self.max_scenes
+            too_big = bool(current) and current_tokens + seg_tokens > budget
+            if current and (too_many or too_big):
+                windows.append(current)
+                current = []
+                current_tokens = 0
+            current.append(seg)
+            current_tokens += seg_tokens
+
+        if current:
+            windows.append(current)
+
+        if self.max_windows and len(windows) > self.max_windows:
+            logger.warning(
+                f"Video produced {len(windows)} windows, exceeding max_windows="
+                f"{self.max_windows}; redistributing {len(visual_segments)} scenes "
+                f"into {self.max_windows} windows."
+            )
+            windows = self._redistribute(visual_segments, self.max_windows)
+
+        return windows
+
+    @staticmethod
+    def _redistribute(
+        items: List[Dict[str, Any]], groups: int
+    ) -> List[List[Dict[str, Any]]]:
+        """Split items into at most ``groups`` near-equal, order-preserving groups."""
+        n = len(items)
+        size = (n + groups - 1) // groups  # ceil
+        return [items[i : i + size] for i in range(0, n, size)]
+
     async def generate_description_only(
         self,
         modal_content,
@@ -368,64 +488,35 @@ class VideoModalProcessor(BaseModalProcessor):
         item_info: Dict[str, Any] = None,
         entity_name: str = None,
     ) -> Tuple[str, Dict[str, Any]]:
-        """Generate video description using dual-channel analysis.
+        """Generate a single merged description for the whole video.
 
-        Args:
-            modal_content: Video content dict with 'video_path' key
-            content_type: Type of modal content ("video")
-            item_info: Item information for context
-            entity_name: Optional predefined entity name
+        For long videos the batch pipeline uses :meth:`generate_chunk_sections`
+        instead, which splits the analysis into multiple ordered chunks.
 
         Returns:
             Tuple of (merged_description, entity_info)
         """
         try:
-            # Parse video content
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"video_path": modal_content}
-            else:
-                content_data = modal_content
-
-            video_path = content_data.get("video_path") or content_data.get("img_path")
+            video_path = self._resolve_video_path(modal_content)
             if not video_path:
                 raise ValueError(
                     f"No video path provided in modal_content: {modal_content}"
                 )
-
             if not Path(video_path).exists():
                 raise FileNotFoundError(f"Video file not found: {video_path}")
 
             logger.info(f"Processing video: {video_path}")
 
-            # Step 1: Detect scenes
-            scenes = self._detect_scenes(video_path)
+            scenes = await asyncio.to_thread(self._detect_scenes, video_path)
             logger.info(f"Detected {len(scenes)} scenes")
 
-            # Step 2: Visual channel - describe each scene
             visual_segments = await self._describe_scenes(video_path, scenes)
+            audio_segments = await self._transcribe_audio_track(video_path)
 
-            # Step 3: Audio channel - extract and transcribe
-            audio_segments = []
-            audio_path = self._extract_audio_track(video_path)
-            if audio_path:
-                try:
-                    audio_segments = self.audio_processor.transcribe(audio_path)
-                except Exception as e:
-                    logger.warning(f"Audio transcription failed: {e}")
-                finally:
-                    if os.path.exists(audio_path):
-                        os.remove(audio_path)
-
-            # Step 4: Merge by timestamp
             merged_description = self._merge_channels(visual_segments, audio_segments)
-
             if not merged_description:
                 merged_description = f"Video file: {Path(video_path).name}"
 
-            # Generate entity info
             filename = Path(video_path).stem
             total_duration = scenes[-1][1] if scenes else 0
             entity_info = {
@@ -451,6 +542,134 @@ class VideoModalProcessor(BaseModalProcessor):
             }
             return str(modal_content), fallback_entity
 
+    @staticmethod
+    def _section_entity_name(
+        entity_name: str, filename: str, part: int, total: int
+    ) -> str:
+        """Build a unique entity name per section."""
+        base = entity_name if entity_name else f"video_{filename}"
+        return base if total == 1 else f"{base}_part{part}"
+
+    async def generate_chunk_sections(
+        self,
+        modal_content,
+        content_type: str,
+        item_info: Dict[str, Any] = None,
+        entity_name: str = None,
+    ) -> List[Dict[str, Any]]:
+        """Analyze the video and split it into one or more ordered sections.
+
+        Scene detection and audio transcription run once for the whole video;
+        scenes are then grouped into windows (bounded by ``max_scenes`` and the
+        token budget). Audio that extends past the last scene is appended to the
+        final window as an audio-only row so nothing is dropped.
+        """
+        try:
+            video_path = self._resolve_video_path(modal_content)
+            if not video_path:
+                raise ValueError(
+                    f"No video path provided in modal_content: {modal_content}"
+                )
+            if not Path(video_path).exists():
+                raise FileNotFoundError(f"Video file not found: {video_path}")
+
+            logger.info(f"Processing video: {video_path}")
+
+            scenes = await asyncio.to_thread(self._detect_scenes, video_path)
+            if not scenes:
+                raise RuntimeError(f"No scenes detected in video: {video_path}")
+            logger.info(f"Detected {len(scenes)} scenes")
+
+            visual_segments = await self._describe_scenes(video_path, scenes)
+            audio_segments = await self._transcribe_audio_track(video_path)
+
+            # Capture audio beyond the last visual scene as a trailing audio-only row
+            if visual_segments and audio_segments:
+                last_end = visual_segments[-1]["end"]
+                tail = [a for a in audio_segments if a["start"] >= last_end]
+                if tail:
+                    visual_segments.append(
+                        {"start": last_end, "end": tail[-1]["end"], "visual": ""}
+                    )
+
+            windows = self._plan_windows(visual_segments)
+            total = len(windows)
+            filename = Path(video_path).stem
+
+            sections: List[Dict[str, Any]] = []
+            for k, window in enumerate(windows, start=1):
+                win_start = window[0]["start"]
+                win_end = window[-1]["end"]
+                text = self._merge_channels(window, audio_segments)
+                if not text:
+                    text = (
+                        f"Video file: {Path(video_path).name} "
+                        f"({self._format_timestamp(win_start)}-"
+                        f"{self._format_timestamp(win_end)})"
+                    )
+                name = self._section_entity_name(entity_name, filename, k, total)
+                part_label = "" if total == 1 else f" part {k}/{total}"
+                entity_info = {
+                    "entity_name": name,
+                    "entity_type": "video",
+                    "summary": (
+                        f"Video{part_label} "
+                        f"({self._format_timestamp(win_start)}-"
+                        f"{self._format_timestamp(win_end)}, {len(window)} scenes). "
+                        f"{text[:150]}..."
+                    ),
+                }
+                window_meta = (
+                    None
+                    if total == 1
+                    else {
+                        "start": win_start,
+                        "end": win_end,
+                        "part": k,
+                        "total": total,
+                    }
+                )
+                sections.append(
+                    {
+                        "description": text,
+                        "entity_info": entity_info,
+                        "window_meta": window_meta,
+                    }
+                )
+
+            return sections
+
+        except Exception as e:
+            logger.error(f"Error generating video sections: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                if entity_name
+                else f"video_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "video",
+                "summary": f"Video content: {str(modal_content)[:100]}",
+            }
+            return [
+                {
+                    "description": str(modal_content),
+                    "entity_info": fallback_entity,
+                    "window_meta": None,
+                }
+            ]
+
+    @staticmethod
+    def _build_video_chunk(video_path: str, section: Dict[str, Any]) -> str:
+        """Format a single video section into chunk text."""
+        meta = section.get("window_meta")
+        header = "[Video Content]"
+        if meta:
+            header += f" — part {meta['part']}/{meta['total']}"
+        return (
+            f"{header}\n"
+            f"Source: {video_path}\n"
+            f"Entity: {section['entity_info']['entity_name']}\n"
+            f"Analysis:\n{section['description']}"
+        )
+
     async def process_multimodal_content(
         self,
         modal_content,
@@ -461,57 +680,52 @@ class VideoModalProcessor(BaseModalProcessor):
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], List[Any]]:
         """Process video content: analyze and insert into knowledge graph.
 
-        Args:
-            modal_content: Video content dict with 'video_path' key
-            content_type: Type of modal content ("video")
-            file_path: Source file path for attribution
-            entity_name: Optional entity name
-            item_info: Item info for context
-            batch_mode: Whether in batch processing mode
-            doc_id: Document ID
-            chunk_order_index: Chunk ordering index
+        Long videos produce multiple ordered chunks; each section is stored with a
+        sequential ``chunk_order_index`` starting at the supplied value.
 
         Returns:
-            Tuple of (chunk_text, entity_info)
+            Tuple of (primary_summary, primary_entity_info, all_chunk_results)
         """
         try:
-            # Generate description using dual-channel analysis
-            description, entity_info = await self.generate_description_only(
+            sections = await self.generate_chunk_sections(
                 modal_content, content_type, item_info, entity_name
             )
+            video_path = self._resolve_video_path(modal_content)
 
-            # Parse video path
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"video_path": modal_content}
-            else:
-                content_data = modal_content
+            all_chunk_results: List[Any] = []
+            section_chunk_ids: List[str] = []
+            primary_summary = None
+            primary_entity = None
 
-            video_path = content_data.get("video_path") or content_data.get(
-                "img_path", ""
-            )
+            for offset, section in enumerate(sections):
+                modal_chunk = self._build_video_chunk(video_path, section)
+                (
+                    summary,
+                    entity_ret,
+                    chunk_results,
+                ) = await self._create_entity_and_chunk(
+                    modal_chunk,
+                    section["entity_info"],
+                    file_path,
+                    batch_mode,
+                    doc_id,
+                    chunk_order_index + offset,
+                )
+                all_chunk_results.extend(chunk_results)
+                if entity_ret.get("chunk_id"):
+                    section_chunk_ids.append(entity_ret["chunk_id"])
+                if primary_summary is None:
+                    primary_summary = summary
+                    primary_entity = entity_ret
 
-            # Build video chunk text
-            modal_chunk = (
-                f"[Video Content]\n"
-                f"Source: {video_path}\n"
-                f"Entity: {entity_info['entity_name']}\n"
-                f"Analysis:\n{description}"
-            )
+            # Expose every section's chunk id so the caller can register them all
+            if primary_entity is not None:
+                primary_entity["chunk_ids"] = section_chunk_ids
 
-            return await self._create_entity_and_chunk(
-                modal_chunk,
-                entity_info,
-                file_path,
-                batch_mode,
-                doc_id,
-                chunk_order_index,
-            )
+            return primary_summary, primary_entity, all_chunk_results
 
         except Exception as e:
             logger.error(f"Error processing video content: {e}")
@@ -522,4 +736,4 @@ class VideoModalProcessor(BaseModalProcessor):
                 "entity_type": "video",
                 "summary": f"Video content: {str(modal_content)[:100]}",
             }
-            return str(modal_content), fallback_entity
+            return str(modal_content), fallback_entity, []

--- a/raganything/modalprocessors_video.py
+++ b/raganything/modalprocessors_video.py
@@ -1,0 +1,525 @@
+"""
+Video Modal Processor for RAG-Anything
+
+Processes video files (MP4, MOV, WebM, AVI, MKV) with dual-channel analysis:
+- Visual channel: scene detection + keyframe extraction + VLM description
+- Audio channel: audio track extraction + faster-whisper transcription
+
+Results are merged by timestamp, producing rich text descriptions like:
+    [0:00-0:30] 画面：展示Q3营收图表 | 语音：本季度同比增长23%...
+
+Supports:
+- Meeting recordings (screen share + voice)
+- Lectures/tutorials (slides + narration)
+- Product demos (UI operations + voiceover)
+- Surveillance/inspection (visual scenes, often no audio)
+- Podcasts with video (talking heads + speech)
+
+Dependencies:
+    pip install raganything[video]
+    # or: pip install scenedetect[opencv] moviepy faster-whisper opencv-python
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from lightrag.utils import compute_mdhash_id
+
+from .modalprocessors import BaseModalProcessor
+from .modalprocessors_audio import AudioModalProcessor
+
+logger = logging.getLogger(__name__)
+
+# Supported video file extensions
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".webm", ".avi", ".mkv", ".flv", ".wmv", ".m4v"}
+
+
+def _load_cv2():
+    """Lazily import OpenCV so that importing this module does not require it."""
+    try:
+        import cv2
+    except ImportError as e:
+        raise ImportError(
+            "opencv-python is required for video processing. "
+            "Install it with: pip install raganything[video] "
+            "or: pip install opencv-python"
+        ) from e
+    return cv2
+
+
+def is_video_file(file_path: str) -> bool:
+    """Check if a file is a supported video format."""
+    return Path(file_path).suffix.lower() in VIDEO_EXTENSIONS
+
+
+class VideoModalProcessor(BaseModalProcessor):
+    """Processor for video content with visual + audio dual-channel analysis.
+
+    Combines:
+    - SceneDetect for intelligent scene boundary detection
+    - OpenCV for keyframe extraction
+    - VLM (via modal_caption_func) for visual description
+    - faster-whisper for audio transcription
+    - Timestamp-aligned merging of both channels
+
+    Suitable for:
+    - Meeting recordings (screen share + discussion)
+    - Lectures and tutorials (slides + narration)
+    - Product demos (UI + voiceover)
+    - Surveillance / inspection videos (visual only)
+    - Podcasts with video component
+
+    Example:
+        >>> processor = VideoModalProcessor(
+        ...     lightrag=rag_instance,
+        ...     modal_caption_func=caption_func,
+        ...     whisper_model="large-v3",
+        ... )
+        >>> result = await processor.process_multimodal_content(
+        ...     modal_content={"video_path": "/path/to/meeting.mp4"},
+        ...     content_type="video",
+        ... )
+    """
+
+    def __init__(
+        self,
+        lightrag,
+        modal_caption_func,
+        context_extractor=None,
+        whisper_model: str = None,
+        whisper_device: str = "auto",
+        whisper_compute_type: str = "auto",
+        language: str = None,
+        min_scene_duration: float = 5.0,
+        max_scenes: int = 50,
+        scene_threshold: float = 27.0,
+    ):
+        """Initialize video processor.
+
+        Args:
+            lightrag: LightRAG instance
+            modal_caption_func: Function for generating visual descriptions
+            context_extractor: Context extractor instance
+            whisper_model: Whisper model size (tiny/base/small/medium/large-v3)
+            whisper_device: Device for inference ("auto", "cpu", "cuda")
+            whisper_compute_type: Compute type ("auto", "float16", "int8")
+            language: Language code for ASR (None for auto-detect)
+            min_scene_duration: Minimum scene duration in seconds to keep
+            max_scenes: Maximum number of scenes to process
+            scene_threshold: ContentDetector threshold (lower = more sensitive)
+        """
+        super().__init__(lightrag, modal_caption_func, context_extractor)
+
+        self.whisper_model_name = whisper_model or os.environ.get(
+            "WHISPER_MODEL", "base"
+        )
+        self.whisper_device = whisper_device
+        self.whisper_compute_type = whisper_compute_type
+        self.language = language or os.environ.get("WHISPER_LANGUAGE", None)
+        self.min_scene_duration = min_scene_duration
+        self.max_scenes = max_scenes
+        self.scene_threshold = scene_threshold
+
+        # Lazy-loaded audio processor (shares whisper model config)
+        self._audio_processor = None
+
+    @property
+    def audio_processor(self) -> AudioModalProcessor:
+        """Get or create audio processor for transcription."""
+        if self._audio_processor is None:
+            self._audio_processor = AudioModalProcessor(
+                lightrag=self.lightrag,
+                modal_caption_func=self.modal_caption_func,
+                whisper_model=self.whisper_model_name,
+                whisper_device=self.whisper_device,
+                whisper_compute_type=self.whisper_compute_type,
+                language=self.language,
+                segment_min_length=10,
+            )
+        return self._audio_processor
+
+    def _detect_scenes(self, video_path: str) -> List[Tuple[float, float]]:
+        """Detect scene boundaries using SceneDetect.
+
+        Args:
+            video_path: Path to video file
+
+        Returns:
+            List of (start_seconds, end_seconds) tuples
+        """
+        try:
+            from scenedetect import detect, ContentDetector
+        except ImportError:
+            raise ImportError(
+                "scenedetect is required for video processing. "
+                "Install it with: pip install raganything[video] "
+                "or: pip install scenedetect[opencv]"
+            )
+
+        scene_list = detect(
+            video_path,
+            ContentDetector(threshold=self.scene_threshold),
+        )
+
+        scenes = []
+        for scene in scene_list:
+            start = scene[0].get_seconds()
+            end = scene[1].get_seconds()
+            duration = end - start
+            if duration >= self.min_scene_duration:
+                scenes.append((start, end))
+
+        # If no scenes detected (e.g. static video), treat as single scene
+        if not scenes:
+            cv2 = _load_cv2()
+            cap = cv2.VideoCapture(video_path)
+            total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+            fps = cap.get(cv2.CAP_PROP_FPS)
+            cap.release()
+            if fps > 0:
+                total_duration = total_frames / fps
+                scenes = [(0, total_duration)]
+
+        # Limit number of scenes
+        return scenes[: self.max_scenes]
+
+    def _extract_frame_at(self, video_path: str, timestamp: float) -> Optional[str]:
+        """Extract a single frame at the given timestamp.
+
+        Args:
+            video_path: Path to video file
+            timestamp: Time in seconds
+
+        Returns:
+            Path to saved frame image, or None on failure
+        """
+        cv2 = _load_cv2()
+        cap = cv2.VideoCapture(video_path)
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        if fps <= 0:
+            cap.release()
+            return None
+
+        frame_num = int(timestamp * fps)
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_num)
+        ret, frame = cap.read()
+        cap.release()
+
+        if not ret:
+            return None
+
+        # Save to temp file
+        frame_path = os.path.join(
+            tempfile.gettempdir(),
+            f"raganything_vframe_{os.getpid()}_{timestamp:.1f}.jpg",
+        )
+        cv2.imwrite(frame_path, frame)
+        return frame_path
+
+    def _extract_audio_track(self, video_path: str) -> Optional[str]:
+        """Extract audio track from video file.
+
+        Args:
+            video_path: Path to video file
+
+        Returns:
+            Path to extracted audio WAV file, or None if no audio
+        """
+        try:
+            from moviepy import VideoFileClip
+        except ImportError:
+            raise ImportError(
+                "moviepy is required for video audio extraction. "
+                "Install it with: pip install raganything[video] "
+                "or: pip install moviepy"
+            )
+
+        audio_path = os.path.join(
+            tempfile.gettempdir(),
+            f"raganything_vaudio_{os.getpid()}.wav",
+        )
+
+        try:
+            clip = VideoFileClip(video_path)
+            if clip.audio is None:
+                clip.close()
+                return None
+            clip.audio.write_audiofile(audio_path, logger=None)
+            clip.close()
+            return audio_path
+        except Exception as e:
+            logger.warning(f"Failed to extract audio from {video_path}: {e}")
+            return None
+
+    def _format_timestamp(self, seconds: float) -> str:
+        """Format seconds to HH:MM:SS or MM:SS."""
+        h = int(seconds // 3600)
+        m = int((seconds % 3600) // 60)
+        s = int(seconds % 60)
+        if h > 0:
+            return f"{h}:{m:02d}:{s:02d}"
+        return f"{m}:{s:02d}"
+
+    def _get_transcript_in_range(
+        self,
+        transcript: List[Dict[str, Any]],
+        start: float,
+        end: float,
+    ) -> str:
+        """Get transcript text that falls within a time range."""
+        texts = []
+        for seg in transcript:
+            # Include segment if it overlaps with the range
+            if seg["end"] > start and seg["start"] < end:
+                texts.append(seg["text"])
+        return " ".join(texts).strip()
+
+    async def _describe_scenes(
+        self, video_path: str, scenes: List[Tuple[float, float]]
+    ) -> List[Dict[str, Any]]:
+        """Generate VLM descriptions for each scene.
+
+        Args:
+            video_path: Path to video file
+            scenes: List of (start, end) tuples
+
+        Returns:
+            List of scene dicts with start, end, visual description
+        """
+        results = []
+        for start, end in scenes:
+            # Extract frame from middle of scene
+            mid_time = (start + end) / 2
+            frame_path = self._extract_frame_at(video_path, mid_time)
+
+            visual_desc = ""
+            if frame_path:
+                try:
+                    # Encode frame to base64 for VLM
+                    import base64
+
+                    with open(frame_path, "rb") as f:
+                        image_base64 = base64.b64encode(f.read()).decode("utf-8")
+
+                    prompt = (
+                        f"Describe this video frame in detail. "
+                        f"This is from a video at approximately "
+                        f"{self._format_timestamp(mid_time)}. "
+                        f"Include: what is shown, any text/UI visible, "
+                        f"people/objects present, and the overall context."
+                    )
+                    visual_desc = await self.modal_caption_func(
+                        prompt, image_data=image_base64
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to describe frame at {mid_time:.1f}s: {e}")
+                finally:
+                    if os.path.exists(frame_path):
+                        os.remove(frame_path)
+
+            results.append({"start": start, "end": end, "visual": visual_desc})
+
+        return results
+
+    def _merge_channels(
+        self,
+        visual_segments: List[Dict[str, Any]],
+        audio_segments: List[Dict[str, Any]],
+    ) -> str:
+        """Merge visual and audio channels by timestamp alignment.
+
+        Args:
+            visual_segments: Scene descriptions with start/end/visual
+            audio_segments: Transcription segments with start/end/text
+
+        Returns:
+            Formatted text with aligned visual + audio per scene
+        """
+        lines = []
+        for vs in visual_segments:
+            start_str = self._format_timestamp(vs["start"])
+            end_str = self._format_timestamp(vs["end"])
+
+            # Find audio transcript in this time range
+            audio_text = self._get_transcript_in_range(
+                audio_segments, vs["start"], vs["end"]
+            )
+
+            line = f"[{start_str}-{end_str}]"
+            if vs.get("visual"):
+                line += f" 画面：{vs['visual']}"
+            if audio_text:
+                line += f" | 语音：{audio_text}"
+
+            # Only add if we have at least one channel
+            if vs.get("visual") or audio_text:
+                lines.append(line)
+
+        return "\n\n".join(lines)
+
+    async def generate_description_only(
+        self,
+        modal_content,
+        content_type: str,
+        item_info: Dict[str, Any] = None,
+        entity_name: str = None,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Generate video description using dual-channel analysis.
+
+        Args:
+            modal_content: Video content dict with 'video_path' key
+            content_type: Type of modal content ("video")
+            item_info: Item information for context
+            entity_name: Optional predefined entity name
+
+        Returns:
+            Tuple of (merged_description, entity_info)
+        """
+        try:
+            # Parse video content
+            if isinstance(modal_content, str):
+                try:
+                    content_data = json.loads(modal_content)
+                except json.JSONDecodeError:
+                    content_data = {"video_path": modal_content}
+            else:
+                content_data = modal_content
+
+            video_path = content_data.get("video_path") or content_data.get("img_path")
+            if not video_path:
+                raise ValueError(
+                    f"No video path provided in modal_content: {modal_content}"
+                )
+
+            if not Path(video_path).exists():
+                raise FileNotFoundError(f"Video file not found: {video_path}")
+
+            logger.info(f"Processing video: {video_path}")
+
+            # Step 1: Detect scenes
+            scenes = self._detect_scenes(video_path)
+            logger.info(f"Detected {len(scenes)} scenes")
+
+            # Step 2: Visual channel - describe each scene
+            visual_segments = await self._describe_scenes(video_path, scenes)
+
+            # Step 3: Audio channel - extract and transcribe
+            audio_segments = []
+            audio_path = self._extract_audio_track(video_path)
+            if audio_path:
+                try:
+                    audio_segments = self.audio_processor.transcribe(audio_path)
+                except Exception as e:
+                    logger.warning(f"Audio transcription failed: {e}")
+                finally:
+                    if os.path.exists(audio_path):
+                        os.remove(audio_path)
+
+            # Step 4: Merge by timestamp
+            merged_description = self._merge_channels(visual_segments, audio_segments)
+
+            if not merged_description:
+                merged_description = f"Video file: {Path(video_path).name}"
+
+            # Generate entity info
+            filename = Path(video_path).stem
+            total_duration = scenes[-1][1] if scenes else 0
+            entity_info = {
+                "entity_name": entity_name if entity_name else f"video_{filename}",
+                "entity_type": "video",
+                "summary": (
+                    f"Video ({self._format_timestamp(total_duration)} duration, "
+                    f"{len(scenes)} scenes). "
+                    f"{merged_description[:150]}..."
+                ),
+            }
+
+            return merged_description, entity_info
+
+        except Exception as e:
+            logger.error(f"Error generating video description: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                if entity_name
+                else f"video_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "video",
+                "summary": f"Video content: {str(modal_content)[:100]}",
+            }
+            return str(modal_content), fallback_entity
+
+    async def process_multimodal_content(
+        self,
+        modal_content,
+        content_type: str,
+        file_path: str = "manual_creation",
+        entity_name: str = None,
+        item_info: Dict[str, Any] = None,
+        batch_mode: bool = False,
+        doc_id: str = None,
+        chunk_order_index: int = 0,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Process video content: analyze and insert into knowledge graph.
+
+        Args:
+            modal_content: Video content dict with 'video_path' key
+            content_type: Type of modal content ("video")
+            file_path: Source file path for attribution
+            entity_name: Optional entity name
+            item_info: Item info for context
+            batch_mode: Whether in batch processing mode
+            doc_id: Document ID
+            chunk_order_index: Chunk ordering index
+
+        Returns:
+            Tuple of (chunk_text, entity_info)
+        """
+        try:
+            # Generate description using dual-channel analysis
+            description, entity_info = await self.generate_description_only(
+                modal_content, content_type, item_info, entity_name
+            )
+
+            # Parse video path
+            if isinstance(modal_content, str):
+                try:
+                    content_data = json.loads(modal_content)
+                except json.JSONDecodeError:
+                    content_data = {"video_path": modal_content}
+            else:
+                content_data = modal_content
+
+            video_path = content_data.get("video_path") or content_data.get(
+                "img_path", ""
+            )
+
+            # Build video chunk text
+            modal_chunk = (
+                f"[Video Content]\n"
+                f"Source: {video_path}\n"
+                f"Entity: {entity_info['entity_name']}\n"
+                f"Analysis:\n{description}"
+            )
+
+            return await self._create_entity_and_chunk(
+                modal_chunk,
+                entity_info,
+                file_path,
+                batch_mode,
+                doc_id,
+                chunk_order_index,
+            )
+
+        except Exception as e:
+            logger.error(f"Error processing video content: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                if entity_name
+                else f"video_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "video",
+                "summary": f"Video content: {str(modal_content)[:100]}",
+            }
+            return str(modal_content), fallback_entity

--- a/raganything/modalprocessors_video.py
+++ b/raganything/modalprocessors_video.py
@@ -37,6 +37,7 @@ from lightrag.utils import compute_mdhash_id
 
 from .modalprocessors import BaseModalProcessor
 from .modalprocessors_audio import AudioModalProcessor
+from .prompt import PROMPTS
 
 logger = logging.getLogger(__name__)
 
@@ -352,10 +353,14 @@ class VideoModalProcessor(BaseModalProcessor):
                             f"This is from a video at approximately "
                             f"{self._format_timestamp(mid_time)}. "
                             f"Include: what is shown, any text/UI visible, "
-                            f"people/objects present, and the overall context."
+                            f"people/objects present, and the overall context. "
+                            f"If the frame is a solid color or otherwise minimal, "
+                            f"still describe what is visible (e.g. the dominant color)."
                         )
                         visual_desc = await self.modal_caption_func(
-                            prompt, image_data=image_base64
+                            prompt,
+                            image_data=image_base64,
+                            system_prompt=PROMPTS["IMAGE_ANALYSIS_SYSTEM"],
                         )
                     except Exception as e:
                         logger.warning(

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1195,9 +1195,7 @@ class ProcessorMixin:
                 )
 
                 return (
-                    f"[Video Content]\n"
-                    f"Source: {video_path}\n"
-                    f"Analysis:\n{description}"
+                    f"[Video Content]\nSource: {video_path}\nAnalysis:\n{description}"
                 )
 
             else:  # generic or unknown types

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -747,6 +747,9 @@ class ProcessorMixin:
         existing_chunks_count = (
             existing_doc_status.get("chunks_count", 0) if existing_doc_status else 0
         )
+        # Running order index; advanced per produced chunk so multi-window items
+        # (long audio/video) don't collide with subsequent items.
+        next_order = existing_chunks_count
 
         for i, item in enumerate(multimodal_items):
             try:
@@ -778,17 +781,23 @@ class ProcessorMixin:
                         item_info=item_info,  # Pass item info for context extraction
                         batch_mode=True,
                         doc_id=doc_id,  # Pass doc_id for proper association
-                        chunk_order_index=existing_chunks_count
-                        + i,  # Proper order index
+                        chunk_order_index=next_order,  # Running order index
                     )
 
                     # Collect chunk results for batch processing
                     all_chunk_results.extend(chunk_results)
 
-                    # Extract chunk ID from the entity_info (actual chunk_id created by processor)
-                    if entity_info and "chunk_id" in entity_info:
-                        chunk_id = entity_info["chunk_id"]
-                        multimodal_chunk_ids.append(chunk_id)
+                    # Register every chunk id created (an item may yield several,
+                    # e.g. long audio/video split into windows) and advance the
+                    # running order index past all of them.
+                    if entity_info and entity_info.get("chunk_ids"):
+                        item_chunk_ids = entity_info["chunk_ids"]
+                    elif entity_info and "chunk_id" in entity_info:
+                        item_chunk_ids = [entity_info["chunk_id"]]
+                    else:
+                        item_chunk_ids = []
+                    multimodal_chunk_ids.extend(item_chunk_ids)
+                    next_order += max(1, len(item_chunk_ids))
 
                     self.logger.info(
                         f"{content_type} processing complete: {entity_info.get('entity_name', 'Unknown')}"
@@ -944,11 +953,10 @@ class ProcessorMixin:
                         "type": content_type,
                     }
 
-                    # Call the correct processor's description generation method
-                    (
-                        description,
-                        entity_info,
-                    ) = await processor.generate_description_only(
+                    # Call the processor's section generator. Most items map to a
+                    # single section; long audio/video may produce several ordered
+                    # sections (windows), each becoming its own chunk.
+                    sections = await processor.generate_chunk_sections(
                         modal_content=item,
                         content_type=content_type,
                         item_info=item_info,
@@ -967,17 +975,29 @@ class ProcessorMixin:
                                 f"Multimodal chunk generation progress: {completed_count}/{total_items} ({progress_percent:.1f}%)"
                             )
 
-                    return {
-                        "index": index,
-                        "content_type": content_type,
-                        "description": description,
-                        "entity_info": entity_info,
-                        "original_item": item,
-                        "item_info": item_info,
-                        "chunk_order_index": existing_chunks_count + index,
-                        "processor": processor,  # Keep reference to the processor used
-                        "file_path": file_path,  # Add file_path to the result
-                    }
+                    # One data dict per section. chunk_order_index is assigned
+                    # after gather (a single item can yield multiple chunks).
+                    section_results = []
+                    for section in sections:
+                        window_meta = section.get("window_meta")
+                        section_item = (
+                            {**item, "_window_meta": window_meta}
+                            if window_meta
+                            else item
+                        )
+                        section_results.append(
+                            {
+                                "index": index,
+                                "content_type": content_type,
+                                "description": section["description"],
+                                "entity_info": section["entity_info"],
+                                "original_item": section_item,
+                                "item_info": item_info,
+                                "processor": processor,
+                                "file_path": file_path,
+                            }
+                        )
+                    return section_results
 
                 except Exception as e:
                     # Update progress even on error (non-blocking)
@@ -1007,14 +1027,21 @@ class ProcessorMixin:
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Filter successful results
+        # Filter successful results and flatten sections (one item -> N sections).
+        # Sections are kept in original item order, then audio/video windows in
+        # their natural order, so a running counter yields correct chunk ordering.
         multimodal_data_list = []
+        running_offset = 0
         for result in results:
             if isinstance(result, Exception):
                 self.logger.error(f"Task failed: {result}")
                 continue
-            if result is not None:
-                multimodal_data_list.append(result)
+            if not result:
+                continue
+            for data in result:
+                data["chunk_order_index"] = existing_chunks_count + running_offset
+                running_offset += 1
+                multimodal_data_list.append(data)
 
         if not multimodal_data_list:
             self.logger.warning("No valid multimodal descriptions generated")
@@ -1106,6 +1133,13 @@ class ProcessorMixin:
         )
         return chunks
 
+    @staticmethod
+    def _format_window_part(window_meta: Optional[Dict[str, Any]]) -> str:
+        """Render the ' — part k/N' suffix for a windowed media chunk, if any."""
+        if not window_meta:
+            return ""
+        return f" — part {window_meta['part']}/{window_meta['total']}"
+
     def _apply_chunk_template(
         self, content_type: str, original_item: Dict[str, Any], description: str
     ) -> str:
@@ -1182,9 +1216,10 @@ class ProcessorMixin:
                 audio_path = original_item.get(
                     "audio_path", original_item.get("img_path", "")
                 )
+                part = self._format_window_part(original_item.get("_window_meta"))
 
                 return (
-                    f"[Audio Content]\n"
+                    f"[Audio Content]{part}\n"
                     f"Source: {audio_path}\n"
                     f"Transcription:\n{description}"
                 )
@@ -1193,9 +1228,12 @@ class ProcessorMixin:
                 video_path = original_item.get(
                     "video_path", original_item.get("img_path", "")
                 )
+                part = self._format_window_part(original_item.get("_window_meta"))
 
                 return (
-                    f"[Video Content]\nSource: {video_path}\nAnalysis:\n{description}"
+                    f"[Video Content]{part}\n"
+                    f"Source: {video_path}\n"
+                    f"Analysis:\n{description}"
                 )
 
             else:  # generic or unknown types

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1178,6 +1178,28 @@ class ProcessorMixin:
                     enhanced_caption=description,
                 )
 
+            elif content_type == "audio":
+                audio_path = original_item.get(
+                    "audio_path", original_item.get("img_path", "")
+                )
+
+                return (
+                    f"[Audio Content]\n"
+                    f"Source: {audio_path}\n"
+                    f"Transcription:\n{description}"
+                )
+
+            elif content_type == "video":
+                video_path = original_item.get(
+                    "video_path", original_item.get("img_path", "")
+                )
+
+                return (
+                    f"[Video Content]\n"
+                    f"Source: {video_path}\n"
+                    f"Analysis:\n{description}"
+                )
+
             else:  # generic or unknown types
                 content = str(original_item.get("content", original_item))
 

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -46,6 +46,18 @@ from raganything.modalprocessors import (
     ContextConfig,
 )
 
+# Optional processors: only available when their extra dependencies are installed
+# (audio -> faster-whisper; video -> scenedetect + moviepy + opencv + faster-whisper).
+try:
+    from raganything.modalprocessors_audio import AudioModalProcessor
+except ImportError:
+    AudioModalProcessor = None
+
+try:
+    from raganything.modalprocessors_video import VideoModalProcessor
+except ImportError:
+    VideoModalProcessor = None
+
 
 @dataclass
 class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
@@ -234,6 +246,43 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                 modal_caption_func=self.llm_model_func,
                 context_extractor=self.context_extractor,
             )
+
+        if self.config.enable_audio_processing:
+            if AudioModalProcessor is None:
+                self.logger.warning(
+                    "enable_audio_processing=True but audio dependencies are missing. "
+                    "Install them with: pip install raganything[audio]. "
+                    "Audio content will fall back to the generic processor."
+                )
+            else:
+                self.modal_processors["audio"] = AudioModalProcessor(
+                    lightrag=self.lightrag,
+                    modal_caption_func=self.llm_model_func,
+                    context_extractor=self.context_extractor,
+                )
+
+        if self.config.enable_video_processing:
+            if VideoModalProcessor is None:
+                self.logger.warning(
+                    "enable_video_processing=True but video dependencies are missing. "
+                    "Install them with: pip install raganything[video]. "
+                    "Video content will fall back to the generic processor."
+                )
+            else:
+                from lightrag.utils import get_env_value
+
+                self.modal_processors["video"] = VideoModalProcessor(
+                    lightrag=self.lightrag,
+                    modal_caption_func=self.vision_model_func or self.llm_model_func,
+                    context_extractor=self.context_extractor,
+                    min_scene_duration=get_env_value(
+                        "VIDEO_MIN_SCENE_DURATION", 5.0, float
+                    ),
+                    max_scenes=get_env_value("VIDEO_MAX_SCENES", 50, int),
+                    scene_threshold=get_env_value(
+                        "VIDEO_SCENE_THRESHOLD", 27.0, float
+                    ),
+                )
 
         # Always include generic processor as fallback
         self.modal_processors["generic"] = GenericModalProcessor(

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -46,17 +46,18 @@ from raganything.modalprocessors import (
     ContextConfig,
 )
 
-# Optional processors: only available when their extra dependencies are installed
+# Optional processors. The modules themselves import cleanly (heavy deps are
+# loaded lazily), so we gate registration on the *runtime* availability of the
+# extra dependencies via the ``*_deps_available`` helpers below.
 # (audio -> faster-whisper; video -> scenedetect + moviepy + opencv + faster-whisper).
-try:
-    from raganything.modalprocessors_audio import AudioModalProcessor
-except ImportError:
-    AudioModalProcessor = None
-
-try:
-    from raganything.modalprocessors_video import VideoModalProcessor
-except ImportError:
-    VideoModalProcessor = None
+from raganything.modalprocessors_audio import (
+    AudioModalProcessor,
+    audio_deps_available,
+)
+from raganything.modalprocessors_video import (
+    VideoModalProcessor,
+    video_deps_available,
+)
 
 
 @dataclass
@@ -248,7 +249,7 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
             )
 
         if self.config.enable_audio_processing:
-            if AudioModalProcessor is None:
+            if not audio_deps_available():
                 self.logger.warning(
                     "enable_audio_processing=True but audio dependencies are missing. "
                     "Install them with: pip install raganything[audio]. "
@@ -262,7 +263,7 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                 )
 
         if self.config.enable_video_processing:
-            if VideoModalProcessor is None:
+            if not video_deps_available():
                 self.logger.warning(
                     "enable_video_processing=True but video dependencies are missing. "
                     "Install them with: pip install raganything[video]. "
@@ -280,6 +281,9 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                     ),
                     max_scenes=get_env_value("VIDEO_MAX_SCENES", 50, int),
                     scene_threshold=get_env_value("VIDEO_SCENE_THRESHOLD", 27.0, float),
+                    max_windows=get_env_value("VIDEO_MAX_WINDOWS", 100, int),
+                    # Reuse the audio processor's whisper model when audio is enabled
+                    audio_processor=self.modal_processors.get("audio"),
                 )
 
         # Always include generic processor as fallback

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -279,9 +279,7 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                         "VIDEO_MIN_SCENE_DURATION", 5.0, float
                     ),
                     max_scenes=get_env_value("VIDEO_MAX_SCENES", 50, int),
-                    scene_threshold=get_env_value(
-                        "VIDEO_SCENE_THRESHOLD", 27.0, float
-                    ),
+                    scene_threshold=get_env_value("VIDEO_SCENE_THRESHOLD", 27.0, float),
                 )
 
         # Always include generic processor as fallback

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -437,6 +437,12 @@ def get_processor_for_type(modal_processors: Dict[str, Any], content_type: str):
         return modal_processors.get("table")
     elif content_type == "equation":
         return modal_processors.get("equation")
+    elif content_type == "audio":
+        # Fall back to generic when audio processing is disabled / deps missing
+        return modal_processors.get("audio") or modal_processors.get("generic")
+    elif content_type == "video":
+        # Fall back to generic when video processing is disabled / deps missing
+        return modal_processors.get("video") or modal_processors.get("generic")
     else:
         # For other types, use generic processor
         return modal_processors.get("generic")
@@ -462,6 +468,16 @@ def get_processor_supports(proc_type: str) -> List[str]:
             "Variable identification",
             "Formula meaning explanation",
             "Formula entity extraction",
+        ],
+        "audio": [
+            "Speech-to-text transcription",
+            "Timestamped segment extraction",
+            "Audio entity extraction",
+        ],
+        "video": [
+            "Scene detection and keyframe analysis",
+            "Visual + audio dual-channel understanding",
+            "Video entity extraction",
         ],
         "generic": [
             "General content analysis",

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -1,21 +1,31 @@
 """Tests for the AudioModalProcessor."""
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from raganything.modalprocessors_audio import is_audio_file
+from raganything.modalprocessors_audio import AudioModalProcessor, is_audio_file
 
-# AudioModalProcessor requires faster-whisper for full functionality,
-# but we can test it with mocked whisper model
-try:
-    import faster_whisper  # noqa: F401
 
-    HAS_FASTER_WHISPER = True
-except ImportError:
-    HAS_FASTER_WHISPER = False
+@dataclass
+class _FakeLightRAG:
+    """Minimal dataclass stand-in for a LightRAG instance.
 
-from raganything.modalprocessors_audio import AudioModalProcessor
+    ``BaseModalProcessor.__init__`` calls ``dataclasses.asdict`` on the lightrag
+    object, which requires a real dataclass instance (a plain ``MagicMock``
+    raises ``TypeError``). Only attribute access is exercised by these tests.
+    """
+
+    text_chunks: object = None
+    chunks_vdb: object = None
+    entities_vdb: object = None
+    relationships_vdb: object = None
+    chunk_entity_relation_graph: object = None
+    embedding_func: object = None
+    llm_model_func: object = None
+    llm_response_cache: object = None
+    tokenizer: object = None
 
 
 class TestIsAudioFile:
@@ -43,8 +53,7 @@ class TestAudioModalProcessorInit:
     """Test AudioModalProcessor initialization."""
 
     def test_default_init(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         caption_func = AsyncMock()
 
         processor = AudioModalProcessor(
@@ -56,8 +65,7 @@ class TestAudioModalProcessorInit:
         assert processor.language is None
 
     def test_custom_model(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         caption_func = AsyncMock()
 
         processor = AudioModalProcessor(
@@ -73,8 +81,7 @@ class TestAudioModalProcessorInit:
         monkeypatch.setenv("WHISPER_MODEL", "medium")
         monkeypatch.setenv("WHISPER_LANGUAGE", "en")
 
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         caption_func = AsyncMock()
 
         processor = AudioModalProcessor(
@@ -89,8 +96,7 @@ class TestFormatTimestamp:
     """Test timestamp formatting."""
 
     def setup_method(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         self.processor = AudioModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -113,8 +119,7 @@ class TestSegmentsToText:
     """Test segment formatting."""
 
     def setup_method(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         self.processor = AudioModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -144,8 +149,7 @@ class TestGenerateDescriptionOnly:
     """Test the generate_description_only method."""
 
     async def test_file_not_found(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         processor = AudioModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -159,8 +163,7 @@ class TestGenerateDescriptionOnly:
         assert entity_info["entity_type"] == "audio"
 
     async def test_with_dict_content(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         processor = AudioModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -184,8 +187,7 @@ class TestGenerateDescriptionOnly:
         assert "audio_test" in entity_info["entity_name"]
 
     async def test_with_string_content(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         processor = AudioModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -255,7 +255,9 @@ class TestAudioChunkSections:
         processor.transcribe = MagicMock(
             return_value=[{"start": 0, "end": 5, "text": "Hello world"}]
         )
-        sections = await processor.generate_chunk_sections({"audio_path": "a.mp3"}, "audio")
+        sections = await processor.generate_chunk_sections(
+            {"audio_path": "a.mp3"}, "audio"
+        )
         assert len(sections) == 1
         assert sections[0]["window_meta"] is None
         assert sections[0]["entity_info"]["entity_name"] == "audio_a"
@@ -280,7 +282,11 @@ class TestAudioChunkSections:
         assert [s["window_meta"]["part"] for s in sections] == [1, 2, 3]
         assert all(s["window_meta"]["total"] == 3 for s in sections)
         names = [s["entity_info"]["entity_name"] for s in sections]
-        assert names == ["audio_meeting_part1", "audio_meeting_part2", "audio_meeting_part3"]
+        assert names == [
+            "audio_meeting_part1",
+            "audio_meeting_part2",
+            "audio_meeting_part3",
+        ]
 
 
 class TestAudioDepsAvailable:

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from raganything.modalprocessors_audio import AudioModalProcessor, is_audio_file
+from raganything.modalprocessors_audio import (
+    AudioModalProcessor,
+    audio_deps_available,
+    is_audio_file,
+)
 
 
 @dataclass
@@ -26,6 +30,7 @@ class _FakeLightRAG:
     llm_model_func: object = None
     llm_response_cache: object = None
     tokenizer: object = None
+    chunk_token_size: int = 1200
 
 
 class TestIsAudioFile:
@@ -202,3 +207,95 @@ class TestGenerateDescriptionOnly:
             "audio",
         )
         assert "[0:00-0:05] Hello" in result
+
+
+class TestGroupSegmentsByTokens:
+    """Test token-bounded grouping of transcription segments."""
+
+    def _processor(self, chunk_token_size=1200):
+        lightrag = _FakeLightRAG(chunk_token_size=chunk_token_size)
+        return AudioModalProcessor(lightrag=lightrag, modal_caption_func=AsyncMock())
+
+    def test_empty(self):
+        assert self._processor()._group_segments_by_tokens([]) == []
+
+    def test_single_window_under_budget(self):
+        processor = self._processor(chunk_token_size=1000)
+        segs = [
+            {"start": 0, "end": 5, "text": "short one"},
+            {"start": 5, "end": 10, "text": "short two"},
+        ]
+        windows = processor._group_segments_by_tokens(segs)
+        assert len(windows) == 1
+        assert len(windows[0]) == 2
+
+    def test_splits_when_over_budget(self):
+        # No tokenizer -> ~len/4 tokens; ~200 chars => ~50 tokens each.
+        processor = self._processor(chunk_token_size=50)
+        long_text = "word " * 40  # 200 chars
+        segs = [{"start": i, "end": i + 1, "text": long_text} for i in range(4)]
+        windows = processor._group_segments_by_tokens(segs)
+        assert len(windows) == 4  # each segment lands in its own window
+
+    def test_oversized_single_segment_is_its_own_window(self):
+        processor = self._processor(chunk_token_size=10)
+        segs = [{"start": 0, "end": 5, "text": "x" * 400}]
+        windows = processor._group_segments_by_tokens(segs)
+        assert len(windows) == 1
+
+
+@pytest.mark.asyncio
+class TestAudioChunkSections:
+    """Test the 1->N generate_chunk_sections for audio."""
+
+    async def test_short_audio_single_section(self):
+        processor = AudioModalProcessor(
+            lightrag=_FakeLightRAG(), modal_caption_func=AsyncMock()
+        )
+        processor.transcribe = MagicMock(
+            return_value=[{"start": 0, "end": 5, "text": "Hello world"}]
+        )
+        sections = await processor.generate_chunk_sections({"audio_path": "a.mp3"}, "audio")
+        assert len(sections) == 1
+        assert sections[0]["window_meta"] is None
+        assert sections[0]["entity_info"]["entity_name"] == "audio_a"
+
+    async def test_long_audio_multiple_sections(self):
+        processor = AudioModalProcessor(
+            lightrag=_FakeLightRAG(chunk_token_size=50),
+            modal_caption_func=AsyncMock(),
+        )
+        long_text = "word " * 40
+        processor.transcribe = MagicMock(
+            return_value=[
+                {"start": i * 10, "end": i * 10 + 9, "text": long_text}
+                for i in range(3)
+            ]
+        )
+        sections = await processor.generate_chunk_sections(
+            {"audio_path": "meeting.mp3"}, "audio"
+        )
+        assert len(sections) == 3
+        # Ordered part metadata + unique entity names
+        assert [s["window_meta"]["part"] for s in sections] == [1, 2, 3]
+        assert all(s["window_meta"]["total"] == 3 for s in sections)
+        names = [s["entity_info"]["entity_name"] for s in sections]
+        assert names == ["audio_meeting_part1", "audio_meeting_part2", "audio_meeting_part3"]
+
+
+class TestAudioDepsAvailable:
+    """Test optional-dependency detection."""
+
+    def test_returns_false_when_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "raganything.modalprocessors_audio.importlib.util.find_spec",
+            lambda name: None,
+        )
+        assert audio_deps_available() is False
+
+    def test_returns_true_when_present(self, monkeypatch):
+        monkeypatch.setattr(
+            "raganything.modalprocessors_audio.importlib.util.find_spec",
+            lambda name: object(),
+        )
+        assert audio_deps_available() is True

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -1,0 +1,202 @@
+"""Tests for the AudioModalProcessor."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from raganything.modalprocessors_audio import is_audio_file
+
+# AudioModalProcessor requires faster-whisper for full functionality,
+# but we can test it with mocked whisper model
+try:
+    import faster_whisper  # noqa: F401
+
+    HAS_FASTER_WHISPER = True
+except ImportError:
+    HAS_FASTER_WHISPER = False
+
+from raganything.modalprocessors_audio import AudioModalProcessor
+
+
+class TestIsAudioFile:
+    """Test audio file detection."""
+
+    def test_supported_extensions(self):
+        assert is_audio_file("meeting.mp3")
+        assert is_audio_file("recording.wav")
+        assert is_audio_file("podcast.flac")
+        assert is_audio_file("voice.m4a")
+        assert is_audio_file("music.ogg")
+        assert is_audio_file("/path/to/file.WAV")  # case insensitive
+        assert is_audio_file("call.aac")
+        assert is_audio_file("audio.opus")
+
+    def test_unsupported_extensions(self):
+        assert not is_audio_file("document.pdf")
+        assert not is_audio_file("image.png")
+        assert not is_audio_file("video.mp4")
+        assert not is_audio_file("text.txt")
+        assert not is_audio_file("no_extension")
+
+
+class TestAudioModalProcessorInit:
+    """Test AudioModalProcessor initialization."""
+
+    def test_default_init(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        caption_func = AsyncMock()
+
+        processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=caption_func,
+        )
+        assert processor.whisper_model_name == "base"
+        assert processor.whisper_device == "auto"
+        assert processor.language is None
+
+    def test_custom_model(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        caption_func = AsyncMock()
+
+        processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=caption_func,
+            whisper_model="large-v3",
+            language="zh",
+        )
+        assert processor.whisper_model_name == "large-v3"
+        assert processor.language == "zh"
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("WHISPER_MODEL", "medium")
+        monkeypatch.setenv("WHISPER_LANGUAGE", "en")
+
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        caption_func = AsyncMock()
+
+        processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=caption_func,
+        )
+        assert processor.whisper_model_name == "medium"
+        assert processor.language == "en"
+
+
+class TestFormatTimestamp:
+    """Test timestamp formatting."""
+
+    def setup_method(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        self.processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+    def test_seconds_only(self):
+        assert self.processor._format_timestamp(45) == "0:45"
+
+    def test_minutes_and_seconds(self):
+        assert self.processor._format_timestamp(125) == "2:05"
+
+    def test_hours(self):
+        assert self.processor._format_timestamp(3661) == "1:01:01"
+
+    def test_zero(self):
+        assert self.processor._format_timestamp(0) == "0:00"
+
+
+class TestSegmentsToText:
+    """Test segment formatting."""
+
+    def setup_method(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        self.processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+    def test_single_segment(self):
+        segments = [{"start": 0, "end": 30, "text": "Hello world"}]
+        result = self.processor._segments_to_text(segments)
+        assert result == "[0:00-0:30] Hello world"
+
+    def test_multiple_segments(self):
+        segments = [
+            {"start": 0, "end": 30, "text": "First segment"},
+            {"start": 30, "end": 65, "text": "Second segment"},
+        ]
+        result = self.processor._segments_to_text(segments)
+        assert "[0:00-0:30] First segment" in result
+        assert "[0:30-1:05] Second segment" in result
+
+    def test_empty_segments(self):
+        result = self.processor._segments_to_text([])
+        assert result == ""
+
+
+@pytest.mark.asyncio
+class TestGenerateDescriptionOnly:
+    """Test the generate_description_only method."""
+
+    async def test_file_not_found(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+        # Should return fallback on missing file
+        result, entity_info = await processor.generate_description_only(
+            {"audio_path": "/nonexistent/file.mp3"},
+            "audio",
+        )
+        assert entity_info["entity_type"] == "audio"
+
+    async def test_with_dict_content(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+        # Mock transcribe to avoid needing actual audio
+        mock_segments = [
+            {"start": 0, "end": 10, "text": "This is a test transcription"},
+            {"start": 10, "end": 20, "text": "Second part of the audio"},
+        ]
+        processor.transcribe = MagicMock(return_value=mock_segments)
+
+        result, entity_info = await processor.generate_description_only(
+            {"audio_path": "/tmp/test.mp3"},
+            "audio",
+        )
+
+        assert "[0:00-0:10] This is a test transcription" in result
+        assert "[0:10-0:20] Second part of the audio" in result
+        assert entity_info["entity_type"] == "audio"
+        assert "audio_test" in entity_info["entity_name"]
+
+    async def test_with_string_content(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        processor = AudioModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+        mock_segments = [{"start": 0, "end": 5, "text": "Hello"}]
+        processor.transcribe = MagicMock(return_value=mock_segments)
+
+        # Pass path as string directly
+        result, entity_info = await processor.generate_description_only(
+            "/tmp/test.mp3",
+            "audio",
+        )
+        assert "[0:00-0:05] Hello" in result

--- a/tests/test_modalprocessors_config.py
+++ b/tests/test_modalprocessors_config.py
@@ -4,6 +4,12 @@ import types
 from dataclasses import dataclass
 from pathlib import Path
 
+# Import the real modules up front so every sys.modules key this file
+# manipulates has a genuine cached entry for monkeypatch to record and
+# restore — otherwise a key first imported inside the stubbed fixture
+# would leak a stub-derived module into the rest of the session.
+import raganything.modalprocessors  # noqa: F401  (imports .prompt and .utils too)
+
 
 class FakeLogger:
     def info(self, *args, **kwargs):
@@ -66,13 +72,20 @@ def _import_modalprocessors_with_lightrag_stubs(monkeypatch):
     operate_module.extract_entities = None
     operate_module.merge_nodes_and_edges = None
 
+    # Remove cached modules THROUGH monkeypatch so teardown restores the
+    # real entries. A bare sys.modules.pop() before setitem() made
+    # monkeypatch record "absent" as the original value: its LIFO undo then
+    # deleted the keys instead of restoring the real package, and every
+    # test module imported afterwards got a fresh, stub-derived
+    # `raganything` — which is why unrelated monkeypatch.setattr targets
+    # (e.g. raganything.modalprocessors_video) vanished mid-session.
     for module_name in [
         "raganything",
         "raganything.prompt",
         "raganything.utils",
         "raganything.modalprocessors",
     ]:
-        sys.modules.pop(module_name, None)
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
 
     monkeypatch.setitem(sys.modules, "raganything", raganything_package)
     monkeypatch.setitem(sys.modules, "lightrag", lightrag_package)
@@ -88,21 +101,15 @@ def _import_modalprocessors_with_lightrag_stubs(monkeypatch):
 
 
 def test_base_modal_processor_uses_lightrag_runtime_global_config(monkeypatch):
-    try:
-        modalprocessors = _import_modalprocessors_with_lightrag_stubs(monkeypatch)
-        lightrag = FakeLightRAG()
+    # No manual cleanup: the fixture registers every sys.modules mutation
+    # with monkeypatch, whose LIFO teardown restores the real modules.
+    modalprocessors = _import_modalprocessors_with_lightrag_stubs(monkeypatch)
+    lightrag = FakeLightRAG()
 
-        processor = modalprocessors.BaseModalProcessor(
-            lightrag=lightrag,
-            modal_caption_func=lambda *args, **kwargs: "",
-        )
+    processor = modalprocessors.BaseModalProcessor(
+        lightrag=lightrag,
+        modal_caption_func=lambda *args, **kwargs: "",
+    )
 
-        assert processor.global_config["working_dir"] == "workdir"
-        assert processor.global_config["role_llm_funcs"] is lightrag.role_llm_funcs
-    finally:
-        for module_name in [
-            "raganything.prompt",
-            "raganything.utils",
-            "raganything.modalprocessors",
-        ]:
-            sys.modules.pop(module_name, None)
+    assert processor.global_config["working_dir"] == "workdir"
+    assert processor.global_config["role_llm_funcs"] is lightrag.role_llm_funcs

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -1,20 +1,31 @@
 """Tests for the VideoModalProcessor."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from raganything.modalprocessors_video import is_video_file
+from raganything.modalprocessors_video import VideoModalProcessor, is_video_file
 
-try:
-    import cv2
-    import faster_whisper
 
-    HAS_VIDEO_DEPS = True
-except ImportError:
-    HAS_VIDEO_DEPS = False
+@dataclass
+class _FakeLightRAG:
+    """Minimal dataclass stand-in for a LightRAG instance.
 
-from raganything.modalprocessors_video import VideoModalProcessor
+    ``BaseModalProcessor.__init__`` calls ``dataclasses.asdict`` on the lightrag
+    object, which requires a real dataclass instance (a plain ``MagicMock``
+    raises ``TypeError``). Only attribute access is exercised by these tests.
+    """
+
+    text_chunks: object = None
+    chunks_vdb: object = None
+    entities_vdb: object = None
+    relationships_vdb: object = None
+    chunk_entity_relation_graph: object = None
+    embedding_func: object = None
+    llm_model_func: object = None
+    llm_response_cache: object = None
+    tokenizer: object = None
 
 
 class TestIsVideoFile:
@@ -42,8 +53,7 @@ class TestVideoModalProcessorInit:
     """Test VideoModalProcessor initialization."""
 
     def test_default_init(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         caption_func = AsyncMock()
 
         processor = VideoModalProcessor(
@@ -56,8 +66,7 @@ class TestVideoModalProcessorInit:
         assert processor.scene_threshold == 27.0
 
     def test_custom_config(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         caption_func = AsyncMock()
 
         processor = VideoModalProcessor(
@@ -78,8 +87,7 @@ class TestTimestampFormatting:
     """Test timestamp formatting."""
 
     def setup_method(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         self.processor = VideoModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -102,8 +110,7 @@ class TestGetTranscriptInRange:
     """Test transcript time-range filtering."""
 
     def setup_method(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         self.processor = VideoModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -140,8 +147,7 @@ class TestMergeChannels:
     """Test visual + audio channel merging."""
 
     def setup_method(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         self.processor = VideoModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -197,8 +203,7 @@ class TestGenerateDescriptionOnly:
     """Test the generate_description_only method."""
 
     async def test_missing_file(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+        lightrag = _FakeLightRAG()
         processor = VideoModalProcessor(
             lightrag=lightrag,
             modal_caption_func=AsyncMock(),
@@ -210,9 +215,8 @@ class TestGenerateDescriptionOnly:
         )
         assert entity_info["entity_type"] == "video"
 
-    async def test_with_mocked_pipeline(self):
-        lightrag = MagicMock()
-        lightrag.tokenizer = None
+    async def test_with_mocked_pipeline(self, tmp_path):
+        lightrag = _FakeLightRAG()
         caption_func = AsyncMock(return_value="A person presenting slides")
         processor = VideoModalProcessor(
             lightrag=lightrag,
@@ -229,8 +233,13 @@ class TestGenerateDescriptionOnly:
         )
         processor._extract_audio_track = MagicMock(return_value=None)
 
+        # generate_description_only checks the path exists before running the
+        # (mocked) pipeline, so point it at a real, empty file.
+        video_file = tmp_path / "test.mp4"
+        video_file.write_bytes(b"")
+
         result, entity_info = await processor.generate_description_only(
-            {"video_path": "/tmp/test.mp4"},
+            {"video_path": str(video_file)},
             "video",
         )
 

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -361,6 +361,33 @@ class TestVideoChunkSections:
         assert "trailing speech" in joined  # tail audio not dropped
 
 
+@pytest.mark.asyncio
+class TestDescribeScenesSystemPrompt:
+    """Frame description must pass a system prompt (matches ImageModalProcessor)."""
+
+    async def test_passes_system_prompt_and_image_data(self, tmp_path):
+        from raganything.prompt import PROMPTS
+
+        cap = AsyncMock(return_value="a solid red frame")
+        proc = VideoModalProcessor(lightrag=_FakeLightRAG(), modal_caption_func=cap)
+
+        # Stub frame extraction to a real (tiny) file so base64 encoding works
+        # without OpenCV; _describe_scenes calls it via asyncio.to_thread.
+        frame = tmp_path / "frame.jpg"
+        frame.write_bytes(b"\xff\xd8\xff\xd9")
+        proc._extract_frame_at = MagicMock(return_value=str(frame))
+
+        out = await proc._describe_scenes("/v.mp4", [(0, 10)])
+        assert out == [{"start": 0, "end": 10, "visual": "a solid red frame"}]
+
+        assert cap.await_count == 1
+        kwargs = cap.call_args.kwargs
+        assert kwargs.get("system_prompt") == PROMPTS["IMAGE_ANALYSIS_SYSTEM"]
+        assert kwargs.get("image_data")  # base64 of the frame was passed
+        # temp frame is cleaned up afterwards
+        assert not frame.exists()
+
+
 class TestVideoDepsAvailable:
     """Test optional-dependency detection."""
 

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -1,0 +1,240 @@
+"""Tests for the VideoModalProcessor."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from raganything.modalprocessors_video import is_video_file
+
+try:
+    import cv2
+    import faster_whisper
+
+    HAS_VIDEO_DEPS = True
+except ImportError:
+    HAS_VIDEO_DEPS = False
+
+from raganything.modalprocessors_video import VideoModalProcessor
+
+
+class TestIsVideoFile:
+    """Test video file detection."""
+
+    def test_supported_extensions(self):
+        assert is_video_file("meeting.mp4")
+        assert is_video_file("recording.mov")
+        assert is_video_file("demo.webm")
+        assert is_video_file("clip.avi")
+        assert is_video_file("video.mkv")
+        assert is_video_file("/path/to/file.MP4")  # case insensitive
+        assert is_video_file("stream.flv")
+        assert is_video_file("screen.m4v")
+
+    def test_unsupported_extensions(self):
+        assert not is_video_file("document.pdf")
+        assert not is_video_file("image.png")
+        assert not is_video_file("audio.mp3")
+        assert not is_video_file("text.txt")
+        assert not is_video_file("no_extension")
+
+
+class TestVideoModalProcessorInit:
+    """Test VideoModalProcessor initialization."""
+
+    def test_default_init(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        caption_func = AsyncMock()
+
+        processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=caption_func,
+        )
+        assert processor.whisper_model_name == "base"
+        assert processor.min_scene_duration == 5.0
+        assert processor.max_scenes == 50
+        assert processor.scene_threshold == 27.0
+
+    def test_custom_config(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        caption_func = AsyncMock()
+
+        processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=caption_func,
+            whisper_model="large-v3",
+            min_scene_duration=10.0,
+            max_scenes=20,
+            scene_threshold=30.0,
+        )
+        assert processor.whisper_model_name == "large-v3"
+        assert processor.min_scene_duration == 10.0
+        assert processor.max_scenes == 20
+        assert processor.scene_threshold == 30.0
+
+
+class TestTimestampFormatting:
+    """Test timestamp formatting."""
+
+    def setup_method(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        self.processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+    def test_seconds_only(self):
+        assert self.processor._format_timestamp(45) == "0:45"
+
+    def test_minutes_and_seconds(self):
+        assert self.processor._format_timestamp(125) == "2:05"
+
+    def test_hours(self):
+        assert self.processor._format_timestamp(3661) == "1:01:01"
+
+    def test_zero(self):
+        assert self.processor._format_timestamp(0) == "0:00"
+
+
+class TestGetTranscriptInRange:
+    """Test transcript time-range filtering."""
+
+    def setup_method(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        self.processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+    def test_overlapping_segments(self):
+        transcript = [
+            {"start": 0, "end": 10, "text": "Hello"},
+            {"start": 10, "end": 20, "text": "World"},
+            {"start": 20, "end": 30, "text": "Goodbye"},
+        ]
+        result = self.processor._get_transcript_in_range(transcript, 5, 25)
+        assert "Hello" in result
+        assert "World" in result
+        assert "Goodbye" in result
+
+    def test_no_overlap(self):
+        transcript = [
+            {"start": 0, "end": 10, "text": "Hello"},
+            {"start": 50, "end": 60, "text": "Later"},
+        ]
+        result = self.processor._get_transcript_in_range(transcript, 20, 40)
+        assert result == ""
+
+    def test_exact_boundaries(self):
+        transcript = [
+            {"start": 10, "end": 20, "text": "Exact"},
+        ]
+        result = self.processor._get_transcript_in_range(transcript, 10, 20)
+        assert "Exact" in result
+
+
+class TestMergeChannels:
+    """Test visual + audio channel merging."""
+
+    def setup_method(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        self.processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+    def test_both_channels(self):
+        visual = [{"start": 0, "end": 30, "visual": "PPT showing revenue chart"}]
+        audio = [{"start": 5, "end": 25, "text": "Revenue grew 23%"}]
+
+        result = self.processor._merge_channels(visual, audio)
+        assert "画面：PPT showing revenue chart" in result
+        assert "语音：Revenue grew 23%" in result
+        assert "[0:00-0:30]" in result
+
+    def test_visual_only(self):
+        visual = [{"start": 0, "end": 30, "visual": "Surveillance footage"}]
+        audio = []
+
+        result = self.processor._merge_channels(visual, audio)
+        assert "画面：Surveillance footage" in result
+        assert "语音" not in result
+
+    def test_audio_only(self):
+        visual = [{"start": 0, "end": 30, "visual": ""}]
+        audio = [{"start": 0, "end": 30, "text": "Just audio content"}]
+
+        result = self.processor._merge_channels(visual, audio)
+        assert "语音：Just audio content" in result
+
+    def test_multiple_scenes(self):
+        visual = [
+            {"start": 0, "end": 30, "visual": "Scene 1"},
+            {"start": 30, "end": 60, "visual": "Scene 2"},
+        ]
+        audio = [
+            {"start": 5, "end": 25, "text": "First part"},
+            {"start": 35, "end": 55, "text": "Second part"},
+        ]
+
+        result = self.processor._merge_channels(visual, audio)
+        assert "Scene 1" in result
+        assert "Scene 2" in result
+        assert "First part" in result
+        assert "Second part" in result
+
+    def test_empty_both(self):
+        result = self.processor._merge_channels([], [])
+        assert result == ""
+
+
+@pytest.mark.asyncio
+class TestGenerateDescriptionOnly:
+    """Test the generate_description_only method."""
+
+    async def test_missing_file(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+        )
+
+        result, entity_info = await processor.generate_description_only(
+            {"video_path": "/nonexistent/video.mp4"},
+            "video",
+        )
+        assert entity_info["entity_type"] == "video"
+
+    async def test_with_mocked_pipeline(self):
+        lightrag = MagicMock()
+        lightrag.tokenizer = None
+        caption_func = AsyncMock(return_value="A person presenting slides")
+        processor = VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=caption_func,
+        )
+
+        # Mock internal methods
+        processor._detect_scenes = MagicMock(return_value=[(0, 30), (30, 60)])
+        processor._describe_scenes = AsyncMock(
+            return_value=[
+                {"start": 0, "end": 30, "visual": "Presenter with slides"},
+                {"start": 30, "end": 60, "visual": "Demo of product"},
+            ]
+        )
+        processor._extract_audio_track = MagicMock(return_value=None)
+
+        result, entity_info = await processor.generate_description_only(
+            {"video_path": "/tmp/test.mp4"},
+            "video",
+        )
+
+        assert "Presenter with slides" in result
+        assert "Demo of product" in result
+        assert entity_info["entity_type"] == "video"
+        assert "video_test" in entity_info["entity_name"]

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from raganything.modalprocessors_video import VideoModalProcessor, is_video_file
+from raganything.modalprocessors_video import (
+    VideoModalProcessor,
+    is_video_file,
+    video_deps_available,
+)
 
 
 @dataclass
@@ -26,6 +30,8 @@ class _FakeLightRAG:
     llm_model_func: object = None
     llm_response_cache: object = None
     tokenizer: object = None
+    chunk_token_size: int = 1200
+    max_parallel_insert: int = 2
 
 
 class TestIsVideoFile:
@@ -247,3 +253,129 @@ class TestGenerateDescriptionOnly:
         assert "Demo of product" in result
         assert entity_info["entity_type"] == "video"
         assert "video_test" in entity_info["entity_name"]
+
+
+class TestPlanWindows:
+    """Test scene -> window grouping and redistribution."""
+
+    def _processor(self, max_scenes=50, max_windows=100, chunk_token_size=100000):
+        lightrag = _FakeLightRAG(chunk_token_size=chunk_token_size)
+        return VideoModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=AsyncMock(),
+            max_scenes=max_scenes,
+            max_windows=max_windows,
+        )
+
+    def _scenes(self, n):
+        return [
+            {"start": i * 10, "end": i * 10 + 10, "visual": f"scene {i}"}
+            for i in range(n)
+        ]
+
+    def test_empty(self):
+        assert self._processor()._plan_windows([]) == []
+
+    def test_single_window_when_under_max_scenes(self):
+        processor = self._processor(max_scenes=50)
+        windows = processor._plan_windows(self._scenes(5))
+        assert len(windows) == 1
+
+    def test_splits_by_max_scenes(self):
+        processor = self._processor(max_scenes=2)
+        windows = processor._plan_windows(self._scenes(5))
+        # 5 scenes / 2 per window -> 3 windows (2, 2, 1), no scene dropped
+        assert len(windows) == 3
+        assert sum(len(w) for w in windows) == 5
+
+    def test_max_windows_redistributes(self):
+        processor = self._processor(max_scenes=1, max_windows=2)
+        windows = processor._plan_windows(self._scenes(6))
+        # max_scenes=1 would give 6 windows, but max_windows caps to 2 groups
+        assert len(windows) == 2
+        assert sum(len(w) for w in windows) == 6  # all scenes preserved
+
+    def test_redistribute_preserves_order(self):
+        items = [{"i": i} for i in range(7)]
+        groups = VideoModalProcessor._redistribute(items, 3)
+        assert sum(len(g) for g in groups) == 7
+        flat = [x["i"] for g in groups for x in g]
+        assert flat == list(range(7))
+
+
+@pytest.mark.asyncio
+class TestVideoChunkSections:
+    """Test the 1->N generate_chunk_sections for video."""
+
+    def _processor(self, max_scenes=1):
+        return VideoModalProcessor(
+            lightrag=_FakeLightRAG(),
+            modal_caption_func=AsyncMock(return_value="desc"),
+            max_scenes=max_scenes,
+        )
+
+    async def test_multiple_windows(self, tmp_path):
+        processor = self._processor(max_scenes=1)
+        processor._detect_scenes = MagicMock(
+            return_value=[(0, 30), (30, 60), (60, 90)]
+        )
+        processor._describe_scenes = AsyncMock(
+            return_value=[
+                {"start": 0, "end": 30, "visual": "Scene A"},
+                {"start": 30, "end": 60, "visual": "Scene B"},
+                {"start": 60, "end": 90, "visual": "Scene C"},
+            ]
+        )
+        processor._transcribe_audio_track = AsyncMock(return_value=[])
+
+        video_file = tmp_path / "clip.mp4"
+        video_file.write_bytes(b"")
+
+        sections = await processor.generate_chunk_sections(
+            {"video_path": str(video_file)}, "video"
+        )
+        assert len(sections) == 3
+        assert [s["window_meta"]["part"] for s in sections] == [1, 2, 3]
+        names = [s["entity_info"]["entity_name"] for s in sections]
+        assert names == ["video_clip_part1", "video_clip_part2", "video_clip_part3"]
+        joined = "\n".join(s["description"] for s in sections)
+        for label in ("Scene A", "Scene B", "Scene C"):
+            assert label in joined
+
+    async def test_tail_audio_beyond_last_scene_is_kept(self, tmp_path):
+        processor = self._processor(max_scenes=50)
+        processor._detect_scenes = MagicMock(return_value=[(0, 30)])
+        processor._describe_scenes = AsyncMock(
+            return_value=[{"start": 0, "end": 30, "visual": "Only scene"}]
+        )
+        # Audio that starts after the last scene end (30s)
+        processor._transcribe_audio_track = AsyncMock(
+            return_value=[{"start": 35, "end": 45, "text": "trailing speech"}]
+        )
+
+        video_file = tmp_path / "clip.mp4"
+        video_file.write_bytes(b"")
+
+        sections = await processor.generate_chunk_sections(
+            {"video_path": str(video_file)}, "video"
+        )
+        joined = "\n".join(s["description"] for s in sections)
+        assert "trailing speech" in joined  # tail audio not dropped
+
+
+class TestVideoDepsAvailable:
+    """Test optional-dependency detection."""
+
+    def test_returns_false_when_any_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "raganything.modalprocessors_video.importlib.util.find_spec",
+            lambda name: None if name == "moviepy" else object(),
+        )
+        assert video_deps_available() is False
+
+    def test_returns_true_when_all_present(self, monkeypatch):
+        monkeypatch.setattr(
+            "raganything.modalprocessors_video.importlib.util.find_spec",
+            lambda name: object(),
+        )
+        assert video_deps_available() is True

--- a/tests/test_video_processor.py
+++ b/tests/test_video_processor.py
@@ -316,9 +316,7 @@ class TestVideoChunkSections:
 
     async def test_multiple_windows(self, tmp_path):
         processor = self._processor(max_scenes=1)
-        processor._detect_scenes = MagicMock(
-            return_value=[(0, 30), (30, 60), (60, 90)]
-        )
+        processor._detect_scenes = MagicMock(return_value=[(0, 30), (30, 60), (60, 90)])
         processor._describe_scenes = AsyncMock(
             return_value=[
                 {"start": 0, "end": 30, "visual": "Scene A"},


### PR DESCRIPTION
## Summary

Adds **audio** and **video** as first-class optional modalities, consolidating the overlapping work in #280, #281 and #289 into a single, fully-integrated and end-to-end tested implementation.

- **AudioModalProcessor** — local ASR via `faster-whisper`, timestamped segments.
- **VideoModalProcessor** — dual-channel: `scenedetect` scene boundaries + OpenCV keyframe + VLM visual description + audio-track transcription, merged by timestamp.

This PR takes the **real processing engine** from #281 (which was a clean standalone module but was *not wired into the pipeline*) and adds the **full integration** that #289 had designed:

- `config`: `enable_audio_processing` / `enable_video_processing` flags (default **off**, since they pull heavy optional deps) + extended `SUPPORTED_FILE_EXTENSIONS`.
- `raganything._initialize_processors`: registers the processors behind **guarded optional imports** (graceful fallback to the generic processor when extras are not installed).
- `utils.get_processor_for_type`: routes `audio` / `video`, falling back to `generic`.
- `processor._apply_chunk_template`: audio/video chunk templates.
- `__init__`: feature-gated optional exports.
- **Fix vs #281**: `cv2` is now imported lazily, so `import raganything` no longer fails when `opencv` is absent.
- `pyproject.toml` / `env.example`: `[audio]` / `[video]` extras and config docs.

## Dependencies (optional)

```
pip install raganything[audio]   # faster-whisper
pip install raganything[video]   # scenedetect + moviepy + opencv-python + faster-whisper
```

## End-to-end testing

Verified locally with real media (macOS `say` + `ffmpeg`), a real VLM/LLM (via OpenRouter) and a local whisper `base` model:

1. **Audio** — `meeting.wav` → faster-whisper → `[0:00-0:04] ...revenue grew by 23%. [0:04-0:07] ...shipped the new search feature...` (timestamped, accurate).
2. **Video** — 3-scene clip + audio track → 3 scenes detected, keyframes described by the VLM (correctly identifies the scene colors), audio transcribed, dual-channel merged `[mm:ss-mm:ss] 画面：… | 语音：…`.
3. **Full pipeline** — `RAGAnything` with `enable_audio_processing=True` registers `['audio','video','generic']`, routing resolves `audio → AudioModalProcessor`, `insert_content_list([{type:audio,…}])` transcribes + builds the KG (5 entities / 9 relations), and `aquery(...)` returns *"revenue grew by 23% … shipped a new search feature"* citing `meeting.wav`.

Regression: with the extras **not** installed, `import raganything` works and audio/video content gracefully falls back to the generic processor.

## Relation to existing PRs

- Supersedes #280 (audio-only, fully contained in #281).
- Built on top of #281 (kept its engine + unit tests; added the missing pipeline wiring). Co-authored with @liuruing.
- Folds in the integration approach from #289 (@Arvuno).

## Test plan

- [x] Audio transcription E2E (faster-whisper)
- [x] Video dual-channel E2E (scenedetect + VLM + whisper)
- [x] Full RAGAnything insert + retrieve E2E
- [x] Import works without optional deps (graceful degradation)
- [ ] CI unit tests (`tests/test_audio_processor.py`, `tests/test_video_processor.py`)

Made with [Cursor](https://cursor.com)