### PR TITLE
fix(batch): apply timeout to each file

### DIFF
--- a/raganything/batch_parser.py
+++ b/raganything/batch_parser.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import tempfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -464,11 +464,23 @@ class BatchParser:
                     for file_path in files_to_process
                 }
 
-                # Process completed tasks
-                for future in as_completed(
-                    future_to_file, timeout=self.timeout_per_file
-                ):
-                    success, file_path, error_msg = future.result()
+                # Wait up to timeout_per_file for each submitted file. Passing
+                # the timeout to as_completed() would incorrectly apply it to
+                # the whole batch instead of each individual parse.
+                for future, submitted_file in future_to_file.items():
+                    try:
+                        success, file_path, error_msg = future.result(
+                            timeout=self.timeout_per_file
+                        )
+                    except TimeoutError:
+                        # cancel() only prevents a not-yet-started task from
+                        # running; a parse already in progress keeps running in
+                        # its worker thread. We still record the file as failed
+                        # and move on so one slow file cannot stall the batch.
+                        future.cancel()
+                        success = False
+                        file_path = submitted_file
+                        error_msg = f"Processing timed out after {self.timeout_per_file} seconds"
 
                     if success:
                         successful_files.append(file_path)

--- a/tests/testbatch_incremental.py
+++ b/tests/testbatch_incremental.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+import time
 import types
 from pathlib import Path
 
@@ -232,3 +233,25 @@ def test_filter_supported_files_deduplicates_overlapping_inputs(monkeypatch, tmp
     # docs_dir (listed twice) overlaps with first_doc; dedup keeps each file
     # exactly once. Compare sorted since directory glob order is not defined.
     assert sorted(result) == sorted([str(first_doc), str(second_doc)])
+
+
+def test_timeout_is_applied_per_file_not_to_entire_batch(monkeypatch, tmp_path):
+    batch_parser, fake_parser = _make_batch_parser(monkeypatch)
+    docs_dir, first_doc, second_doc = _seed_two_docs(tmp_path)
+    batch_parser.timeout_per_file = 0.1
+
+    original_parse = fake_parser.parse_document
+
+    def slow_parse(*args, **kwargs):
+        time.sleep(0.06)
+        return original_parse(*args, **kwargs)
+
+    fake_parser.parse_document = slow_parse
+
+    result = batch_parser.process_batch([str(docs_dir)], str(tmp_path / "out"))
+
+    # Both files finish under the per-file timeout, so both succeed. The old
+    # as_completed(timeout=...) applied the timeout to the whole batch and would
+    # have failed here. Compare sorted since glob order is not defined.
+    assert sorted(result.successful_files) == sorted([str(first_doc), str(second_doc)])
+    assert result.failed_files == []


### PR DESCRIPTION
## Summary
- apply timeout_per_file to each parsing future instead of the entire batch iterator
- report a timeout only for the affected file
- retain completed results from other files

## Tests
- added a regression test where total batch duration exceeds the per-file timeout while each file remains within it
- full suite: 258 passed, 1 skipped