### PR TITLE
Fix Windows LibreOffice discovery for office conversion

### DIFF
--- a/examples/office_document_test.py
+++ b/examples/office_document_test.py
@@ -18,13 +18,14 @@ import asyncio
 import sys
 from pathlib import Path
 from raganything import RAGAnything
+from raganything.parser import Parser
 
 
 def check_libreoffice_installation():
     """Check if LibreOffice is installed and available"""
     import subprocess
 
-    for cmd in ["libreoffice", "soffice"]:
+    for cmd in Parser._libreoffice_command_candidates():
         try:
             result = subprocess.run(
                 [cmd, "--version"], capture_output=True, check=True, timeout=10

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -191,6 +191,46 @@ class Parser:
         return Path(base_dir) / f"{stem}_{path_hash}"
 
     @classmethod
+    def _libreoffice_command_candidates(cls) -> List[str]:
+        """Return LibreOffice executable candidates for office conversion."""
+        command_names = ["libreoffice", "soffice"]
+        candidates: List[str] = []
+
+        for command_name in command_names:
+            resolved = shutil.which(command_name)
+            if resolved:
+                candidates.append(resolved)
+            candidates.append(command_name)
+
+        if _IS_WINDOWS:
+            for command_name in ["soffice.exe", "libreoffice.exe"]:
+                resolved = shutil.which(command_name)
+                if resolved:
+                    candidates.append(resolved)
+                candidates.append(command_name)
+
+            for env_name in ("PROGRAMFILES", "PROGRAMFILES(X86)"):
+                program_files = os.environ.get(env_name)
+                if not program_files:
+                    continue
+
+                libreoffice_program = Path(program_files) / "LibreOffice" / "program"
+                for exe_name in ("soffice.exe", "libreoffice.exe"):
+                    exe_path = libreoffice_program / exe_name
+                    if exe_path.exists():
+                        candidates.append(str(exe_path))
+
+        deduped: List[str] = []
+        seen = set()
+        for candidate in candidates:
+            normalized = os.path.normcase(candidate)
+            if normalized not in seen:
+                seen.add(normalized)
+                deduped.append(candidate)
+
+        return deduped
+
+    @classmethod
     def convert_office_to_pdf(
         cls, doc_path: Union[str, Path], output_dir: Optional[str] = None
     ) -> Path:
@@ -230,9 +270,8 @@ class Parser:
                     f"Converting {doc_path.name} to PDF using LibreOffice..."
                 )
 
-                # Prepare subprocess parameters to hide console window on Windows
                 # Try LibreOffice commands in order of preference
-                commands_to_try = ["libreoffice", "soffice"]
+                commands_to_try = cls._libreoffice_command_candidates()
 
                 conversion_successful = False
                 last_cmd = commands_to_try[-1]

--- a/tests/testparser_kwargs.py
+++ b/tests/testparser_kwargs.py
@@ -24,7 +24,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 import os
 import re
-from raganything.parser import MineruParser, DoclingParser
+from raganything.parser import MineruParser, DoclingParser, Parser
 import raganything.parser as parser_module
 
 
@@ -155,6 +155,59 @@ def test_invalid_env_contents(mineru_parser, docling_parser, dummy_path, tmp_pat
             file_stem="stem",
             env={"key": 123},
         )
+
+
+def test_windows_libreoffice_candidates_include_standard_install_dir(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(parser_module, "_IS_WINDOWS", True)
+    monkeypatch.setattr(parser_module.shutil, "which", lambda command: None)
+    monkeypatch.setenv("PROGRAMFILES", str(tmp_path))
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+
+    soffice_path = tmp_path / "LibreOffice" / "program" / "soffice.exe"
+    soffice_path.parent.mkdir(parents=True)
+    soffice_path.write_text("", encoding="utf-8")
+
+    candidates = Parser._libreoffice_command_candidates()
+
+    assert str(soffice_path) in candidates
+
+
+def test_convert_office_to_pdf_uses_windows_standard_libreoffice_path(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(parser_module, "_IS_WINDOWS", True)
+    monkeypatch.setattr(parser_module.subprocess, "CREATE_NO_WINDOW", 0, raising=False)
+    monkeypatch.setattr(parser_module.shutil, "which", lambda command: None)
+    monkeypatch.setenv("PROGRAMFILES", str(tmp_path))
+    monkeypatch.delenv("PROGRAMFILES(X86)", raising=False)
+
+    soffice_path = tmp_path / "LibreOffice" / "program" / "soffice.exe"
+    soffice_path.parent.mkdir(parents=True)
+    soffice_path.write_text("", encoding="utf-8")
+
+    doc_path = tmp_path / "sample.docx"
+    doc_path.write_bytes(b"docx")
+    output_dir = tmp_path / "out"
+    captured_commands = []
+
+    def fake_run(cmd, **kwargs):
+        captured_commands.append(cmd)
+        if cmd[0] != str(soffice_path):
+            raise FileNotFoundError(cmd[0])
+
+        pdf_path = Path(cmd[cmd.index("--outdir") + 1]) / "sample.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4\n" + b"0" * 200)
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(parser_module.subprocess, "run", fake_run)
+
+    pdf_path = Parser.convert_office_to_pdf(doc_path, output_dir)
+
+    assert captured_commands[-1][0] == str(soffice_path)
+    assert pdf_path == output_dir / "sample.pdf"
+    assert pdf_path.exists()
 
 
 def test_mineru_windows_unsafe_pdf_uses_safe_paths(


### PR DESCRIPTION
## Summary
- add reusable LibreOffice command discovery for office document conversion
- include Windows .exe command names and standard Program Files LibreOffice install paths
- reuse the same discovery logic in the office document example checker
- add regression coverage for the Windows standard install path fallback

Fixes #290.

## Verification
- python -m py_compile raganything/parser.py examples/office_document_test.py tests/testparser_kwargs.py
- direct parser LibreOffice fallback harness passed locally

Note: python -m pytest tests/testparser_kwargs.py -q could not collect in this local environment because lightrag is not installed.