### PR TITLE
Add incremental batch folder scans

### DIFF
--- a/docs/batch_processing.md
+++ b/docs/batch_processing.md
@@ -145,8 +145,10 @@ python -m raganything.batch_parser --help
 
 Use `incremental=True` when repeatedly processing the same folder. RAG-Anything
 stores a manifest at `.raganything_batch_manifest.json` inside the output
-directory and skips files whose size, modification time, and MD5 hash match the
-last successful run.
+directory and skips files that are unchanged since the last successful run. A
+file is considered unchanged when its size and modification time match the
+manifest; only when those differ is the MD5 hash recomputed and compared, so
+large unchanged files are not re-hashed on every run.
 
 ```python
 result = batch_parser.process_batch(

--- a/docs/batch_processing.md
+++ b/docs/batch_processing.md
@@ -134,8 +134,30 @@ python -m raganything.batch_parser examples/sample_docs/ --output ./output --no-
 # Dry run (list supported files without processing)
 python -m raganything.batch_parser examples/sample_docs/ --output ./output --dry-run
 
+# Incremental run (skip files unchanged since the last successful batch)
+python -m raganything.batch_parser examples/sample_docs/ --output ./output --incremental
+
 # Help
 python -m raganything.batch_parser --help
+```
+
+### Incremental Folder Scans
+
+Use `incremental=True` when repeatedly processing the same folder. RAG-Anything
+stores a manifest at `.raganything_batch_manifest.json` inside the output
+directory and skips files whose size, modification time, and MD5 hash match the
+last successful run.
+
+```python
+result = batch_parser.process_batch(
+    file_paths=["./documents"],
+    output_dir="./output",
+    recursive=True,
+    incremental=True,
+)
+
+print(f"Processed: {len(result.successful_files)}")
+print(f"Skipped unchanged: {len(result.skipped_files)}")
 ```
 
 ## Configuration
@@ -179,6 +201,7 @@ class BatchProcessingResult:
     errors: Dict[str, str]           # Error messages for failed files
     output_dir: str                  # Output directory used
     dry_run: bool                    # True if run was a dry-run
+    skipped_files: List[str]         # Unchanged files skipped in incremental mode
 
     def summary(self) -> str:        # Human-readable summary
     def success_rate(self) -> float: # Success rate as percentage

--- a/raganything/batch.py
+++ b/raganything/batch.py
@@ -182,6 +182,7 @@ class BatchMixin:
         max_workers: Optional[int] = None,
         recursive: Optional[bool] = None,
         show_progress: bool = True,
+        incremental: bool = False,
         **kwargs,
     ) -> BatchProcessingResult:
         """
@@ -194,6 +195,7 @@ class BatchMixin:
             max_workers: Maximum number of workers for parallel processing
             recursive: Whether to process directories recursively
             show_progress: Whether to show progress bar
+            incremental: Whether to skip files unchanged since the last successful batch run
             **kwargs: Additional arguments passed to the parser
 
         Returns:
@@ -223,6 +225,7 @@ class BatchMixin:
             output_dir=output_dir,
             parse_method=parse_method,
             recursive=recursive,
+            incremental=incremental,
             **kwargs,
         )
 
@@ -234,6 +237,7 @@ class BatchMixin:
         max_workers: Optional[int] = None,
         recursive: Optional[bool] = None,
         show_progress: bool = True,
+        incremental: bool = False,
         **kwargs,
     ) -> BatchProcessingResult:
         """
@@ -246,6 +250,7 @@ class BatchMixin:
             max_workers: Maximum number of workers for parallel processing
             recursive: Whether to process directories recursively
             show_progress: Whether to show progress bar
+            incremental: Whether to skip files unchanged since the last successful batch run
             **kwargs: Additional arguments passed to the parser
 
         Returns:
@@ -275,6 +280,7 @@ class BatchMixin:
             output_dir=output_dir,
             parse_method=parse_method,
             recursive=recursive,
+            incremental=incremental,
             **kwargs,
         )
 
@@ -310,6 +316,7 @@ class BatchMixin:
         max_workers: Optional[int] = None,
         recursive: Optional[bool] = None,
         show_progress: bool = True,
+        incremental: bool = False,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -326,6 +333,7 @@ class BatchMixin:
             max_workers: Maximum number of workers for parallel processing
             recursive: Whether to process directories recursively
             show_progress: Whether to show progress bar
+            incremental: Whether to skip files unchanged since the last successful batch run
             **kwargs: Additional arguments passed to the parser
 
         Returns:
@@ -361,6 +369,7 @@ class BatchMixin:
             max_workers=max_workers,
             recursive=recursive,
             show_progress=show_progress,
+            incremental=incremental,
             **kwargs,
         )
 

--- a/raganything/batch_parser.py
+++ b/raganything/batch_parser.py
@@ -9,6 +9,8 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
+import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
 from pathlib import Path
@@ -243,33 +245,54 @@ class BatchParser:
         """Persist incremental processing metadata atomically."""
         manifest_path = self._manifest_path(output_dir)
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = manifest_path.with_suffix(".tmp")
         payload = {
             "version": 1,
             "updated_at": time.time(),
             "files": manifest,
         }
-        temp_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        # Write to a uniquely named temp file in the same directory before the
+        # atomic replace. A fixed ".tmp" name would let two concurrent batches
+        # writing to the same output_dir clobber each other's half-written temp.
+        fd, temp_name = tempfile.mkstemp(
+            dir=str(manifest_path.parent),
+            prefix=".raganything_batch_manifest.",
+            suffix=".tmp",
         )
-        temp_path.replace(manifest_path)
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+                json.dump(payload, temp_file, indent=2, sort_keys=True)
+            temp_path.replace(manifest_path)
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise
 
     @staticmethod
-    def _file_signature(file_path: str) -> Dict[str, object]:
-        """Return size, mtime, and md5 metadata for change detection."""
+    def _file_metadata(file_path: str) -> Dict[str, object]:
+        """Return cheap stat metadata (resolved path, size, mtime) without hashing."""
         path = Path(file_path)
         stat = path.stat()
-        md5 = hashlib.md5()
-        with path.open("rb") as file_obj:
-            for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
-                md5.update(chunk)
-
         return {
             "path": str(path.resolve()),
             "size": stat.st_size,
             "mtime_ns": stat.st_mtime_ns,
-            "md5": md5.hexdigest(),
         }
+
+    @staticmethod
+    def _compute_md5(file_path: str) -> str:
+        """Stream a file and return its md5 hex digest."""
+        md5 = hashlib.md5()
+        with Path(file_path).open("rb") as file_obj:
+            for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    @classmethod
+    def _file_signature(cls, file_path: str) -> Dict[str, object]:
+        """Return size, mtime, and md5 metadata for change detection."""
+        metadata = cls._file_metadata(file_path)
+        metadata["md5"] = cls._compute_md5(file_path)
+        return metadata
 
     def _filter_incremental_files(
         self, file_paths: List[str], manifest: Dict[str, Dict[str, object]]
@@ -280,11 +303,47 @@ class BatchParser:
         signatures = {}
 
         for file_path in file_paths:
-            signature = self._file_signature(file_path)
-            manifest_key = signature["path"]
-            signatures[file_path] = signature
+            try:
+                metadata = self._file_metadata(file_path)
+            except OSError as exc:
+                # File vanished or became unreadable between discovery and the
+                # incremental scan. Treat it as changed so the normal per-file
+                # error path handles it instead of aborting the whole batch.
+                self.logger.warning(
+                    f"Could not read {file_path} for incremental scan: {exc}"
+                )
+                files_to_process.append(file_path)
+                continue
 
-            if manifest.get(manifest_key) == signature:
+            manifest_key = metadata["path"]
+            previous = manifest.get(manifest_key)
+
+            # Fast path: if size and mtime match a previous run, trust the
+            # stored signature and skip re-hashing the file entirely.
+            if (
+                isinstance(previous, dict)
+                and previous.get("size") == metadata["size"]
+                and previous.get("mtime_ns") == metadata["mtime_ns"]
+                and "md5" in previous
+            ):
+                signatures[file_path] = previous
+                skipped_files.append(file_path)
+                continue
+
+            # Metadata differs (or the file is new/unrecorded): hash to build a
+            # full signature and compare content.
+            try:
+                metadata["md5"] = self._compute_md5(file_path)
+            except OSError as exc:
+                self.logger.warning(
+                    f"Could not read {file_path} for incremental scan: {exc}"
+                )
+                files_to_process.append(file_path)
+                continue
+
+            signatures[file_path] = metadata
+
+            if previous == metadata:
                 skipped_files.append(file_path)
             else:
                 files_to_process.append(file_path)

--- a/raganything/batch_parser.py
+++ b/raganything/batch_parser.py
@@ -6,11 +6,14 @@ with progress reporting and error handling.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import time
 
 from tqdm import tqdm
@@ -29,21 +32,25 @@ class BatchProcessingResult:
     errors: Dict[str, str]
     output_dir: str
     dry_run: bool = False
+    skipped_files: List[str] = field(default_factory=list)
 
     @property
     def success_rate(self) -> float:
         """Calculate success rate as percentage"""
         if self.total_files == 0:
             return 0.0
-        return (len(self.successful_files) / self.total_files) * 100
+        completed_files = len(self.successful_files) + len(self.skipped_files)
+        return (completed_files / self.total_files) * 100
 
     def summary(self) -> str:
         """Generate a summary of the batch processing results"""
         return (
             f"Batch Processing Summary:\n"
             f"  Total files: {self.total_files}\n"
-            f"  Successful: {len(self.successful_files)} ({self.success_rate:.1f}%)\n"
+            f"  Successful: {len(self.successful_files)}\n"
             f"  Failed: {len(self.failed_files)}\n"
+            f"  Skipped: {len(self.skipped_files)}\n"
+            f"  Success rate: {self.success_rate:.1f}%\n"
             f"  Processing time: {self.processing_time:.2f} seconds\n"
             f"  Output directory: {self.output_dir}\n"
             f"  Dry run: {self.dry_run}"
@@ -200,6 +207,90 @@ class BatchParser:
             self.logger.error(error_msg)
             return False, file_path, error_msg
 
+    @staticmethod
+    def _manifest_path(output_dir: str) -> Path:
+        """Return the incremental processing manifest path."""
+        return Path(output_dir) / ".raganything_batch_manifest.json"
+
+    def _load_incremental_manifest(
+        self, output_dir: str
+    ) -> Dict[str, Dict[str, object]]:
+        """Load incremental processing metadata."""
+        manifest_path = self._manifest_path(output_dir)
+        if not manifest_path.exists():
+            return {}
+
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            self.logger.warning(
+                f"Could not read incremental manifest {manifest_path}: {exc}"
+            )
+            return {}
+
+        if not isinstance(data, dict):
+            self.logger.warning(
+                f"Ignoring invalid incremental manifest {manifest_path}: expected object"
+            )
+            return {}
+
+        files = data.get("files", {})
+        return files if isinstance(files, dict) else {}
+
+    def _save_incremental_manifest(
+        self, output_dir: str, manifest: Dict[str, Dict[str, object]]
+    ) -> None:
+        """Persist incremental processing metadata atomically."""
+        manifest_path = self._manifest_path(output_dir)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = manifest_path.with_suffix(".tmp")
+        payload = {
+            "version": 1,
+            "updated_at": time.time(),
+            "files": manifest,
+        }
+        temp_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        temp_path.replace(manifest_path)
+
+    @staticmethod
+    def _file_signature(file_path: str) -> Dict[str, object]:
+        """Return size, mtime, and md5 metadata for change detection."""
+        path = Path(file_path)
+        stat = path.stat()
+        md5 = hashlib.md5()
+        with path.open("rb") as file_obj:
+            for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+                md5.update(chunk)
+
+        return {
+            "path": str(path.resolve()),
+            "size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+            "md5": md5.hexdigest(),
+        }
+
+    def _filter_incremental_files(
+        self, file_paths: List[str], manifest: Dict[str, Dict[str, object]]
+    ) -> Tuple[List[str], List[str], Dict[str, Dict[str, object]]]:
+        """Split files into changed and unchanged groups using manifest metadata."""
+        files_to_process = []
+        skipped_files = []
+        signatures = {}
+
+        for file_path in file_paths:
+            signature = self._file_signature(file_path)
+            manifest_key = signature["path"]
+            signatures[file_path] = signature
+
+            if manifest.get(manifest_key) == signature:
+                skipped_files.append(file_path)
+            else:
+                files_to_process.append(file_path)
+
+        return files_to_process, skipped_files, signatures
+
     def process_batch(
         self,
         file_paths: List[str],
@@ -207,6 +298,7 @@ class BatchParser:
         parse_method: str = "auto",
         recursive: bool = True,
         dry_run: bool = False,
+        incremental: bool = False,
         **kwargs,
     ) -> BatchProcessingResult:
         """
@@ -218,6 +310,8 @@ class BatchParser:
             parse_method: Parsing method for all files
             recursive: Whether to search directories recursively
             dry_run: When True, only list files without processing them
+            incremental: When True, skip files whose size, mtime, and md5 match
+                the previous successful batch run in output_dir
             **kwargs: Additional parser arguments
 
         Returns:
@@ -242,23 +336,38 @@ class BatchParser:
 
         self.logger.info(f"Found {len(supported_files)} files to process")
 
+        # Create output directory before reading/writing the incremental manifest
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        skipped_files: List[str] = []
+        manifest: Dict[str, Dict[str, object]] = {}
+        signatures: Dict[str, Dict[str, object]] = {}
+        files_to_process = supported_files
+        if incremental:
+            manifest = self._load_incremental_manifest(output_dir)
+            files_to_process, skipped_files, signatures = (
+                self._filter_incremental_files(supported_files, manifest)
+            )
+            self.logger.info(
+                f"Incremental scan: {len(files_to_process)} changed files, "
+                f"{len(skipped_files)} unchanged files"
+            )
+
         if dry_run:
             self.logger.info(
-                f"Dry run enabled. {len(supported_files)} files would be processed."
+                f"Dry run enabled. {len(files_to_process)} files would be processed."
             )
             return BatchProcessingResult(
-                successful_files=supported_files,
+                successful_files=files_to_process,
                 failed_files=[],
                 total_files=len(supported_files),
                 processing_time=0.0,
                 errors={},
                 output_dir=output_dir,
                 dry_run=True,
+                skipped_files=skipped_files,
             )
-
-        # Create output directory
-        output_path = Path(output_dir)
-        output_path.mkdir(parents=True, exist_ok=True)
 
         # Process files in parallel
         successful_files = []
@@ -269,11 +378,12 @@ class BatchParser:
         pbar = None
         if self.show_progress:
             pbar = tqdm(
-                total=len(supported_files),
+                total=len(files_to_process),
                 desc=f"Processing files ({self.parser_type})",
                 unit="file",
             )
 
+        future_to_file = {}
         try:
             with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
                 # Submit all tasks
@@ -285,7 +395,7 @@ class BatchParser:
                         parse_method,
                         **kwargs,
                     ): file_path
-                    for file_path in supported_files
+                    for file_path in files_to_process
                 }
 
                 # Process completed tasks
@@ -318,6 +428,13 @@ class BatchParser:
             if pbar:
                 pbar.close()
 
+        if incremental and successful_files:
+            for file_path in successful_files:
+                signature = signatures.get(file_path)
+                if signature:
+                    manifest[signature["path"]] = signature
+            self._save_incremental_manifest(output_dir, manifest)
+
         processing_time = time.time() - start_time
 
         # Create result
@@ -329,6 +446,7 @@ class BatchParser:
             errors=errors,
             output_dir=output_dir,
             dry_run=False,
+            skipped_files=skipped_files,
         )
 
         # Log summary
@@ -343,6 +461,7 @@ class BatchParser:
         parse_method: str = "auto",
         recursive: bool = True,
         dry_run: bool = False,
+        incremental: bool = False,
         **kwargs,
     ) -> BatchProcessingResult:
         """
@@ -354,6 +473,7 @@ class BatchParser:
             parse_method: Parsing method for all files
             recursive: Whether to search directories recursively
             dry_run: When True, only list files without processing them
+            incremental: When True, skip unchanged files based on the batch manifest
             **kwargs: Additional parser arguments
 
         Returns:
@@ -361,16 +481,17 @@ class BatchParser:
         """
         # Run the sync version in a thread pool
         loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(
-            None,
+        process_func = partial(
             self.process_batch,
-            file_paths,
-            output_dir,
-            parse_method,
-            recursive,
-            dry_run,
+            file_paths=file_paths,
+            output_dir=output_dir,
+            parse_method=parse_method,
+            recursive=recursive,
+            dry_run=dry_run,
+            incremental=incremental,
             **kwargs,
         )
+        return await loop.run_in_executor(None, process_func)
 
 
 def main():
@@ -417,6 +538,11 @@ def main():
         action="store_true",
         help="List files that would be processed without running parsers",
     )
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Skip files unchanged since the last successful batch run",
+    )
 
     args = parser.parse_args()
 
@@ -442,6 +568,7 @@ def main():
             parse_method=args.method,
             recursive=args.recursive,
             dry_run=args.dry_run,
+            incremental=args.incremental,
         )
 
         # Print summary
@@ -454,6 +581,10 @@ def main():
                     print(f"  - {file_path}")
             else:
                 print("\nDry run: no supported files found.")
+            if result.skipped_files:
+                print("\nDry run: unchanged files that would be skipped:")
+                for file_path in result.skipped_files:
+                    print(f"  - {file_path}")
 
         # Exit with error code if any files failed
         if result.failed_files:

--- a/tests/testbatch_incremental.py
+++ b/tests/testbatch_incremental.py
@@ -120,3 +120,102 @@ def test_incremental_dry_run_reports_changed_and_skipped_files(monkeypatch, tmp_
     assert dry_run_result.successful_files == [str(first_doc)]
     assert dry_run_result.skipped_files == [str(second_doc)]
     assert fake_parser.processed_files == []
+
+
+def _seed_two_docs(tmp_path):
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    first_doc = docs_dir / "a.txt"
+    second_doc = docs_dir / "b.txt"
+    first_doc.write_text("alpha", encoding="utf-8")
+    second_doc.write_text("beta", encoding="utf-8")
+    return docs_dir, first_doc, second_doc
+
+
+def test_incremental_skip_does_not_rehash_unchanged_files(monkeypatch, tmp_path):
+    batch_parser, _ = _make_batch_parser(monkeypatch)
+    docs_dir, first_doc, second_doc = _seed_two_docs(tmp_path)
+    output_dir = tmp_path / "out"
+
+    batch_parser.process_batch([str(docs_dir)], str(output_dir), incremental=True)
+
+    # Second run: both files are unchanged, so the size+mtime fast path must
+    # skip them without hashing a single byte.
+    hashed = []
+    real_md5 = type(batch_parser)._compute_md5
+
+    def counting_md5(file_path):
+        hashed.append(file_path)
+        return real_md5(file_path)
+
+    monkeypatch.setattr(type(batch_parser), "_compute_md5", staticmethod(counting_md5))
+
+    result = batch_parser.process_batch(
+        [str(docs_dir)], str(output_dir), incremental=True
+    )
+
+    assert set(result.skipped_files) == {str(first_doc), str(second_doc)}
+    assert hashed == []
+
+
+def test_incremental_ignores_corrupt_manifest(monkeypatch, tmp_path):
+    batch_parser, fake_parser = _make_batch_parser(monkeypatch)
+    docs_dir, first_doc, second_doc = _seed_two_docs(tmp_path)
+    output_dir = tmp_path / "out"
+
+    batch_parser.process_batch([str(docs_dir)], str(output_dir), incremental=True)
+
+    manifest_path = output_dir / ".raganything_batch_manifest.json"
+    manifest_path.write_text("this is not valid json{", encoding="utf-8")
+    fake_parser.processed_files.clear()
+
+    result = batch_parser.process_batch(
+        [str(docs_dir)], str(output_dir), incremental=True
+    )
+
+    # A corrupt manifest must be ignored and every file reprocessed.
+    assert set(result.successful_files) == {str(first_doc), str(second_doc)}
+    assert result.skipped_files == []
+
+
+def test_incremental_tolerates_unreadable_file(monkeypatch, tmp_path):
+    batch_parser, fake_parser = _make_batch_parser(monkeypatch)
+    docs_dir, first_doc, second_doc = _seed_two_docs(tmp_path)
+    output_dir = tmp_path / "out"
+
+    batch_parser.process_batch([str(docs_dir)], str(output_dir), incremental=True)
+    fake_parser.processed_files.clear()
+
+    # Simulate one file becoming unreadable between discovery and the scan.
+    real_metadata = type(batch_parser)._file_metadata
+
+    def flaky_metadata(file_path):
+        if file_path == str(first_doc):
+            raise OSError("simulated unreadable file")
+        return real_metadata(file_path)
+
+    monkeypatch.setattr(
+        type(batch_parser), "_file_metadata", staticmethod(flaky_metadata)
+    )
+
+    # Must not raise; the unreadable file is treated as changed (queued for
+    # processing) while the other unchanged file is still skipped.
+    result = batch_parser.process_batch(
+        [str(docs_dir)], str(output_dir), incremental=True
+    )
+
+    assert str(first_doc) in (result.successful_files + result.failed_files)
+    assert result.skipped_files == [str(second_doc)]
+
+
+def test_incremental_dry_run_does_not_write_manifest(monkeypatch, tmp_path):
+    batch_parser, _ = _make_batch_parser(monkeypatch)
+    docs_dir, _first_doc, _second_doc = _seed_two_docs(tmp_path)
+    output_dir = tmp_path / "out"
+
+    batch_parser.process_batch(
+        [str(docs_dir)], str(output_dir), incremental=True, dry_run=True
+    )
+
+    manifest_path = output_dir / ".raganything_batch_manifest.json"
+    assert not manifest_path.exists()

--- a/tests/testbatch_incremental.py
+++ b/tests/testbatch_incremental.py
@@ -1,0 +1,122 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class FakeParser:
+    OFFICE_FORMATS = {".docx"}
+    IMAGE_FORMATS = {".png"}
+    TEXT_FORMATS = {".txt", ".md"}
+
+    def __init__(self):
+        self.processed_files = []
+
+    def check_installation(self):
+        return True
+
+    def parse_document(self, file_path, output_dir, method="auto", **kwargs):
+        self.processed_files.append(file_path)
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        return [{"type": "text", "text": Path(file_path).read_text()}]
+
+
+def _make_batch_parser(monkeypatch):
+    fake_parser = FakeParser()
+    repo_root = Path(__file__).parents[1]
+
+    package = types.ModuleType("raganything")
+    package.__path__ = [str(repo_root / "raganything")]
+    parser_module = types.ModuleType("raganything.parser")
+    parser_module.get_parser = lambda parser_type: fake_parser
+
+    monkeypatch.setitem(sys.modules, "raganything", package)
+    monkeypatch.setitem(sys.modules, "raganything.parser", parser_module)
+    sys.modules.pop("raganything.batch_parser", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "raganything.batch_parser",
+        repo_root / "raganything" / "batch_parser.py",
+    )
+    batch_parser_module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "raganything.batch_parser", batch_parser_module)
+    spec.loader.exec_module(batch_parser_module)
+
+    batch_parser = batch_parser_module.BatchParser(
+        parser_type="fake",
+        max_workers=1,
+        show_progress=False,
+        skip_installation_check=True,
+    )
+    return batch_parser, fake_parser
+
+
+def test_incremental_batch_skips_unchanged_files(monkeypatch, tmp_path):
+    batch_parser, fake_parser = _make_batch_parser(monkeypatch)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    first_doc = docs_dir / "a.txt"
+    second_doc = docs_dir / "b.txt"
+    first_doc.write_text("alpha", encoding="utf-8")
+    second_doc.write_text("beta", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    first_result = batch_parser.process_batch(
+        [str(docs_dir)],
+        str(output_dir),
+        incremental=True,
+    )
+
+    assert set(first_result.successful_files) == {str(first_doc), str(second_doc)}
+    assert first_result.skipped_files == []
+    assert set(fake_parser.processed_files) == {str(first_doc), str(second_doc)}
+
+    fake_parser.processed_files.clear()
+    second_result = batch_parser.process_batch(
+        [str(docs_dir)],
+        str(output_dir),
+        incremental=True,
+    )
+
+    assert second_result.successful_files == []
+    assert set(second_result.skipped_files) == {str(first_doc), str(second_doc)}
+    assert second_result.success_rate == 100.0
+    assert fake_parser.processed_files == []
+
+    first_doc.write_text("alpha changed", encoding="utf-8")
+    third_result = batch_parser.process_batch(
+        [str(docs_dir)],
+        str(output_dir),
+        incremental=True,
+    )
+
+    assert third_result.successful_files == [str(first_doc)]
+    assert third_result.skipped_files == [str(second_doc)]
+    assert fake_parser.processed_files == [str(first_doc)]
+
+
+def test_incremental_dry_run_reports_changed_and_skipped_files(monkeypatch, tmp_path):
+    batch_parser, fake_parser = _make_batch_parser(monkeypatch)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    first_doc = docs_dir / "a.txt"
+    second_doc = docs_dir / "b.txt"
+    first_doc.write_text("alpha", encoding="utf-8")
+    second_doc.write_text("beta", encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    batch_parser.process_batch([str(docs_dir)], str(output_dir), incremental=True)
+    fake_parser.processed_files.clear()
+
+    first_doc.write_text("alpha changed", encoding="utf-8")
+    dry_run_result = batch_parser.process_batch(
+        [str(docs_dir)],
+        str(output_dir),
+        incremental=True,
+        dry_run=True,
+    )
+
+    assert dry_run_result.dry_run is True
+    assert dry_run_result.successful_files == [str(first_doc)]
+    assert dry_run_result.skipped_files == [str(second_doc)]
+    assert fake_parser.processed_files == []


### PR DESCRIPTION
## Summary
- add opt-in incremental mode for batch folder processing
- store a per-output-dir manifest keyed by resolved file path with size, mtime, and MD5
- skip unchanged files on later runs while reporting skipped files in BatchProcessingResult
- expose incremental=True through RAGAnything batch APIs and add --incremental to the CLI
- document incremental folder scans and add regression tests

Fixes #156.

## Verification
- python -m pytest tests/testbatch_incremental.py -q
- python -m py_compile raganything/batch_parser.py raganything/batch.py tests/testbatch_incremental.py
- python -m black raganything/batch_parser.py raganything/batch.py tests/testbatch_incremental.py
- git diff --check