### PR TITLE
fix: improve vision prompts to handle technical diagrams and schematics

### DIFF
--- a/raganything/prompt.py
+++ b/raganything/prompt.py
@@ -88,12 +88,13 @@ PROMPTS[
 
 {{
     "detailed_description": "A comprehensive and detailed visual description of the image following these guidelines:
-    - Describe the overall composition and layout
-    - Identify all objects, people, text, and visual elements
-    - Explain relationships between elements
-    - Note colors, lighting, and visual style
-    - Describe any actions or activities shown
-    - Include technical details if relevant (charts, diagrams, etc.)
+    - Describe the overall composition, layout, and structure
+    - Transcribe ALL text labels verbatim (titles, annotations, axis labels, node names, edge labels, legends, etc.)
+    - For diagrams/charts/flowcharts/UML: enumerate every node, edge, relationship type, and connection direction; preserve structural topology
+    - For photographs/illustrations: identify all objects, people, text, and visual elements; describe actions and scene
+    - Explain relationships and connections between elements
+    - Note colors, visual style, and layout patterns where relevant
+    - Include technical details if relevant (equations, measurements, data values, etc.)
     - Always use specific names instead of pronouns",
     "entity_info": {{
         "entity_name": "{entity_name}",
@@ -118,12 +119,13 @@ PROMPTS[
 
 {{
     "detailed_description": "A comprehensive and detailed visual description of the image following these guidelines:
-    - Describe the overall composition and layout
-    - Identify all objects, people, text, and visual elements
-    - Explain relationships between elements and how they relate to the surrounding context
-    - Note colors, lighting, and visual style
-    - Describe any actions or activities shown
-    - Include technical details if relevant (charts, diagrams, etc.)
+    - Describe the overall composition, layout, and structure
+    - Transcribe ALL text labels verbatim (titles, annotations, axis labels, node names, edge labels, legends, etc.)
+    - For diagrams/charts/flowcharts/UML: enumerate every node, edge, relationship type, and connection direction; preserve structural topology
+    - For photographs/illustrations: identify all objects, people, text, and visual elements; describe actions and scene
+    - Explain relationships and connections between elements and how they relate to the surrounding context
+    - Note colors, visual style, and layout patterns where relevant
+    - Include technical details if relevant (equations, measurements, data values, etc.)
     - Reference connections to the surrounding content when relevant
     - Always use specific names instead of pronouns",
     "entity_info": {{


### PR DESCRIPTION
## Problem

Fixes #313

The default vision prompts in `raganything/prompt.py` are written for natural photographs, not technical schematics. When processing UML diagrams, flowcharts, architecture diagrams, or charts, the VLM is instructed to focus on "colors, lighting, and visual style" and "actions or activities" -- guidance that is irrelevant for technical images and causes most diagram-specific information to be lost during retrieval.

## Root Cause

The `detailed_description` guidelines in both `vision_prompt` and `vision_prompt_with_context` templates contain photograph-oriented instructions:

- "Note colors, lighting, and visual style" -- meaningless for UML/flowcharts
- "Describe any actions or activities shown" -- assumes photographic content with people/agents
- "Identify all objects, people, text" -- "people" is irrelevant for diagrams
- No instruction to transcribe text labels -- the single most important information in diagrams
- No instruction to preserve relationship types or structural topology

## Solution

Updated the guidelines in both `vision_prompt` and `vision_prompt_with_context` to be image-type-agnostic:

1. **Added**: "Transcribe ALL text labels verbatim" -- ensures every node name, edge label, axis label, etc. is captured
2. **Added**: Diagram-specific instruction -- "For diagrams/charts/flowcharts/UML: enumerate every node, edge, relationship type, and connection direction; preserve structural topology"
3. **Added**: Photo-specific instruction separated -- "For photographs/illustrations: identify all objects, people, text, and visual elements"
4. **Removed**: "lighting" from style guidance (irrelevant for diagrams)
5. **Changed**: "Describe any actions or activities" moved to photo-specific section only

The JSON response structure is unchanged -- this is a pure prompt content improvement.

## Impact

- Diagrams/charts will now have their text labels, relationships, and structure properly transcribed
- Photographs continue to work with the same quality as before
- No breaking changes to the API or response format
