### PR TITLE
feat(processor): add opt-in force_multimodal_reprocess flag (fixes #154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,39 @@ This method is particularly useful when:
 - You need to insert content from multiple sources into a single knowledge base
 - You have cached parsing results that you want to reuse
 
+#### 8. Re-processing Multimodal Content After a Storage Backend Change
+
+By default, `process_document_complete` and `insert_content_list` skip multimodal
+(image/table/equation) processing for a document that is already marked as fully
+processed, to avoid redundant LLM calls. If you switch to a **new** graph/vector
+storage backend (e.g. migrating from the default file-based storage to Neo4j),
+the new backend will not yet contain the multimodal entities/relations that were
+written to the old one — see [#154](https://github.com/HKUDS/RAG-Anything/issues/154).
+
+Pass `force_multimodal_reprocess=True` to explicitly re-run multimodal processing
+and re-populate the current storage backend for an already-processed document:
+
+```python
+# Re-run multimodal processing so the current storage backend has the
+# image/table/equation entities and relations (default is False, i.e. no change
+# to existing behavior for documents that have not switched backends)
+await rag.process_document_complete(
+    file_path="path/to/your/document.pdf",
+    doc_id="doc-already-processed-id",
+    force_multimodal_reprocess=True,
+)
+
+# Same flag is available for direct content list insertion
+await rag.insert_content_list(
+    content_list=content_list,
+    doc_id="doc-already-processed-id",
+    force_multimodal_reprocess=True,
+)
+```
+
+This flag only affects multimodal content; it is opt-in and defaults to `False`,
+so existing behavior is unchanged unless you explicitly set it.
+
 ---
 
 ## 🛠️ Examples

--- a/README_zh.md
+++ b/README_zh.md
@@ -974,6 +974,31 @@ if __name__ == "__main__":
 - 您需要将来自多个源的内容插入到单个知识库中
 - 您有想要重用的缓存解析结果
 
+#### 8. 切换存储后端后重新处理多模态内容
+
+默认情况下，`process_document_complete` 和 `insert_content_list` 会跳过已标记为"完全处理完成"文档的多模态（图像/表格/公式）处理，以避免重复的 LLM 调用。如果您切换到了**新的**图/向量存储后端（例如从默认的文件存储迁移到 Neo4j），新后端中还不会包含之前写入旧后端的多模态实体/关系——详见 [#154](https://github.com/HKUDS/RAG-Anything/issues/154)。
+
+传入 `force_multimodal_reprocess=True` 可以显式地重新运行多模态处理，将数据重新写入当前存储后端：
+
+```python
+# 重新运行多模态处理，让当前存储后端拥有图像/表格/公式的实体和关系
+# （默认值为 False，即对尚未切换后端的文档不改变原有行为）
+await rag.process_document_complete(
+    file_path="path/to/your/document.pdf",
+    doc_id="doc-already-processed-id",
+    force_multimodal_reprocess=True,
+)
+
+# insert_content_list 也支持相同的参数
+await rag.insert_content_list(
+    content_list=content_list,
+    doc_id="doc-already-processed-id",
+    force_multimodal_reprocess=True,
+)
+```
+
+该参数只影响多模态内容处理，是纯可选（opt-in）参数，默认值为 `False`，因此不会改变任何现有行为，除非您显式设置它。
+
 ---
 
 ## 🛠️ 示例

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -613,6 +613,7 @@ class ProcessorMixin:
         doc_id: str,
         pipeline_status: Optional[Any] = None,
         pipeline_status_lock: Optional[Any] = None,
+        force_reprocess: bool = False,
     ):
         """
         Process multimodal content (using specialized processors)
@@ -623,6 +624,13 @@ class ProcessorMixin:
             doc_id: Document ID for proper chunk association
             pipeline_status: Pipeline status object
             pipeline_status_lock: Pipeline status lock
+            force_reprocess: If True, bypass the "already processed" short-circuit
+                and re-run multimodal processing even if doc_status/compatibility
+                cache report it as complete. Defaults to False, which preserves
+                the original skip-if-already-processed behavior. Useful when the
+                underlying graph/vector storage backend was swapped (see
+                https://github.com/HKUDS/RAG-Anything/issues/154) and multimodal
+                entities/relations need to be re-written into the new backend.
         """
 
         if not multimodal_items:
@@ -648,37 +656,43 @@ class ProcessorMixin:
             return
 
         # Check multimodal processing status - handle LightRAG's early DocStatus.PROCESSED marking
-        try:
-            existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
-            if existing_doc_status:
-                # Check if multimodal content is already processed
-                multimodal_processed = await self._get_multimodal_processed_flag(
-                    doc_id, existing_doc_status
-                )
-
-                if multimodal_processed:
-                    self.logger.info(
-                        f"Document {doc_id} multimodal content is already processed"
+        # (skipped entirely when force_reprocess=True, e.g. after switching storage backends)
+        if force_reprocess:
+            self.logger.info(
+                f"force_reprocess=True: bypassing already-processed check for document {doc_id}"
+            )
+        else:
+            try:
+                existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
+                if existing_doc_status:
+                    # Check if multimodal content is already processed
+                    multimodal_processed = await self._get_multimodal_processed_flag(
+                        doc_id, existing_doc_status
                     )
-                    return
 
-                # Even if status is DocStatus.PROCESSED (text processing done),
-                # we still need to process multimodal content if not yet done
-                doc_status = existing_doc_status.get("status", "")
-                if doc_status == DocStatus.PROCESSED and not multimodal_processed:
-                    self.logger.info(
-                        f"Document {doc_id} text processing is complete, but multimodal content still needs processing"
-                    )
-                    # Continue with multimodal processing
-                elif doc_status == DocStatus.PROCESSED and multimodal_processed:
-                    self.logger.info(
-                        f"Document {doc_id} is fully processed (text + multimodal)"
-                    )
-                    return
+                    if multimodal_processed:
+                        self.logger.info(
+                            f"Document {doc_id} multimodal content is already processed"
+                        )
+                        return
 
-        except Exception as e:
-            self.logger.debug(f"Error checking document status for {doc_id}: {e}")
-            # Continue with processing if cache check fails
+                    # Even if status is DocStatus.PROCESSED (text processing done),
+                    # we still need to process multimodal content if not yet done
+                    doc_status = existing_doc_status.get("status", "")
+                    if doc_status == DocStatus.PROCESSED and not multimodal_processed:
+                        self.logger.info(
+                            f"Document {doc_id} text processing is complete, but multimodal content still needs processing"
+                        )
+                        # Continue with multimodal processing
+                    elif doc_status == DocStatus.PROCESSED and multimodal_processed:
+                        self.logger.info(
+                            f"Document {doc_id} is fully processed (text + multimodal)"
+                        )
+                        return
+
+            except Exception as e:
+                self.logger.debug(f"Error checking document status for {doc_id}: {e}")
+                # Continue with processing if cache check fails
 
         # Use ProcessorMixin's own batch processing that can handle multiple content types
         log_message = "Starting multimodal content processing..."
@@ -811,13 +825,17 @@ class ProcessorMixin:
 
                 if current_doc_status:
                     existing_chunks_list = current_doc_status.get("chunks_list", [])
-                    existing_chunks_count = current_doc_status.get("chunks_count", 0)
+                    existing_ids = set(existing_chunks_list)
 
-                    # Add multimodal chunks to the standard chunks_list
-                    updated_chunks_list = existing_chunks_list + multimodal_chunk_ids
-                    updated_chunks_count = existing_chunks_count + len(
-                        multimodal_chunk_ids
-                    )
+                    # Add multimodal chunks to the standard chunks_list, skipping any
+                    # chunk IDs already present (e.g. when force-reprocessing a
+                    # previously completed document, chunk IDs are deterministic
+                    # and would otherwise be duplicated)
+                    new_chunk_ids = [
+                        cid for cid in multimodal_chunk_ids if cid not in existing_ids
+                    ]
+                    updated_chunks_list = existing_chunks_list + new_chunk_ids
+                    updated_chunks_count = len(updated_chunks_list)
 
                     # Update document status with integrated chunk list
                     await self.lightrag.doc_status.upsert(
@@ -835,7 +853,7 @@ class ProcessorMixin:
                     await self.lightrag.doc_status.index_done_callback()
 
                     self.logger.info(
-                        f"Updated doc_status with {len(multimodal_chunk_ids)} multimodal chunks integrated into chunks_list"
+                        f"Updated doc_status with {len(new_chunk_ids)} multimodal chunks integrated into chunks_list"
                     )
 
             except Exception as e:
@@ -1505,11 +1523,15 @@ class ProcessorMixin:
 
             if current_doc_status:
                 existing_chunks_list = current_doc_status.get("chunks_list", [])
-                existing_chunks_count = current_doc_status.get("chunks_count", 0)
+                existing_ids = set(existing_chunks_list)
 
-                # Add multimodal chunks to the standard chunks_list
-                updated_chunks_list = existing_chunks_list + chunk_ids
-                updated_chunks_count = existing_chunks_count + len(chunk_ids)
+                # Add multimodal chunks to the standard chunks_list, skipping any
+                # chunk IDs already present (e.g. when force-reprocessing a
+                # previously completed document, chunk IDs are deterministic
+                # and would otherwise be duplicated)
+                new_chunk_ids = [cid for cid in chunk_ids if cid not in existing_ids]
+                updated_chunks_list = existing_chunks_list + new_chunk_ids
+                updated_chunks_count = len(updated_chunks_list)
 
                 # Update document status with integrated chunk list
                 await self.lightrag.doc_status.upsert(
@@ -1527,7 +1549,7 @@ class ProcessorMixin:
                 await self.lightrag.doc_status.index_done_callback()
 
                 self.logger.info(
-                    f"Updated doc_status: added {len(chunk_ids)} multimodal chunks to standard chunks_list "
+                    f"Updated doc_status: added {len(new_chunk_ids)} multimodal chunks to standard chunks_list "
                     f"(total chunks: {updated_chunks_count})"
                 )
 
@@ -1667,6 +1689,7 @@ class ProcessorMixin:
         split_by_character_only: bool = False,
         doc_id: str | None = None,
         file_name: str | None = None,
+        force_multimodal_reprocess: bool = False,
         **kwargs,
     ):
         """
@@ -1680,6 +1703,14 @@ class ProcessorMixin:
             split_by_character: Optional character to split the text by
             split_by_character_only: If True, split only by the specified character
             doc_id: Optional document ID, if not provided will be generated from content
+            force_multimodal_reprocess: If True, re-run multimodal (image/table/equation)
+                processing even if this document was already marked as fully
+                processed. Defaults to False (original behavior: already-processed
+                documents are skipped). This is useful after switching to a new
+                graph/vector storage backend, since a fresh backend will not yet
+                contain the multimodal entities/relations that were written to the
+                previous one (see https://github.com/HKUDS/RAG-Anything/issues/154).
+                Text content is unaffected by this flag.
             **kwargs: Additional parameters for parser (e.g., lang, device, start_page, end_page, formula, table, backend, source)
         """
         callback_manager = getattr(self, "callback_manager", None)
@@ -1779,7 +1810,10 @@ class ProcessorMixin:
             stage = "multimodal"
             if multimodal_items:
                 await self._process_multimodal_content(
-                    multimodal_items, file_name, doc_id
+                    multimodal_items,
+                    file_name,
+                    doc_id,
+                    force_reprocess=force_multimodal_reprocess,
                 )
             else:
                 # If no multimodal content, mark multimodal processing as complete
@@ -2109,6 +2143,7 @@ class ProcessorMixin:
         split_by_character_only: bool = False,
         doc_id: str | None = None,
         display_stats: bool = None,
+        force_multimodal_reprocess: bool = False,
     ):
         """
         Insert content list directly without document parsing
@@ -2129,6 +2164,14 @@ class ProcessorMixin:
             split_by_character_only: If True, split only by the specified character
             doc_id: Optional document ID, if not provided will be generated from content
             display_stats: Whether to display content statistics (defaults to config.display_content_stats)
+            force_multimodal_reprocess: If True, re-run multimodal (image/table/equation)
+                processing even if this document was already marked as fully
+                processed. Defaults to False (original behavior: already-processed
+                documents are skipped). This is useful after switching to a new
+                graph/vector storage backend, since a fresh backend will not yet
+                contain the multimodal entities/relations that were written to the
+                previous one (see https://github.com/HKUDS/RAG-Anything/issues/154).
+                Text content is unaffected by this flag.
 
         Note:
             - img_path must be an absolute path to the image file
@@ -2238,7 +2281,12 @@ class ProcessorMixin:
 
         # Step 3: Process multimodal content (using specialized processors)
         if multimodal_items:
-            await self._process_multimodal_content(multimodal_items, file_ref, doc_id)
+            await self._process_multimodal_content(
+                multimodal_items,
+                file_ref,
+                doc_id,
+                force_reprocess=force_multimodal_reprocess,
+            )
         else:
             # If no multimodal content, mark multimodal processing as complete
             # This ensures the document status properly reflects completion of all processing

--- a/tests/test_doc_status_creation.py
+++ b/tests/test_doc_status_creation.py
@@ -260,7 +260,9 @@ async def test_image_only_document_falls_back_when_multimodal_flag_is_unsupporte
             "doc-image",
         )
 
-    async def fake_process_multimodal_content(multimodal_items, file_name, doc_id):
+    async def fake_process_multimodal_content(
+        multimodal_items, file_name, doc_id, **kwargs
+    ):
         await processor._mark_multimodal_processing_complete(doc_id)
 
     processor._ensure_lightrag_initialized = fake_ensure_lightrag_initialized

--- a/tests/test_force_multimodal_reprocess.py
+++ b/tests/test_force_multimodal_reprocess.py
@@ -1,0 +1,358 @@
+"""Tests for the opt-in force_multimodal_reprocess feature.
+
+This flag lets callers explicitly re-run multimodal (image/table/equation)
+processing for a document that was already marked complete, which is useful
+after swapping the underlying graph/vector storage backend (see
+https://github.com/HKUDS/RAG-Anything/issues/154). It defaults to False, so
+existing callers see no behavior change.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class InMemoryJsonStorage:
+    def __init__(self, records=None):
+        self.records = records or {}
+
+    async def get_by_id(self, key):
+        return self.records.get(key)
+
+    async def upsert(self, data):
+        for key, value in data.items():
+            self.records[key] = value
+
+    async def index_done_callback(self):
+        return None
+
+
+def _load_raganything_module(module_name: str, relative_path: str):
+    module_path = PROJECT_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def raganything_modules(monkeypatch):
+    logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+
+    fake_lightrag = types.ModuleType("lightrag")
+    fake_lightrag_utils = types.ModuleType("lightrag.utils")
+    fake_lightrag_utils.logger = logger
+    fake_lightrag_utils.compute_mdhash_id = lambda value, prefix="": (
+        f"{prefix}{abs(hash(value))}"
+    )
+
+    monkeypatch.setitem(sys.modules, "lightrag", fake_lightrag)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", fake_lightrag_utils)
+
+    rag_pkg = types.ModuleType("raganything")
+    rag_pkg.__path__ = [str(PROJECT_ROOT / "raganything")]
+    monkeypatch.setitem(sys.modules, "raganything", rag_pkg)
+
+    base_module = _load_raganything_module("raganything.base", "raganything/base.py")
+    _load_raganything_module("raganything.parser", "raganything/parser.py")
+    utils_module = _load_raganything_module("raganything.utils", "raganything/utils.py")
+    processor_module = _load_raganything_module(
+        "raganything.processor", "raganything/processor.py"
+    )
+
+    return types.SimpleNamespace(
+        base=base_module,
+        utils=utils_module,
+        processor=processor_module,
+    )
+
+
+def _make_processor(processor_module, doc_status_records):
+    class FakeDocStatusStorage:
+        def __init__(self, records):
+            self.records = records
+
+        async def get_by_id(self, key):
+            return self.records.get(key)
+
+        async def upsert(self, data):
+            for key, value in data.items():
+                self.records[key] = value
+
+        async def index_done_callback(self):
+            return None
+
+    class FakeLightRAG:
+        def __init__(self, records):
+            self.doc_status = FakeDocStatusStorage(records)
+
+    class DummyProcessor(processor_module.ProcessorMixin):
+        pass
+
+    processor = DummyProcessor()
+    processor.lightrag = FakeLightRAG(doc_status_records)
+    processor.multimodal_status_cache = InMemoryJsonStorage()
+    processor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+    processor.callback_manager = None
+
+    async def fake_ensure_lightrag_initialized():
+        return {"success": True}
+
+    processor._ensure_lightrag_initialized = fake_ensure_lightrag_initialized
+    return processor
+
+
+@pytest.mark.asyncio
+async def test_default_behavior_still_skips_already_processed_document(
+    raganything_modules,
+):
+    """Regression guard: without the new flag, nothing changes."""
+    processor_module = raganything_modules.processor
+    DocStatus = raganything_modules.base.DocStatus
+
+    processor = _make_processor(
+        processor_module,
+        {
+            "doc-image": {
+                "status": DocStatus.PROCESSED,
+                "multimodal_processed": True,
+                "file_path": "figure.png",
+            }
+        },
+    )
+
+    called = {"batch": 0}
+
+    async def fake_batch_type_aware(*args, **kwargs):
+        called["batch"] += 1
+
+    processor._process_multimodal_content_batch_type_aware = fake_batch_type_aware
+
+    await processor._process_multimodal_content(
+        [{"type": "image", "img_path": "figure.png"}],
+        "figure.png",
+        "doc-image",
+    )
+
+    assert called["batch"] == 0
+
+
+@pytest.mark.asyncio
+async def test_force_reprocess_bypasses_already_processed_check(raganything_modules):
+    processor_module = raganything_modules.processor
+    DocStatus = raganything_modules.base.DocStatus
+
+    processor = _make_processor(
+        processor_module,
+        {
+            "doc-image": {
+                "status": DocStatus.PROCESSED,
+                "multimodal_processed": True,
+                "file_path": "figure.png",
+            }
+        },
+    )
+
+    called = {"batch": 0}
+
+    async def fake_batch_type_aware(*args, **kwargs):
+        called["batch"] += 1
+
+    processor._process_multimodal_content_batch_type_aware = fake_batch_type_aware
+
+    await processor._process_multimodal_content(
+        [{"type": "image", "img_path": "figure.png"}],
+        "figure.png",
+        "doc-image",
+        force_reprocess=True,
+    )
+
+    assert called["batch"] == 1
+    # Reprocessing still (re)marks the document as complete.
+    assert processor.lightrag.doc_status.records["doc-image"]["multimodal_processed"]
+
+
+@pytest.mark.asyncio
+async def test_process_document_complete_forwards_force_flag(
+    raganything_modules, tmp_path
+):
+    processor_module = raganything_modules.processor
+
+    processor = _make_processor(processor_module, {})
+    processor.config = types.SimpleNamespace(
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+        content_format="default",
+    )
+
+    async def fake_parse_document(
+        file_path, output_dir, parse_method, display_stats, **kwargs
+    ):
+        return (
+            [
+                {
+                    "type": "image",
+                    "img_path": str(tmp_path / "figure.png"),
+                    "page_idx": 0,
+                }
+            ],
+            "doc-image",
+        )
+
+    seen_kwargs = {}
+
+    async def fake_process_multimodal_content(
+        multimodal_items, file_name, doc_id, **kwargs
+    ):
+        seen_kwargs.update(kwargs)
+
+    processor.parse_document = fake_parse_document
+    processor._process_multimodal_content = fake_process_multimodal_content
+
+    await processor.process_document_complete(
+        file_path=str(tmp_path / "figure.png"),
+        doc_id="doc-image",
+        file_name="figure.png",
+        force_multimodal_reprocess=True,
+    )
+
+    assert seen_kwargs == {"force_reprocess": True}
+
+
+@pytest.mark.asyncio
+async def test_process_document_complete_defaults_force_flag_to_false(
+    raganything_modules, tmp_path
+):
+    processor_module = raganything_modules.processor
+
+    processor = _make_processor(processor_module, {})
+    processor.config = types.SimpleNamespace(
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+        content_format="default",
+    )
+
+    async def fake_parse_document(
+        file_path, output_dir, parse_method, display_stats, **kwargs
+    ):
+        return (
+            [
+                {
+                    "type": "image",
+                    "img_path": str(tmp_path / "figure.png"),
+                    "page_idx": 0,
+                }
+            ],
+            "doc-image",
+        )
+
+    seen_kwargs = {}
+
+    async def fake_process_multimodal_content(
+        multimodal_items, file_name, doc_id, **kwargs
+    ):
+        seen_kwargs.update(kwargs)
+
+    processor.parse_document = fake_parse_document
+    processor._process_multimodal_content = fake_process_multimodal_content
+
+    # force_multimodal_reprocess intentionally omitted here to prove the default
+    # keeps callers that predate this feature working exactly as before.
+    await processor.process_document_complete(
+        file_path=str(tmp_path / "figure.png"),
+        doc_id="doc-image",
+        file_name="figure.png",
+    )
+
+    assert seen_kwargs == {"force_reprocess": False}
+
+
+@pytest.mark.asyncio
+async def test_insert_content_list_forwards_force_flag(raganything_modules, tmp_path):
+    processor_module = raganything_modules.processor
+
+    processor = _make_processor(processor_module, {})
+    processor.config = types.SimpleNamespace(
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+        content_format="default",
+    )
+
+    seen_kwargs = {}
+
+    async def fake_process_multimodal_content(
+        multimodal_items, file_name, doc_id, **kwargs
+    ):
+        seen_kwargs.update(kwargs)
+
+    processor._process_multimodal_content = fake_process_multimodal_content
+
+    await processor.insert_content_list(
+        content_list=[
+            {
+                "type": "image",
+                "img_path": str(tmp_path / "figure.png"),
+                "page_idx": 0,
+            }
+        ],
+        file_path="figure.png",
+        doc_id="doc-image",
+        force_multimodal_reprocess=True,
+    )
+
+    assert seen_kwargs == {"force_reprocess": True}
+
+
+@pytest.mark.asyncio
+async def test_update_doc_status_with_chunks_deduplicates_ids(raganything_modules):
+    """Re-running processing for the same doc must not duplicate chunk ids
+    in chunks_list/chunks_count, since chunk ids are content-derived and
+    therefore identical across a force_reprocess run."""
+    processor_module = raganything_modules.processor
+
+    processor = _make_processor(
+        processor_module,
+        {
+            "doc-1": {
+                "chunks_list": ["chunk-a", "chunk-b"],
+                "chunks_count": 2,
+            }
+        },
+    )
+
+    # First-time-like call with a brand new chunk id: appended normally.
+    await processor._update_doc_status_with_chunks_type_aware("doc-1", ["chunk-c"])
+    record = processor.lightrag.doc_status.records["doc-1"]
+    assert record["chunks_list"] == ["chunk-a", "chunk-b", "chunk-c"]
+    assert record["chunks_count"] == 3
+
+    # Re-running with the same (deterministic) chunk ids must not duplicate them.
+    await processor._update_doc_status_with_chunks_type_aware(
+        "doc-1", ["chunk-a", "chunk-b", "chunk-c"]
+    )
+    record = processor.lightrag.doc_status.records["doc-1"]
+    assert record["chunks_list"] == ["chunk-a", "chunk-b", "chunk-c"]
+    assert record["chunks_count"] == 3

--- a/tests/test_insert_content_list.py
+++ b/tests/test_insert_content_list.py
@@ -124,7 +124,9 @@ class DummyProcessor(ProcessorMixin):
     def _generate_content_based_doc_id(self, content_list):
         return "doc-content-list"
 
-    async def _process_multimodal_content(self, multimodal_items, file_ref, doc_id):
+    async def _process_multimodal_content(
+        self, multimodal_items, file_ref, doc_id, **kwargs
+    ):
         self.events.append(("multimodal", doc_id, file_ref))
 
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `force_multimodal_reprocess: bool = False` parameter to `process_document_complete()` and `insert_content_list()` that lets callers explicitly re-run image/table/equation processing for a document already marked as fully processed.
- Fixes #154: after switching to a new graph/vector storage backend, the new backend never receives the multimodal entities/relations that were only ever written to the old one, since processing is skipped once `multimodal_processed` is true.
- Default behavior is fully preserved (flag defaults to `False`); this is purely additive.
- Also hardens `chunks_list`/`chunks_count` bookkeeping to de-duplicate chunk ids, since force-reprocessing produces the same deterministic chunk ids and would otherwise duplicate entries in the list.

## Test plan
- [x] Added `tests/test_force_multimodal_reprocess.py` covering: default behavior unchanged, force flag bypasses the skip check, flag is forwarded from both public entry points, chunk id de-duplication.
- [x] Full existing test suite passes locally (265 passed, 1 skipped, skip pre-existing and unrelated).
