### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/examples/minimax_integration_example.py
+++ b/examples/minimax_integration_example.py
@@ -52,7 +52,7 @@ load_dotenv()
 # MiniMax configuration
 MINIMAX_BASE_URL = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
 MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY", "")
-MINIMAX_LLM_MODEL = os.getenv("MINIMAX_LLM_MODEL", "MiniMax-M2.7")
+MINIMAX_LLM_MODEL = os.getenv("MINIMAX_LLM_MODEL", "MiniMax-M3")
 
 # Embedding configuration (MiniMax does not provide an embedding model;
 # configure a separate embedding service below)
@@ -257,14 +257,15 @@ class MiniMaxRAGIntegration:
                     "This integration connects MiniMax's powerful language models "
                     "with RAG-Anything's multimodal document processing pipeline.\n\n"
                     "Key features:\n"
-                    "- MiniMax-M2.7: Peak Performance. Ultimate Value. Master the Complex.\n"
-                    "- MiniMax-M2.7-highspeed: Same performance, faster and more agile.\n"
+                    "- MiniMax-M3: The latest flagship model and current default.\n"
+                    "- MiniMax-M2.7: Previous generation, available as alternative.\n"
+                    "- MiniMax-M2.7-highspeed: Same as M2.7, faster and more agile.\n"
                     "- OpenAI-compatible API — no SDK changes required.\n"
                     "- Supports text, table, and equation modalities.\n\n"
                     "Configuration:\n"
                     "  MINIMAX_API_KEY=your-api-key\n"
                     "  MINIMAX_BASE_URL=https://api.minimax.io/v1  (default)\n"
-                    "  MINIMAX_LLM_MODEL=MiniMax-M2.7  (default)\n"
+                    "  MINIMAX_LLM_MODEL=MiniMax-M3  (default)\n"
                 ),
                 "page_idx": 0,
             }

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -79,7 +79,7 @@ def _load_example(extra_env=None):
     env = {
         "MINIMAX_API_KEY": "test-key",
         "MINIMAX_BASE_URL": "https://api.minimax.io/v1",
-        "MINIMAX_LLM_MODEL": "MiniMax-M2.7",
+        "MINIMAX_LLM_MODEL": "MiniMax-M3",
         "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
         "EMBEDDING_BINDING_API_KEY": "test-embed-key",
         "EMBEDDING_MODEL": "text-embedding-3-small",
@@ -124,7 +124,7 @@ class TestMiniMaxConstants:
             k: v
             for k, v in {
                 "MINIMAX_API_KEY": "test-key",
-                "MINIMAX_LLM_MODEL": "MiniMax-M2.7",
+                "MINIMAX_LLM_MODEL": "MiniMax-M3",
                 "EMBEDDING_BINDING_HOST": "https://api.openai.com/v1",
                 "EMBEDDING_BINDING_API_KEY": "test-embed-key",
                 "EMBEDDING_MODEL": "text-embedding-3-small",
@@ -149,7 +149,7 @@ class TestMiniMaxConstants:
         }
         with patch.dict(os.environ, env, clear=True):
             mod, _ = _load_example()
-        assert mod.MINIMAX_LLM_MODEL == "MiniMax-M2.7"
+        assert mod.MINIMAX_LLM_MODEL == "MiniMax-M3"
 
     def test_custom_model_env(self):
         mod, _ = _load_example({"MINIMAX_LLM_MODEL": "MiniMax-M2.7-highspeed"})
@@ -311,7 +311,7 @@ class TestMiniMaxLLMFunc:
 
         mod.openai_complete_if_cache = mock_complete
         await mod.minimax_llm_model_func("test")
-        assert captured["model"] == "MiniMax-M2.7"
+        assert captured["model"] == "MiniMax-M3"
 
     @pytest.mark.asyncio
     async def test_system_prompt_passed_through(self):
@@ -375,7 +375,7 @@ class TestMiniMaxRAGIntegration:
     def test_default_model_name(self):
         mod, _ = _load_example()
         integration = mod.MiniMaxRAGIntegration()
-        assert integration.model_name == "MiniMax-M2.7"
+        assert integration.model_name == "MiniMax-M3"
 
     def test_default_base_url(self):
         mod, _ = _load_example()


### PR DESCRIPTION
## Description

Upgrade the MiniMax integration example's default model from `MiniMax-M2.7` to the new flagship `MiniMax-M3`, and refresh the sample content / unit tests accordingly.

## Related Issues

N/A — follow-up to PR #264 (initial MiniMax provider integration).

## Changes Made

- `examples/minimax_integration_example.py`
  - `MINIMAX_LLM_MODEL` default: `MiniMax-M2.7` -> `MiniMax-M3`
  - Sample query content describes M3 as the new default and keeps M2.7 and M2.7-highspeed as available alternatives
- `tests/test_minimax_integration.py`
  - Update default model assertions and stubbed env defaults to `MiniMax-M3`
  - Retain the existing `M2.7-highspeed` custom-env test to confirm overrides still work

## Why

`MiniMax-M3` is MiniMax's latest flagship model with a 512K context window, 128K max output, and image input support across both the OpenAI-compatible and Anthropic-compatible interfaces. Picking M3 by default lets users immediately benefit from the larger context and better quality while M2.7 remains available via `MINIMAX_LLM_MODEL=MiniMax-M2.7`.

The base URL, environment variables, temperature handling, and overall integration shape are unchanged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary) — sample content within the example reflects the new default
- [x] Unit tests added (if applicable) — existing tests updated to assert the new default

## Additional Notes

`pytest tests/test_minimax_integration.py` passes all 25 tests after the change. The default still falls back to the env variable `MINIMAX_LLM_MODEL`, so any user who already pins a specific model continues to use it.