### PR TITLE
fix(parser): composite LA images with alpha onto white

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -756,6 +756,25 @@ class MineruParser(Parser):
         super().__init__()
 
     @classmethod
+    def _prepare_image_for_mineru(cls, img: "Image.Image") -> "Image.Image":
+        """Normalize image modes before writing PNG for MinerU.
+
+        RGBA/LA/P are composited onto white using the alpha channel. LA must be
+        converted to RGBA first; pasting LA without a mask drops transparency.
+        """
+        from PIL import Image
+
+        if img.mode in ("RGBA", "LA", "P"):
+            if img.mode in ("P", "LA"):
+                img = img.convert("RGBA")
+            background = Image.new("RGB", img.size, (255, 255, 255))
+            background.paste(img, mask=img.split()[-1])
+            return background
+        if img.mode not in ("RGB", "L"):
+            return img.convert("RGB")
+        return img
+
+    @classmethod
     def _is_mineru_unsafe_windows_path(cls, path: Union[str, Path]) -> bool:
         if not _IS_WINDOWS:
             return False
@@ -1348,24 +1367,7 @@ class MineruParser(Parser):
                 try:
                     # Open and convert image
                     with Image.open(image_path) as img:
-                        # Handle different image modes
-                        if img.mode in ("RGBA", "LA", "P"):
-                            # For images with transparency or palette, convert to RGB first
-                            if img.mode == "P":
-                                img = img.convert("RGBA")
-
-                            # Create white background for transparent images
-                            background = Image.new("RGB", img.size, (255, 255, 255))
-                            if img.mode == "RGBA":
-                                background.paste(
-                                    img, mask=img.split()[-1]
-                                )  # Use alpha channel as mask
-                            else:
-                                background.paste(img)
-                            img = background
-                        elif img.mode not in ("RGB", "L"):
-                            # Convert other modes to RGB
-                            img = img.convert("RGB")
+                        img = self._prepare_image_for_mineru(img)
 
                         # Save as PNG
                         img.save(temp_converted_file, "PNG", optimize=True)

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -40,6 +40,7 @@ import urllib.request
 import shutil
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Dict,
     List,
     Optional,
@@ -48,6 +49,9 @@ from typing import (
     Any,
     Iterator,
 )
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 from raganything.asset_urls import attach_public_media_urls
 

--- a/tests/test_image_la_alpha_composite.py
+++ b/tests/test_image_la_alpha_composite.py
@@ -1,0 +1,40 @@
+"""LA (greyscale+alpha) images must composite onto white using the alpha mask."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+
+def _load_mineru_parser_class():
+    module_path = Path(__file__).resolve().parents[1] / "raganything" / "parser.py"
+    spec = importlib.util.spec_from_file_location("_raganything_parser_la", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.MineruParser
+
+
+MineruParser = _load_mineru_parser_class()
+
+
+def test_la_semi_transparent_black_composites_to_gray():
+    img = Image.new("LA", (1, 1), (0, 128))
+    composited = MineruParser._prepare_image_for_mineru(img)
+    assert composited.mode == "RGB"
+    assert composited.getpixel((0, 0)) == (127, 127, 127)
+
+
+def test_rgba_semi_transparent_black_still_composites_to_gray():
+    img = Image.new("RGBA", (1, 1), (0, 0, 0, 128))
+    composited = MineruParser._prepare_image_for_mineru(img)
+    assert composited.getpixel((0, 0)) == (127, 127, 127)
+
+
+def test_opaque_rgb_passthrough():
+    img = Image.new("RGB", (1, 1), (10, 20, 30))
+    out = MineruParser._prepare_image_for_mineru(img)
+    assert out.getpixel((0, 0)) == (10, 20, 30)


### PR DESCRIPTION
Greyscale+alpha (LA) images converted for MinerU were pasted without an alpha mask, so semi-transparent pixels became fully opaque.

Convert LA to RGBA first and always mask when flattening onto white.