### PR TITLE
Fix MinerU Windows unsafe paths

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -711,6 +711,80 @@ class MineruParser(Parser):
         super().__init__()
 
     @classmethod
+    def _is_mineru_unsafe_windows_path(cls, path: Union[str, Path]) -> bool:
+        if not _IS_WINDOWS:
+            return False
+
+        path = Path(path)
+        path_text = str(path)
+        try:
+            path_text.encode("ascii")
+        except UnicodeEncodeError:
+            return True
+
+        return any(
+            part.endswith((" ", ".")) for part in path.parts
+        ) or path.stem.endswith((" ", "."))
+
+    @classmethod
+    def _mineru_safe_path_hash(cls, path: Union[str, Path]) -> str:
+        path_text = str(Path(path).resolve())
+        return hashlib.md5(path_text.encode("utf-8")).hexdigest()[:10]
+
+    @classmethod
+    def _prepare_mineru_paths(
+        cls,
+        input_path: Union[str, Path],
+        output_dir: Union[str, Path],
+        hash_path: Optional[Union[str, Path]] = None,
+    ) -> Tuple[Path, Path, str, Optional[Path]]:
+        input_path = Path(input_path)
+        output_dir = Path(output_dir)
+        hash_source = Path(hash_path) if hash_path is not None else input_path
+
+        input_is_unsafe = cls._is_mineru_unsafe_windows_path(input_path)
+        output_is_unsafe = cls._is_mineru_unsafe_windows_path(output_dir)
+        if not input_is_unsafe and not output_is_unsafe:
+            return input_path, output_dir, input_path.stem, None
+
+        path_hash = cls._mineru_safe_path_hash(hash_source)
+        temp_dir = Path(tempfile.mkdtemp(prefix="raganything_mineru_"))
+
+        mineru_input_path = input_path
+        if input_is_unsafe:
+            suffix = input_path.suffix.lower()
+            mineru_input_path = temp_dir / f"input_{path_hash}{suffix}"
+            shutil.copy2(input_path, mineru_input_path)
+
+        mineru_output_dir = output_dir
+        if output_is_unsafe:
+            mineru_output_dir = temp_dir / f"mineru_{path_hash}"
+            mineru_output_dir.mkdir(parents=True, exist_ok=True)
+
+        return mineru_input_path, mineru_output_dir, mineru_input_path.stem, temp_dir
+
+    @classmethod
+    def _copy_mineru_output_tree(cls, source_dir: Path, target_dir: Path) -> None:
+        if source_dir == target_dir:
+            return
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        if not source_dir.exists():
+            return
+
+        for item in source_dir.iterdir():
+            target = target_dir / item.name
+            if item.is_dir():
+                shutil.copytree(item, target, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, target)
+
+    @classmethod
+    def _cleanup_mineru_temp_dir(cls, temp_dir: Optional[Path]) -> None:
+        if temp_dir is not None and temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @classmethod
     def _run_mineru_command(
         cls,
         input_path: Union[str, Path],
@@ -1102,8 +1176,6 @@ class MineruParser(Parser):
             if not pdf_path.exists():
                 raise FileNotFoundError(f"PDF file does not exist: {pdf_path}")
 
-            name_without_suff = pdf_path.stem
-
             # Prepare output directory — use unique subdirectory to prevent
             # same-name file collisions when output_dir is shared (#51)
             if output_dir:
@@ -1113,34 +1185,43 @@ class MineruParser(Parser):
 
             base_output_dir.mkdir(parents=True, exist_ok=True)
 
-            # Run mineru command
-            self._run_mineru_command(
-                input_path=pdf_path,
-                output_dir=base_output_dir,
-                method=method,
-                lang=lang,
-                **kwargs,
+            mineru_input_path, mineru_output_dir, file_stem, temp_dir = (
+                self._prepare_mineru_paths(pdf_path, base_output_dir)
             )
 
-            # Read the generated output files
-            # Map backend to expected output directory name for better compatibility
-            # MinerU 2.7.0+ uses different directory names based on backend:
-            # - pipeline -> auto/
-            # - vlm-* -> vlm/
-            # - hybrid-* -> hybrid_auto/
-            # Note: _read_output_files() will scan subdirectories automatically,
-            # so this mapping is just for optimization and fallback
-            # Use `or ""` to handle both missing keys and explicit None values
-            backend = kwargs.get("backend") or ""
-            if backend.startswith("vlm-"):
-                method = "vlm"
-            elif backend.startswith("hybrid-"):
-                method = "hybrid_auto"
+            try:
+                # Run mineru command
+                self._run_mineru_command(
+                    input_path=mineru_input_path,
+                    output_dir=mineru_output_dir,
+                    method=method,
+                    lang=lang,
+                    **kwargs,
+                )
 
-            content_list, _ = self._read_output_files(
-                base_output_dir, name_without_suff, method=method
-            )
-            return content_list
+                self._copy_mineru_output_tree(mineru_output_dir, base_output_dir)
+
+                # Read the generated output files
+                # Map backend to expected output directory name for better compatibility
+                # MinerU 2.7.0+ uses different directory names based on backend:
+                # - pipeline -> auto/
+                # - vlm-* -> vlm/
+                # - hybrid-* -> hybrid_auto/
+                # Note: _read_output_files() will scan subdirectories automatically,
+                # so this mapping is just for optimization and fallback
+                # Use `or ""` to handle both missing keys and explicit None values
+                backend = kwargs.get("backend") or ""
+                if backend.startswith("vlm-"):
+                    method = "vlm"
+                elif backend.startswith("hybrid-"):
+                    method = "hybrid_auto"
+
+                content_list, _ = self._read_output_files(
+                    base_output_dir, file_stem, method=method
+                )
+                return content_list
+            finally:
+                self._cleanup_mineru_temp_dir(temp_dir)
 
         except MineruExecutionError:
             raise
@@ -1256,8 +1337,6 @@ class MineruParser(Parser):
                         f"Failed to convert image {image_path.name}: {str(e)}"
                     )
 
-            name_without_suff = image_path.stem
-
             # Prepare output directory — use unique subdirectory to prevent
             # same-name file collisions when output_dir is shared (#51)
             if output_dir:
@@ -1267,19 +1346,27 @@ class MineruParser(Parser):
 
             base_output_dir.mkdir(parents=True, exist_ok=True)
 
+            mineru_input_path, mineru_output_dir, file_stem, mineru_temp_dir = (
+                self._prepare_mineru_paths(
+                    actual_image_path, base_output_dir, hash_path=image_path
+                )
+            )
+
             try:
                 # Run mineru command (images are processed with OCR method)
                 self._run_mineru_command(
-                    input_path=actual_image_path,
-                    output_dir=base_output_dir,
+                    input_path=mineru_input_path,
+                    output_dir=mineru_output_dir,
                     method="ocr",  # Images require OCR method
                     lang=lang,
                     **kwargs,
                 )
 
+                self._copy_mineru_output_tree(mineru_output_dir, base_output_dir)
+
                 # Read the generated output files
                 content_list, _ = self._read_output_files(
-                    base_output_dir, name_without_suff, method="ocr"
+                    base_output_dir, file_stem, method="ocr"
                 )
                 return content_list
 
@@ -1287,6 +1374,8 @@ class MineruParser(Parser):
                 raise
 
             finally:
+                self._cleanup_mineru_temp_dir(mineru_temp_dir)
+
                 # Clean up temporary converted file if it was created
                 if temp_converted_file and temp_converted_file.exists():
                     try:

--- a/tests/testparser_kwargs.py
+++ b/tests/testparser_kwargs.py
@@ -23,7 +23,9 @@ Usage:
 import pytest
 from unittest.mock import patch, MagicMock
 import os
+import re
 from raganything.parser import MineruParser, DoclingParser
+import raganything.parser as parser_module
 
 
 @pytest.fixture
@@ -153,6 +155,92 @@ def test_invalid_env_contents(mineru_parser, docling_parser, dummy_path, tmp_pat
             file_stem="stem",
             env={"key": 123},
         )
+
+
+def test_mineru_windows_unsafe_pdf_uses_safe_paths(
+    monkeypatch, mineru_parser, tmp_path
+):
+    monkeypatch.setattr(parser_module, "_IS_WINDOWS", True)
+    source_dir = tmp_path / "docs"
+    source_dir.mkdir()
+    pdf_path = source_dir / "sample-测试 .pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    captured = {}
+
+    def fake_run_mineru_command(**kwargs):
+        captured.update(kwargs)
+        assert kwargs["input_path"].exists()
+        assert kwargs["input_path"].read_bytes() == b"%PDF-1.4\n"
+
+    with patch.object(
+        MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
+    ), patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read:
+        mineru_parser.parse_pdf(pdf_path, output_dir=tmp_path / "out")
+
+    input_path = captured["input_path"]
+    output_dir = captured["output_dir"]
+    assert re.fullmatch(r"input_[0-9a-f]{10}\.pdf", input_path.name)
+    assert re.fullmatch(r"mineru_[0-9a-f]{10}", output_dir.name)
+    assert input_path.name.isascii()
+    assert output_dir.name.isascii()
+    assert read.call_args.args[1] == input_path.stem
+
+
+def test_mineru_windows_safe_pdf_keeps_original_path(
+    monkeypatch, mineru_parser, tmp_path
+):
+    monkeypatch.setattr(parser_module, "_IS_WINDOWS", True)
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    output_dir = tmp_path / "out"
+
+    captured = {}
+
+    def fake_run_mineru_command(**kwargs):
+        captured.update(kwargs)
+
+    with patch.object(
+        MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
+    ), patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read:
+        mineru_parser.parse_pdf(pdf_path, output_dir=output_dir)
+
+    assert captured["input_path"] == pdf_path
+    assert captured["output_dir"] == MineruParser._unique_output_dir(
+        output_dir, pdf_path
+    )
+    assert read.call_args.args[1] == "sample"
+
+
+def test_mineru_windows_unsafe_png_uses_safe_paths(
+    monkeypatch, mineru_parser, tmp_path
+):
+    monkeypatch.setattr(parser_module, "_IS_WINDOWS", True)
+    source_dir = tmp_path / "docs"
+    source_dir.mkdir()
+    image_path = source_dir / "sample-测试 .png"
+    image_path.write_bytes(b"\x89PNG\r\n")
+
+    captured = {}
+
+    def fake_run_mineru_command(**kwargs):
+        captured.update(kwargs)
+        assert kwargs["method"] == "ocr"
+        assert kwargs["input_path"].exists()
+        assert kwargs["input_path"].read_bytes() == b"\x89PNG\r\n"
+
+    with patch.object(
+        MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
+    ), patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read:
+        mineru_parser.parse_image(image_path, output_dir=tmp_path / "out")
+
+    input_path = captured["input_path"]
+    output_dir = captured["output_dir"]
+    assert re.fullmatch(r"input_[0-9a-f]{10}\.png", input_path.name)
+    assert re.fullmatch(r"mineru_[0-9a-f]{10}", output_dir.name)
+    assert input_path.name.isascii()
+    assert output_dir.name.isascii()
+    assert read.call_args.args[1] == input_path.stem
 
 
 @patch.object(DoclingParser, "_get_converter")

--- a/tests/testparser_kwargs.py
+++ b/tests/testparser_kwargs.py
@@ -173,9 +173,12 @@ def test_mineru_windows_unsafe_pdf_uses_safe_paths(
         assert kwargs["input_path"].exists()
         assert kwargs["input_path"].read_bytes() == b"%PDF-1.4\n"
 
-    with patch.object(
-        MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
-    ), patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read:
+    with (
+        patch.object(
+            MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
+        ),
+        patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read,
+    ):
         mineru_parser.parse_pdf(pdf_path, output_dir=tmp_path / "out")
 
     input_path = captured["input_path"]
@@ -200,9 +203,12 @@ def test_mineru_windows_safe_pdf_keeps_original_path(
     def fake_run_mineru_command(**kwargs):
         captured.update(kwargs)
 
-    with patch.object(
-        MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
-    ), patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read:
+    with (
+        patch.object(
+            MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
+        ),
+        patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read,
+    ):
         mineru_parser.parse_pdf(pdf_path, output_dir=output_dir)
 
     assert captured["input_path"] == pdf_path
@@ -229,9 +235,12 @@ def test_mineru_windows_unsafe_png_uses_safe_paths(
         assert kwargs["input_path"].exists()
         assert kwargs["input_path"].read_bytes() == b"\x89PNG\r\n"
 
-    with patch.object(
-        MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
-    ), patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read:
+    with (
+        patch.object(
+            MineruParser, "_run_mineru_command", side_effect=fake_run_mineru_command
+        ),
+        patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read,
+    ):
         mineru_parser.parse_image(image_path, output_dir=tmp_path / "out")
 
     input_path = captured["input_path"]


### PR DESCRIPTION
## Summary
Fixes MinerU parsing failures on Windows when paths contain non-ASCII characters, trailing spaces, or trailing dots.
- Adds a safe-path adapter layer for MinerU.
- Applies to both `parse_pdf` and `parse_image`.
- Preserves original behavior for safe paths.
- Auto-cleans temporary files/directories after processing.

## What This Fixes
Previously, MinerU received raw input/output paths directly. On Windows, paths like:
- `sample-测试 .pdf`
- `sample-测试 .png`

could break execution or output lookup due to unsafe characters/formatting.

## Implementation
Adds a transparent safe-path layer:
1.  Unsafe input → copied to temp ASCII-only path (`input_<hash>.pdf`).
2.  Unsafe output dir → redirected to temp ASCII-only dir (`mineru_<hash>`).
3.  MinerU output → copied back to the requested directory.
4.  Temp workspace → cleaned up in `finally`.

Added MinerU helpers in `raganything/parser.py`:
- `_is_mineru_unsafe_windows_path`
- `_prepare_mineru_paths`
- `_copy_mineru_output_tree`
- `_cleanup_mineru_temp_dir`

Also fixes result reading to use the actual MinerU-safe file stem after path rewriting.

## Tests
Verified locally on Windows with:
- ✅ Unsafe PDF/image paths now parse correctly.
- ✅ Safe paths remain unchanged (no side effects).
- ✅ Temp files are properly cleaned up.
- ✅ Regression: existing MinerU flows still work on non-Windows systems.