### PR TITLE
fix: preserve LightRAG runtime global config

### DIFF
--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -392,7 +392,11 @@ class BaseModalProcessor:
         # Use LightRAG's configuration and functions
         self.embedding_func = lightrag.embedding_func
         self.llm_model_func = lightrag.llm_model_func
-        self.global_config = asdict(lightrag)
+        build_global_config = getattr(lightrag, "_build_global_config", None)
+        if callable(build_global_config):
+            self.global_config = build_global_config()
+        else:
+            self.global_config = asdict(lightrag)
         self.hashing_kv = lightrag.llm_response_cache
         self.tokenizer = lightrag.tokenizer
 

--- a/tests/test_modalprocessors_config.py
+++ b/tests/test_modalprocessors_config.py
@@ -1,0 +1,106 @@
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+@dataclass
+class FakeLightRAG:
+    text_chunks: object = None
+    chunks_vdb: object = None
+    entities_vdb: object = None
+    relationships_vdb: object = None
+    chunk_entity_relation_graph: object = None
+    embedding_func: object = None
+    llm_model_func: object = None
+    llm_response_cache: object = None
+    tokenizer: object = None
+    working_dir: str = "workdir"
+
+    def __post_init__(self):
+        self.role_llm_funcs = {"default": object()}
+
+    def _build_global_config(self):
+        return {
+            "working_dir": self.working_dir,
+            "role_llm_funcs": self.role_llm_funcs,
+        }
+
+
+def _import_modalprocessors_with_lightrag_stubs(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+
+    raganything_package = types.ModuleType("raganything")
+    raganything_package.__path__ = [str(repo_root / "raganything")]
+
+    lightrag_package = types.ModuleType("lightrag")
+
+    utils_module = types.ModuleType("lightrag.utils")
+    utils_module.logger = FakeLogger()
+    utils_module.compute_mdhash_id = lambda value, prefix="": f"{prefix}hash"
+
+    lightrag_module = types.ModuleType("lightrag.lightrag")
+    lightrag_module.LightRAG = FakeLightRAG
+
+    kg_package = types.ModuleType("lightrag.kg")
+    shared_storage_module = types.ModuleType("lightrag.kg.shared_storage")
+    shared_storage_module.get_namespace_data = lambda *args, **kwargs: {}
+    shared_storage_module.get_pipeline_status_lock = lambda *args, **kwargs: None
+
+    operate_module = types.ModuleType("lightrag.operate")
+    operate_module.extract_entities = None
+    operate_module.merge_nodes_and_edges = None
+
+    for module_name in [
+        "raganything",
+        "raganything.prompt",
+        "raganything.utils",
+        "raganything.modalprocessors",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    monkeypatch.setitem(sys.modules, "raganything", raganything_package)
+    monkeypatch.setitem(sys.modules, "lightrag", lightrag_package)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "lightrag.lightrag", lightrag_module)
+    monkeypatch.setitem(sys.modules, "lightrag.kg", kg_package)
+    monkeypatch.setitem(sys.modules, "lightrag.kg.shared_storage", shared_storage_module)
+    monkeypatch.setitem(sys.modules, "lightrag.operate", operate_module)
+
+    return importlib.import_module("raganything.modalprocessors")
+
+
+def test_base_modal_processor_uses_lightrag_runtime_global_config(monkeypatch):
+    try:
+        modalprocessors = _import_modalprocessors_with_lightrag_stubs(monkeypatch)
+        lightrag = FakeLightRAG()
+
+        processor = modalprocessors.BaseModalProcessor(
+            lightrag=lightrag,
+            modal_caption_func=lambda *args, **kwargs: "",
+        )
+
+        assert processor.global_config["working_dir"] == "workdir"
+        assert processor.global_config["role_llm_funcs"] is lightrag.role_llm_funcs
+    finally:
+        for module_name in [
+            "raganything.prompt",
+            "raganything.utils",
+            "raganything.modalprocessors",
+        ]:
+            sys.modules.pop(module_name, None)

--- a/tests/test_modalprocessors_config.py
+++ b/tests/test_modalprocessors_config.py
@@ -79,7 +79,9 @@ def _import_modalprocessors_with_lightrag_stubs(monkeypatch):
     monkeypatch.setitem(sys.modules, "lightrag.utils", utils_module)
     monkeypatch.setitem(sys.modules, "lightrag.lightrag", lightrag_module)
     monkeypatch.setitem(sys.modules, "lightrag.kg", kg_package)
-    monkeypatch.setitem(sys.modules, "lightrag.kg.shared_storage", shared_storage_module)
+    monkeypatch.setitem(
+        sys.modules, "lightrag.kg.shared_storage", shared_storage_module
+    )
     monkeypatch.setitem(sys.modules, "lightrag.operate", operate_module)
 
     return importlib.import_module("raganything.modalprocessors")


### PR DESCRIPTION
 ## Summary                                                                                                                  
                                                                                                                              
  - Use LightRAG's runtime global config builder for modal processors when available.                                         
  - Preserve dynamically injected config keys such as `role_llm_funcs` during multimodal extraction.                          
  - Keep the existing `asdict(lightrag)` behavior as a fallback for older LightRAG versions.                                  
  - Fixes #297.                                                                                                               
                                                                                                                              
  ## Validation                                                                                                               
                                                                                                                              
  - `python -m pytest tests/test_modalprocessors_config.py -q`                                                                
    - Failed before the fix with `KeyError: 'role_llm_funcs'`.                                                                
    - Passed after the fix: `1 passed`.                                                                                       
                                                                                                                              
  - `python -m pytest tests/test_modalprocessors_config.py tests/test_full_entities_merge.py -q`                              
    - Passed: `5 passed`.                                                                                                     
                                                                                                                              
  - `python -m py_compile raganything/modalprocessors.py tests/test_modalprocessors_config.py`                                
    - Passed.                                                                                                                 
                                                                                                                              
  - `git diff --check HEAD~1..HEAD`                                                                                           
    - Passed.                                                                                                                 
                                                                                                                              
  - Installed full `.[all]` dependencies plus test/dev tools in an isolated environment.                                      
                                                                                                                              
  - `python -m pytest tests -q --basetemp <ascii-temp-dir>`                                                                   
    - Passed: `247 passed