### PR TITLE
feat: add opt-in TwelveLabs video modality (Pegasus + Marengo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ pip install raganything
 pip install 'raganything[all]'              # All optional features
 pip install 'raganything[image]'            # Image format conversion (BMP, TIFF, GIF, WebP)
 pip install 'raganything[text]'             # Text file processing (TXT, MD)
+pip install 'raganything[video]'            # Video understanding & embeddings (TwelveLabs)
 pip install 'raganything[image,text]'       # Multiple features
 ```
 
@@ -578,6 +579,41 @@ async def process_multimodal_content():
 if __name__ == "__main__":
     asyncio.run(process_multimodal_content())
 ```
+
+##### Video Modality (TwelveLabs) — optional
+
+RAG-Anything ships an **opt-in** `video` modality powered by [TwelveLabs](https://twelvelabs.io):
+
+- **Pegasus** (`analyze`) generates a rich transcript/description of the video, which flows through the same knowledge-graph + chunk pipeline as every other modality.
+- **Marengo** (`embed`) produces a 512-dim multimodal embedding returned on the video item's `entity_info` (key `tl_video_embedding`) for semantic retrieval; pair it with `embed_text()` to score a text query in the same space.
+
+Enable it with the `video` extra and an API key (free tier at https://twelvelabs.io):
+
+```bash
+pip install 'raganything[video]'
+export ENABLE_VIDEO_PROCESSING=true
+export TWELVELABS_API_KEY=your-twelvelabs-api-key
+```
+
+When enabled, video items are routed automatically during document processing. You can also use the processor directly:
+
+```python
+from raganything import TwelveLabsModalProcessor
+
+video_processor = TwelveLabsModalProcessor(lightrag=rag)  # reads TWELVELABS_API_KEY
+
+description, entity_info = await video_processor.process_multimodal_content(
+    modal_content={
+        "type": "video",
+        "video_url": "https://example.com/clip.mp4",  # or video_path / video_id
+        "video_caption": ["Product demo recording"],
+    },
+    content_type="video",
+    file_path="product_demo.mp4",
+)
+```
+
+This modality is disabled by default; existing behaviour is unchanged when `ENABLE_VIDEO_PROCESSING` is unset.
 
 #### 3. Batch Processing
 

--- a/env.example
+++ b/env.example
@@ -50,6 +50,12 @@ OLLAMA_EMULATING_MODEL_TAG=latest
 # ENABLE_TABLE_PROCESSING=true
 # ENABLE_EQUATION_PROCESSING=true
 
+### Video Processing (TwelveLabs) — opt-in, requires `pip install raganything[video]`
+# ENABLE_VIDEO_PROCESSING=false
+# TWELVELABS_API_KEY=your-twelvelabs-api-key   # free tier at https://twelvelabs.io
+# TWELVELABS_PEGASUS_MODEL=pegasus1.5          # video understanding / description
+# TWELVELABS_MARENGO_MODEL=marengo3.0          # multimodal embeddings (512-dim)
+
 ### Batch Processing Configuration
 # MAX_CONCURRENT_FILES=1
 # SUPPORTED_FILE_EXTENSIONS=.pdf,.jpg,.jpeg,.png,.bmp,.tiff,.tif,.gif,.webp,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.txt,.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ markdown = [
     "weasyprint>=60.0",
     "pygments>=2.10.0",
 ]
+video = ["twelvelabs>=1.2.8"]
 all = [
     "Pillow>=10.0.0",
     "reportlab>=4.0.0",
@@ -48,6 +49,7 @@ all = [
     "markdown>=3.4.0",
     "weasyprint>=60.0",
     "pygments>=2.10.0",
+    "twelvelabs>=1.2.8",
 ]
 
 [project.urls]

--- a/raganything/__init__.py
+++ b/raganything/__init__.py
@@ -43,6 +43,14 @@ except ModuleNotFoundError:
 except ImportError:
     pass
 
+# Optional: TwelveLabs video modality processor (requires the 'twelvelabs' extra).
+try:
+    from .twelvelabs import TwelveLabsModalProcessor as TwelveLabsModalProcessor
+except ModuleNotFoundError:
+    pass
+except ImportError:
+    pass
+
 # Optional: multilingual prompt manager.
 try:
     from .prompt_manager import (
@@ -96,6 +104,9 @@ if "ProcessingCallback" in globals():
             "ProcessingEvent",
         ]
     )
+
+if "TwelveLabsModalProcessor" in globals():
+    __all__.append("TwelveLabsModalProcessor")
 
 if "set_prompt_language" in globals():
     __all__.extend(

--- a/raganything/config.py
+++ b/raganything/config.py
@@ -51,6 +51,14 @@ class RAGAnythingConfig:
     )
     """Enable equation content processing."""
 
+    enable_video_processing: bool = field(
+        default=get_env_value("ENABLE_VIDEO_PROCESSING", False, bool)
+    )
+    """Enable video content processing via TwelveLabs (Pegasus + Marengo).
+
+    Opt-in: disabled by default. Requires the ``twelvelabs`` package
+    (``pip install raganything[video]``) and a ``TWELVELABS_API_KEY``."""
+
     # Batch Processing Configuration
     # ---
     max_concurrent_files: int = field(

--- a/raganything/raganything.py
+++ b/raganything/raganything.py
@@ -235,6 +235,22 @@ class RAGAnything(QueryMixin, ProcessorMixin, BatchMixin):
                 context_extractor=self.context_extractor,
             )
 
+        if getattr(self.config, "enable_video_processing", False):
+            try:
+                from raganything.twelvelabs import TwelveLabsModalProcessor
+
+                self.modal_processors["video"] = TwelveLabsModalProcessor(
+                    lightrag=self.lightrag,
+                    modal_caption_func=self.llm_model_func,
+                    context_extractor=self.context_extractor,
+                )
+            except (ImportError, ValueError) as e:
+                # Missing 'twelvelabs' package or TWELVELABS_API_KEY: skip the
+                # optional video modality rather than break initialization.
+                self.logger.warning(
+                    f"Video processing requested but unavailable, skipping: {e}"
+                )
+
         # Always include generic processor as fallback
         self.modal_processors["generic"] = GenericModalProcessor(
             lightrag=self.lightrag,

--- a/raganything/twelvelabs.py
+++ b/raganything/twelvelabs.py
@@ -1,0 +1,347 @@
+"""
+TwelveLabs video modality processor for RAGAnything.
+
+Adds a "video" modality backed by the TwelveLabs platform:
+
+- **Pegasus** (``analyze``) generates a rich textual description / transcript of
+  the video. This text feeds the existing knowledge-graph / chunk pipeline just
+  like any other modality.
+- **Marengo** (``embed``) produces a 512-dim multimodal embedding for the video
+  (or a text query). The embedding is returned on the modal item's ``entity_info``
+  (key ``tl_video_embedding``) so callers can index it for semantic video
+  retrieval; pair it with :meth:`embed_text` to score a text query in the same
+  512-dim space.
+
+The processor mirrors :class:`raganything.modalprocessors.GenericModalProcessor`
+and reuses :meth:`BaseModalProcessor._create_entity_and_chunk`, so video content
+flows through the same entity/relationship extraction machinery as images,
+tables and equations.
+
+This is an **opt-in** modality: it is only registered when
+``enable_video_processing`` is True (env ``ENABLE_VIDEO_PROCESSING``) and the
+``twelvelabs`` package is installed. Existing behaviour is unchanged when it is
+disabled.
+
+A "video" multimodal item looks like::
+
+    {"type": "video", "video_url": "https://.../clip.mp4", "video_caption": ["..."]}
+    {"type": "video", "video_path": "/abs/path/clip.mp4"}
+    {"type": "video", "video_id": "<indexed-video-id>"}
+
+Get a free API key at https://twelvelabs.io (generous free tier).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from lightrag.utils import compute_mdhash_id, logger
+from lightrag.lightrag import LightRAG
+
+from raganything.modalprocessors import BaseModalProcessor, ContextExtractor
+from raganything.prompt import PROMPTS
+
+# Default model identifiers. Overridable via env so users can pin a version
+# without code changes (TwelveLabs occasionally retires model aliases).
+DEFAULT_PEGASUS_MODEL = os.getenv("TWELVELABS_PEGASUS_MODEL", "pegasus1.5")
+DEFAULT_MARENGO_MODEL = os.getenv("TWELVELABS_MARENGO_MODEL", "marengo3.0")
+
+# Register prompts the same way the other modalities do.
+PROMPTS["VIDEO_ANALYSIS_SYSTEM"] = (
+    "You are an expert video analyst. Describe video content accurately and in detail."
+)
+PROMPTS[
+    "video_analysis_prompt"
+] = """Watch this video and produce a detailed, factual description suitable for retrieval.
+Cover, where present: the setting/scene, people and objects, on-screen text,
+spoken content / narration, actions and events over time, and any notable
+visual or audio details. Be specific and avoid pronouns where a name applies.
+
+{context_block}Captions provided by the source document: {captions}
+"""
+PROMPTS["video_chunk"] = """Video Content Analysis
+Source: {video_ref}
+Captions: {captions}
+
+Description (TwelveLabs Pegasus):
+{description}
+"""
+
+
+class TwelveLabsModalProcessor(BaseModalProcessor):
+    """Process video content via TwelveLabs Pegasus (analyze) + Marengo (embed).
+
+    Args:
+        lightrag: LightRAG instance (provides storage + KG machinery).
+        modal_caption_func: Unused for video (description comes from Pegasus);
+            accepted for interface compatibility with the other processors.
+        context_extractor: Optional context extractor.
+        api_key: TwelveLabs API key. Falls back to ``TWELVELABS_API_KEY`` env.
+        pegasus_model: Pegasus model id for analysis.
+        marengo_model: Marengo model id for embeddings.
+    """
+
+    def __init__(
+        self,
+        lightrag: LightRAG,
+        modal_caption_func=None,
+        context_extractor: ContextExtractor = None,
+        api_key: Optional[str] = None,
+        pegasus_model: str = DEFAULT_PEGASUS_MODEL,
+        marengo_model: str = DEFAULT_MARENGO_MODEL,
+    ):
+        super().__init__(lightrag, modal_caption_func, context_extractor)
+
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError as e:  # pragma: no cover - guarded at registration
+            raise ImportError(
+                "The 'twelvelabs' package is required for video processing. "
+                "Install it with: pip install 'raganything[video]' "
+                "(or: pip install twelvelabs)."
+            ) from e
+
+        self.api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "TwelveLabs API key not found. Set TWELVELABS_API_KEY or pass "
+                "api_key=. Get a free key at https://twelvelabs.io."
+            )
+
+        self._client = TwelveLabs(api_key=self.api_key)
+        self.pegasus_model = pegasus_model
+        self.marengo_model = marengo_model
+
+    # ── TwelveLabs API helpers ───────────────────────────────────────────
+
+    @staticmethod
+    def _resolve_video_ref(content_data: Dict[str, Any]) -> Tuple[str, str]:
+        """Resolve the video reference from a modal item.
+
+        Returns a ``(kind, value)`` tuple where kind is one of
+        ``"url"``, ``"video_id"`` or ``"path"``.
+        """
+        if content_data.get("video_url"):
+            return "url", content_data["video_url"]
+        if content_data.get("video_id"):
+            return "video_id", content_data["video_id"]
+        if content_data.get("video_path"):
+            return "path", content_data["video_path"]
+        raise ValueError(
+            "Video modal item must provide one of: video_url, video_id, video_path. "
+            f"Got keys: {sorted(content_data.keys())}"
+        )
+
+    def _analyze_video(self, kind: str, value: str, prompt: str) -> str:
+        """Call Pegasus to generate a description. Returns the description text."""
+        from twelvelabs.types.video_context import (
+            VideoContext_AssetId,
+            VideoContext_Url,
+        )
+
+        kwargs: Dict[str, Any] = {
+            "model_name": self.pegasus_model,
+            "prompt": prompt,
+            "max_tokens": 2048,
+        }
+        if kind == "video_id":
+            kwargs["video_id"] = value
+        elif kind == "url":
+            kwargs["video"] = VideoContext_Url(url=value)
+        else:  # path -> upload as asset, then analyze by asset id
+            asset_id = self._upload_asset(value)
+            kwargs["video"] = VideoContext_AssetId(asset_id=asset_id)
+
+        response = self._client.analyze(**kwargs)
+        return (response.data or "").strip()
+
+    def _upload_asset(self, path: str) -> str:
+        """Upload a local video file as a TwelveLabs asset; return its id."""
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"Video file not found: {path}")
+        with open(p, "rb") as f:
+            asset = self._client.assets.create(method="direct", file=f)
+        return asset.id
+
+    def embed_video(
+        self, kind: str, value: str, timeout_sec: int = 300, poll_interval_sec: int = 5
+    ) -> Optional[List[float]]:
+        """Compute a Marengo embedding for a video reference (best-effort).
+
+        Video embedding is an asynchronous task: this submits the task and polls
+        until it finishes or ``timeout_sec`` elapses. Returns a 512-dim vector
+        (the first/video-scope segment), or None if embedding is unavailable for
+        the given reference type (e.g. a bare ``video_id``) or did not complete
+        in time. Never raises -- ingestion proceeds without the embedding.
+        """
+        import time
+
+        try:
+            if kind == "url":
+                task = self._client.embed.tasks.create(
+                    model_name=self.marengo_model,
+                    video_url=value,
+                    video_embedding_scope=["video"],
+                )
+            elif kind == "path":
+                with open(value, "rb") as f:
+                    task = self._client.embed.tasks.create(
+                        model_name=self.marengo_model,
+                        video_file=f,
+                        video_embedding_scope=["video"],
+                    )
+            else:
+                return None
+
+            deadline = time.monotonic() + timeout_sec
+            while time.monotonic() < deadline:
+                status = self._client.embed.tasks.status(task.id)
+                if status.status == "ready":
+                    break
+                if status.status == "failed":
+                    logger.warning(f"TwelveLabs embedding task {task.id} failed")
+                    return None
+                time.sleep(poll_interval_sec)
+            else:
+                logger.warning(
+                    f"TwelveLabs embedding task {task.id} timed out after {timeout_sec}s"
+                )
+                return None
+
+            result = self._client.embed.tasks.retrieve(task.id)
+            segments = getattr(result.video_embedding, "segments", None)
+            if segments:
+                return list(segments[0].float_)
+        except Exception as e:  # pragma: no cover - network/availability dependent
+            logger.warning(f"TwelveLabs video embedding failed: {e}")
+        return None
+
+    def embed_text(self, text: str) -> List[float]:
+        """Compute a Marengo embedding for a text query (512-dim).
+
+        Useful at retrieval time to score a text query against stored video
+        embeddings in the same multimodal space.
+        """
+        resp = self._client.embed.create(model_name=self.marengo_model, text=text)
+        return list(resp.text_embedding.segments[0].float_)
+
+    # ── Pipeline integration (mirrors GenericModalProcessor) ─────────────
+
+    async def generate_description_only(
+        self,
+        modal_content,
+        content_type: str,
+        item_info: Dict[str, Any] = None,
+        entity_name: str = None,
+    ) -> Tuple[str, Dict[str, Any]]:
+        try:
+            content_data = _coerce_content(modal_content)
+            kind, value = self._resolve_video_ref(content_data)
+            captions = content_data.get(
+                "video_caption", content_data.get("caption", [])
+            )
+
+            context = ""
+            if item_info:
+                context = self._get_context_for_item(item_info)
+            context_block = (
+                f"Surrounding document context:\n{context}\n\n" if context else ""
+            )
+
+            prompt = PROMPTS["video_analysis_prompt"].format(
+                context_block=context_block,
+                captions=", ".join(captions) if captions else "None",
+            )
+
+            description = self._analyze_video(kind, value, prompt)
+            if not description:
+                raise RuntimeError("Pegasus returned an empty description")
+
+            name = entity_name or f"video_{compute_mdhash_id(value)}"
+            entity_info = {
+                "entity_name": name,
+                "entity_type": "video",
+                "summary": description[:100]
+                + ("..." if len(description) > 100 else ""),
+            }
+            return description, entity_info
+
+        except Exception as e:
+            logger.error(f"Error generating video description: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                or f"video_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "video",
+                "summary": f"Video content: {str(modal_content)[:100]}",
+            }
+            return str(modal_content), fallback_entity
+
+    async def process_multimodal_content(
+        self,
+        modal_content,
+        content_type: str,
+        file_path: str = "manual_creation",
+        entity_name: str = None,
+        item_info: Dict[str, Any] = None,
+        batch_mode: bool = False,
+        doc_id: str = None,
+        chunk_order_index: int = 0,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Process a video item: Pegasus description + Marengo embedding."""
+        try:
+            description, entity_info = await self.generate_description_only(
+                modal_content, content_type, item_info, entity_name
+            )
+
+            content_data = _coerce_content(modal_content)
+            kind, value = self._resolve_video_ref(content_data)
+            captions = content_data.get(
+                "video_caption", content_data.get("caption", [])
+            )
+
+            # Best-effort Marengo embedding, returned on entity_info for callers
+            # that want to index it for semantic video retrieval (pair with
+            # ``embed_text`` to score a text query in the same 512-dim space).
+            # Never blocks ingestion -- None on timeout/unavailable refs.
+            embedding = self.embed_video(kind, value)
+            if embedding is not None:
+                entity_info["tl_video_embedding"] = embedding
+
+            modal_chunk = PROMPTS["video_chunk"].format(
+                video_ref=value,
+                captions=", ".join(captions) if captions else "None",
+                description=description,
+            )
+
+            return await self._create_entity_and_chunk(
+                modal_chunk,
+                entity_info,
+                file_path,
+                batch_mode,
+                doc_id,
+                chunk_order_index,
+            )
+
+        except Exception as e:
+            logger.error(f"Error processing video content: {e}")
+            fallback_entity = {
+                "entity_name": entity_name
+                or f"video_{compute_mdhash_id(str(modal_content))}",
+                "entity_type": "video",
+                "summary": f"Video content: {str(modal_content)[:100]}",
+            }
+            return str(modal_content), fallback_entity
+
+
+def _coerce_content(modal_content) -> Dict[str, Any]:
+    """Accept a dict or a JSON string and return a dict."""
+    if isinstance(modal_content, str):
+        try:
+            return json.loads(modal_content)
+        except json.JSONDecodeError:
+            return {"video_url": modal_content}
+    return modal_content

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -437,6 +437,8 @@ def get_processor_for_type(modal_processors: Dict[str, Any], content_type: str):
         return modal_processors.get("table")
     elif content_type == "equation":
         return modal_processors.get("equation")
+    elif content_type == "video" and "video" in modal_processors:
+        return modal_processors.get("video")
     else:
         # For other types, use generic processor
         return modal_processors.get("generic")
@@ -462,6 +464,12 @@ def get_processor_supports(proc_type: str) -> List[str]:
             "Variable identification",
             "Formula meaning explanation",
             "Formula entity extraction",
+        ],
+        "video": [
+            "Video understanding (TwelveLabs Pegasus)",
+            "Transcript / description generation",
+            "Multimodal video embeddings (TwelveLabs Marengo, 512-dim)",
+            "Video entity extraction",
         ],
         "generic": [
             "General content analysis",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ tqdm
 # - [image]: Pillow>=10.0.0 (for BMP, TIFF, GIF, WebP format conversion)
 # - [text]: reportlab>=4.0.0 (for TXT, MD to PDF conversion)
 # - [paddleocr]: paddleocr + pypdfium2 (for parser='paddleocr' - better OCR for scanned PDFs)
+# - [video]: twelvelabs>=1.2.8 (for the TwelveLabs video modality: Pegasus + Marengo)
 # - [office]: requires LibreOffice (external program, not Python package)
 # - [all]: includes all optional dependencies
 #

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ extras_require = {
         "paddleocr>=2.7.0",
         "pypdfium2>=4.25.0",
     ],  # PaddleOCR parser for scanned PDFs
+    "video": ["twelvelabs>=1.2.8"],  # Video understanding & embeddings (TwelveLabs)
     "all": [
         "Pillow>=10.0.0",
         "reportlab>=4.0.0",
@@ -75,6 +76,7 @@ extras_require = {
         "markdown>=3.4.0",
         "weasyprint>=60.0",
         "pygments>=2.10.0",
+        "twelvelabs>=1.2.8",
     ],  # All optional features
     "markdown": [
         "markdown>=3.4.0",

--- a/tests/test_twelvelabs_integration.py
+++ b/tests/test_twelvelabs_integration.py
@@ -1,0 +1,229 @@
+"""
+Tests for the TwelveLabs video modality integration.
+
+Two layers:
+
+1. **No-network unit tests** — verify config wiring, processor dispatch, and the
+   TwelveLabs processor's request construction (Pegasus analyze + Marengo embed)
+   using a fully mocked TwelveLabs client. Heavy deps (lightrag) are stubbed at
+   the sys.modules level, mirroring tests/test_minimax_integration.py.
+
+2. **Live smoke test** — gated on TWELVELABS_API_KEY; asserts a real Marengo
+   text embedding is 512-dim. Skipped automatically when the key/SDK is absent.
+"""
+
+import os
+import sys
+import types
+import pytest
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Lightweight lightrag stub so raganything.twelvelabs imports without heavy deps
+# ---------------------------------------------------------------------------
+
+
+def _load_raganything_module(name):
+    """Load a raganything submodule by file path without running the package
+    __init__ (which imports dotenv/lightrag not installed for unit tests)."""
+    import importlib.util
+    from pathlib import Path
+
+    _ensure_lightrag_stub()
+    full = f"raganything.{name}"
+    if full in sys.modules:
+        return sys.modules[full]
+
+    # Preferred path (CI with full deps installed): normal package import.
+    try:
+        return importlib.import_module(full)
+    except Exception:
+        pass
+
+    # Fallback for lean unit-test environments where the package __init__ pulls
+    # in heavy deps (dotenv/lightrag) we don't install: load the submodule by
+    # file path against a namespace package pointing at the real source dir.
+    if "raganything" not in sys.modules:
+        pkg = types.ModuleType("raganything")
+        pkg.__path__ = [str(Path(__file__).resolve().parent.parent / "raganything")]
+        sys.modules["raganything"] = pkg
+
+    mod_path = Path(__file__).resolve().parent.parent / "raganything" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(full, mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[full] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ensure_lightrag_stub():
+    import importlib.util
+
+    # If a real lightrag is installed (e.g. in CI with `.[all]`), use it as-is.
+    if "lightrag" in sys.modules or importlib.util.find_spec("lightrag") is not None:
+        return
+    lightrag_mod = types.ModuleType("lightrag")
+    lightrag_utils = types.ModuleType("lightrag.utils")
+    lightrag_lightrag = types.ModuleType("lightrag.lightrag")
+
+    def compute_mdhash_id(content, prefix=""):
+        import hashlib
+
+        return prefix + hashlib.md5(str(content).encode()).hexdigest()
+
+    lightrag_utils.compute_mdhash_id = compute_mdhash_id
+    lightrag_utils.logger = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+    lightrag_utils.get_env_value = lambda key, default, t=str: default
+
+    class _LightRAG:
+        pass
+
+    lightrag_lightrag.LightRAG = _LightRAG
+
+    # modalprocessors imports a number of lightrag internals; stub them too.
+    lightrag_kg = types.ModuleType("lightrag.kg")
+    lightrag_kg_shared = types.ModuleType("lightrag.kg.shared_storage")
+    lightrag_kg_shared.get_namespace_data = lambda *a, **k: {}
+    lightrag_kg_shared.get_pipeline_status_lock = lambda *a, **k: None
+    lightrag_operate = types.ModuleType("lightrag.operate")
+    lightrag_operate.extract_entities = lambda *a, **k: []
+    lightrag_operate.merge_nodes_and_edges = lambda *a, **k: None
+
+    sys.modules["lightrag"] = lightrag_mod
+    sys.modules["lightrag.utils"] = lightrag_utils
+    sys.modules["lightrag.lightrag"] = lightrag_lightrag
+    sys.modules["lightrag.kg"] = lightrag_kg
+    sys.modules["lightrag.kg.shared_storage"] = lightrag_kg_shared
+    sys.modules["lightrag.operate"] = lightrag_operate
+
+
+# ---------------------------------------------------------------------------
+# Config + dispatch (no network, no twelvelabs SDK required)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigAndDispatch:
+    def test_video_processing_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("ENABLE_VIDEO_PROCESSING", raising=False)
+        RAGAnythingConfig = _load_raganything_module("config").RAGAnythingConfig
+
+        cfg = RAGAnythingConfig()
+        assert cfg.enable_video_processing is False
+
+    def test_dispatch_routes_video_when_registered(self):
+        get_processor_for_type = _load_raganything_module(
+            "utils"
+        ).get_processor_for_type
+
+        processors = {"generic": object(), "video": object()}
+        assert get_processor_for_type(processors, "video") is processors["video"]
+
+    def test_dispatch_falls_back_to_generic_without_video(self):
+        get_processor_for_type = _load_raganything_module(
+            "utils"
+        ).get_processor_for_type
+
+        processors = {"generic": object()}
+        # No video processor registered -> generic fallback, never KeyError.
+        assert get_processor_for_type(processors, "video") is processors["generic"]
+
+
+# ---------------------------------------------------------------------------
+# Processor request wiring (mocked TwelveLabs client, no network)
+# ---------------------------------------------------------------------------
+
+twelvelabs = pytest.importorskip("twelvelabs", reason="twelvelabs SDK not installed")
+
+
+def _import_tl_module():
+    """Import raganything.twelvelabs by file path, bypassing the package
+    __init__ (which pulls in dotenv/lightrag we don't install for unit tests)."""
+    # twelvelabs.py imports raganything.prompt + raganything.modalprocessors.
+    _load_raganything_module("prompt")
+    _load_raganything_module("modalprocessors")
+    return _load_raganything_module("twelvelabs")
+
+
+def _make_processor():
+    TwelveLabsModalProcessor = _import_tl_module().TwelveLabsModalProcessor
+
+    # Bypass BaseModalProcessor.__init__ (needs a real LightRAG); we only test
+    # the TwelveLabs request construction here.
+    proc = TwelveLabsModalProcessor.__new__(TwelveLabsModalProcessor)
+    proc._client = MagicMock()
+    proc.pegasus_model = "pegasus1.5"
+    proc.marengo_model = "marengo3.0"
+    return proc
+
+
+class TestProcessorWiring:
+    def test_resolve_video_ref_priority(self):
+        P = _import_tl_module().TwelveLabsModalProcessor
+
+        assert P._resolve_video_ref({"video_url": "u"}) == ("url", "u")
+        assert P._resolve_video_ref({"video_id": "i"}) == ("video_id", "i")
+        assert P._resolve_video_ref({"video_path": "p"}) == ("path", "p")
+        with pytest.raises(ValueError):
+            P._resolve_video_ref({"nope": 1})
+
+    def test_analyze_video_url_wiring(self):
+        proc = _make_processor()
+        proc._client.analyze.return_value = types.SimpleNamespace(
+            data="A person rides a bicycle."
+        )
+        out = proc._analyze_video("url", "https://x/clip.mp4", "describe")
+        assert out == "A person rides a bicycle."
+        kwargs = proc._client.analyze.call_args.kwargs
+        assert kwargs["model_name"] == "pegasus1.5"
+        assert kwargs["prompt"] == "describe"
+        assert kwargs["max_tokens"] == 2048
+        # video passed as a VideoContext_Url with the right url
+        assert getattr(kwargs["video"], "url", None) == "https://x/clip.mp4"
+
+    def test_analyze_video_id_wiring(self):
+        proc = _make_processor()
+        proc._client.analyze.return_value = types.SimpleNamespace(data="desc")
+        proc._analyze_video("video_id", "vid123", "p")
+        assert proc._client.analyze.call_args.kwargs["video_id"] == "vid123"
+
+    def test_embed_text_returns_vector(self):
+        proc = _make_processor()
+        seg = types.SimpleNamespace(float_=[0.1] * 512)
+        proc._client.embed.create.return_value = types.SimpleNamespace(
+            text_embedding=types.SimpleNamespace(segments=[seg])
+        )
+        vec = proc.embed_text("a query")
+        assert len(vec) == 512
+        assert proc._client.embed.create.call_args.kwargs["model_name"] == "marengo3.0"
+
+    def test_embed_video_returns_none_for_bare_id(self):
+        proc = _make_processor()
+        # A bare video_id has no URL/file to embed -> None, no exception.
+        assert proc.embed_video("video_id", "vid123") is None
+
+
+# ---------------------------------------------------------------------------
+# Live smoke test (gated on TWELVELABS_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set; skipping live TwelveLabs call",
+)
+def test_marengo_text_embedding_live():
+    from twelvelabs import TwelveLabs
+
+    client = TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+    resp = client.embed.create(
+        model_name=os.getenv("TWELVELABS_MARENGO_MODEL", "marengo3.0"),
+        text="a person riding a bicycle",
+    )
+    vec = resp.text_embedding.segments[0].float_
+    assert len(vec) == 512


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## Description

This PR adds an **opt-in `video` modality** to RAG-Anything, backed by the [TwelveLabs](https://twelvelabs.io) platform. It lets RAG-Anything ingest and retrieve video the same way it already handles images, tables and equations.

- **Pegasus** (`analyze`) generates a detailed transcript/description of a video. That text flows through the **existing** knowledge-graph + chunk pipeline via `BaseModalProcessor._create_entity_and_chunk` — no new retrieval path, no special-casing downstream.
- **Marengo** (`embed`) produces a 512-dim multimodal embedding, returned on the item's `entity_info` (`tl_video_embedding`) for semantic video retrieval. A companion `embed_text()` lets you score a text query in the same 512-dim space.

## Why it helps this project

RAG-Anything is explicitly multimodal, but video isn't yet a first-class modality. Pegasus + Marengo give a turnkey way to bring video understanding and video↔text semantic search into the existing graph/RAG pipeline, with no extra infra on the user's side.

## Changes Made

- `raganything/twelvelabs.py`: new `TwelveLabsModalProcessor` (mirrors `GenericModalProcessor`). Accepts `video_url`, `video_path` (uploaded as a TwelveLabs asset), or `video_id`.
- `config.py`: `enable_video_processing` flag (env `ENABLE_VIDEO_PROCESSING`), **default False**.
- `raganything.py`: registers the `video` processor only when enabled **and** `twelvelabs` is installed and a key is present; otherwise it logs a warning and skips — initialization never breaks.
- `utils.py`: dispatch routes `"video"` to the processor (falls back to `generic` when unregistered, never `KeyError`).
- `__init__.py`: optional `TwelveLabsModalProcessor` export (same try/except pattern as other optional features).
- `pyproject.toml` / `setup.py`: new `[video]` extra (`twelvelabs>=1.2.8`), also folded into `[all]`.
- `env.example`, `requirements.txt`, `README.md`: docs + config entries.

## Opt-in / non-breaking

Disabled by default. With `ENABLE_VIDEO_PROCESSING` unset, there are **zero** behavioural changes and no new hard dependency (`twelvelabs` only installs via the `[video]`/`[all]` extra).

## How it was tested

`tests/test_twelvelabs_integration.py`:
- No-network unit tests: config default, dispatch routing/fallback, and Pegasus/Marengo request wiring against a mocked TwelveLabs client.
- A live smoke test (gated on `TWELVELABS_API_KEY`, skipped in CI without it) asserting a real Marengo text embedding is **512-dim** — verified locally (`9 passed`).

Ran the repo's `ruff format --check` and `ruff check --ignore=E402` on all changed files — clean.

> Note: full Pegasus/Marengo *video* runs are server-side and can be slow (Marengo video embedding is an async, polled task). The video paths are wiring-verified against the SDK contract; the synchronous Marengo text-embedding path is verified end-to-end against the live API.

## Checklist

- [x] Changes tested locally
- [x] Documentation updated
- [x] Unit tests added

## Additional Notes

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
