### PR TITLE
Validate image files before base64 encoding

### DIFF
--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -237,6 +237,8 @@ def encode_image_to_base64(image_path: str) -> str:
         str: Base64 encoded string, empty string if encoding fails
     """
     try:
+        if not validate_image_file(image_path):
+            return ""
         with open(image_path, "rb") as image_file:
             encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
         return encoded_string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import base64
+
+from raganything.utils import encode_image_to_base64
+
+
+def test_encode_image_to_base64_rejects_non_image_extension(tmp_path):
+    path = tmp_path / "payload.txt"
+    path.write_bytes(b"not an image")
+
+    assert encode_image_to_base64(str(path)) == ""
+
+
+def test_encode_image_to_base64_accepts_valid_image_extension(tmp_path):
+    path = tmp_path / "pixel.png"
+    path.write_bytes(b"png bytes")
+
+    assert encode_image_to_base64(str(path)) == base64.b64encode(b"png bytes").decode("utf-8")


### PR DESCRIPTION
## Summary
- reuse image validation before reading files for base64 encoding
- return an empty string for non-image paths instead of encoding arbitrary files
- add regression tests for accepted and rejected paths

## Validation
- python -m py_compile raganything/utils.py tests/test_utils.py
- full pytest not run locally because lightrag is not installed in this Python 3.14 environment