### PR TITLE
fix(parser): escape markdown text before ReportLab Paragraph

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -516,7 +516,7 @@ class Parser:
 
                 # Handle markdown or plain text
                 if text_path.suffix.lower() == ".md":
-                    # Handle markdown content - simplified implementation
+                    # ReportLab Paragraph requires escaped markup; reuse inline helper.
                     lines = text_content.split("\n")
                     for line in lines:
                         line = line.strip()
@@ -536,10 +536,19 @@ class Parser:
                                     spaceAfter=8,
                                     spaceBefore=16 if level <= 2 else 12,
                                 )
-                                story.append(Paragraph(header_text, header_style))
+                                story.append(
+                                    Paragraph(
+                                        cls._process_inline_markdown(header_text),
+                                        header_style,
+                                    )
+                                )
                         else:
                             # Regular text
-                            story.append(Paragraph(line, normal_style))
+                            story.append(
+                                Paragraph(
+                                    cls._process_inline_markdown(line), normal_style
+                                )
+                            )
                             story.append(Spacer(1, 6))
                 else:
                     # Handle plain text files (.txt)
@@ -640,7 +649,7 @@ class Parser:
         # Links: [text](url) - convert to text with URL annotation
         def link_replacer(match):
             link_text = match.group(1)
-            url = match.group(2)
+            url = match.group(2).replace('"', "&quot;")
             return f'<link href="{url}" color="blue"><u>{link_text}</u></link>'
 
         text = re.sub(r"\[([^\]]+?)\]\(([^)]+?)\)", link_replacer, text)

--- a/tests/test_md_pdf_escape.py
+++ b/tests/test_md_pdf_escape.py
@@ -1,0 +1,40 @@
+"""Markdown text-to-PDF must escape ReportLab markup like the .txt path does."""
+
+import pytest
+
+from test_parser_url_download import Parser
+
+
+pytest.importorskip("reportlab")
+
+
+def test_convert_text_to_pdf_escapes_angle_brackets_in_markdown(tmp_path):
+    md_path = tmp_path / "cmp.md"
+    md_path.write_text(
+        "Use filter when score <threshold.\n\n# Tom & Jerry\n",
+        encoding="utf-8",
+    )
+
+    pdf_path = Parser.convert_text_to_pdf(md_path, output_dir=str(tmp_path / "out"))
+
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size > 100
+
+
+def test_convert_text_to_pdf_plain_text_still_escapes(tmp_path):
+    txt_path = tmp_path / "cmp.txt"
+    txt_path.write_text("Use filter when score <threshold.\n", encoding="utf-8")
+
+    pdf_path = Parser.convert_text_to_pdf(txt_path, output_dir=str(tmp_path / "out2"))
+
+    assert pdf_path.exists()
+    assert pdf_path.stat().st_size > 100
+
+
+def test_process_inline_markdown_escapes_bare_angle_bracket():
+    assert "&lt;threshold" in Parser._process_inline_markdown("score <threshold")
+
+
+def test_process_inline_markdown_escapes_quotes_in_link_href():
+    out = Parser._process_inline_markdown('see [x](http://ex.com/a"b) here')
+    assert 'href="http://ex.com/a&quot;b"' in out


### PR DESCRIPTION
convert_text_to_pdf crashed on valid markdown lines with bare angle brackets such as "score <threshold", because the .md path skipped the escaping already used for .txt.

Route markdown lines through the same inline markdown processing and escape quotes in link hrefs.