### PR TITLE
fix(parser): diagnose MinerU/pdftext PageChars incompatibility

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -54,15 +54,62 @@ from raganything.asset_urls import attach_public_media_urls
 _IS_WINDOWS: bool = platform.system() == "Windows"
 
 
+# Known MinerU failure signatures mapped to actionable remediation advice.
+#
+# MinerU runs as a subprocess, so a broken dependency inside its own environment
+# surfaces here only as an opaque traceback line. Each entry maps a substring of
+# MinerU's stderr to a hint explaining what the user actually has to fix.
+_MINERU_KNOWN_FAILURES: Tuple[Tuple[str, str], ...] = (
+    (
+        "'PageChars' object is not iterable",
+        "This is a MinerU/pdftext version incompatibility, not a problem with your document.\n"
+        "pdftext 0.7 changed its character-extraction API, and MinerU only handles the new\n"
+        "'PageChars' return type from version 3.4.1 onward. Fix it by upgrading MinerU:\n"
+        '    pip install -U "mineru[core]>=3.4.1"\n'
+        "or, if you must stay on an older MinerU, pin the previous pdftext release:\n"
+        '    pip install "pdftext==0.6.3"\n'
+        "Office documents (.xls, .xlsx, .doc, .docx, .ppt, .pptx) trigger this most often\n"
+        "because they are converted to text-based PDFs, which always take MinerU's pdftext\n"
+        "path. As an immediate workaround for those formats, the Docling parser reads them\n"
+        'natively without going through MinerU: RAGAnythingConfig(parser="docling").',
+    ),
+)
+
+
+def _diagnose_mineru_failure(error_msg: Any) -> Optional[str]:
+    """
+    Match MinerU's captured error output against known failure signatures.
+
+    Args:
+        error_msg: The error output collected from MinerU (a list of lines or a string)
+
+    Returns:
+        Optional[str]: Remediation advice, or None if the failure is not recognized
+    """
+    if isinstance(error_msg, (list, tuple)):
+        haystack = "\n".join(str(line) for line in error_msg)
+    else:
+        haystack = str(error_msg)
+
+    for signature, hint in _MINERU_KNOWN_FAILURES:
+        if signature in haystack:
+            return hint
+    return None
+
+
 class MineruExecutionError(Exception):
     """catch mineru error"""
 
-    def __init__(self, return_code, error_msg):
+    def __init__(self, return_code, error_msg, hint: Optional[str] = None):
         self.return_code = return_code
         self.error_msg = error_msg
-        super().__init__(
-            f"Mineru command failed with return code {return_code}: {error_msg}"
-        )
+        # Recognize known dependency/environment failures so that users get an
+        # actionable message instead of a raw MinerU traceback line.
+        self.hint = hint if hint is not None else _diagnose_mineru_failure(error_msg)
+        message = f"Mineru command failed with return code {return_code}: {error_msg}"
+        if self.hint:
+            message = f"{message}\n\n{self.hint}"
+        super().__init__(message)
 
 
 class Parser:
@@ -1054,7 +1101,10 @@ class MineruParser(Parser):
 
             if return_code != 0 or error_lines:
                 cls.logger.info("[MinerU] Command executed failed")
-                raise MineruExecutionError(return_code, error_lines)
+                hint = _diagnose_mineru_failure(error_lines)
+                if hint:
+                    cls.logger.error(f"[MinerU] {hint}")
+                raise MineruExecutionError(return_code, error_lines, hint=hint)
             else:
                 cls.logger.info("[MinerU] Command executed successfully")
 

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1980,6 +1980,10 @@ class ProcessorMixin:
                     error_message = "\n".join(str(m) for m in e.error_msg)
                 else:
                     error_message = str(e.error_msg)
+                # Surface remediation advice for recognized MinerU failures in the
+                # persisted doc status, not just in the logs.
+                if getattr(e, "hint", None):
+                    error_message = f"{error_message}\n\n{e.hint}"
                 await self.lightrag.doc_status.upsert(
                     {
                         doc_pre_id: {

--- a/tests/test_mineru_error_hints.py
+++ b/tests/test_mineru_error_hints.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Tests for MinerU failure diagnosis (issue #304).
+
+When MinerU crashes inside its own subprocess, RAG-Anything can only see the
+stderr lines it printed. For known dependency incompatibilities we translate
+those opaque tracebacks into actionable remediation advice.
+
+Usage:
+    pytest tests/test_mineru_error_hints.py
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from raganything.parser import (
+    MineruExecutionError,
+    MineruParser,
+    _diagnose_mineru_failure,
+)
+
+
+# The stderr lines exactly as reported in issue #304 (xlsx -> PDF -> MinerU).
+PAGECHARS_ERROR_LINES = [
+    "2026-07-02 08:25:13.423 | ERROR | __main__:_process_task:1154 - "
+    "Async task failed: 10306380-016b-434d-ab67-c25c588184d4",
+    "TypeError: 'PageChars' object is not iterable",
+    "Error: 1 task(s) failed while processing documents:",
+    "- task#1 (excel_table): Task 10306380-016b-434d-ab67-c25c588184d4 failed "
+    'for task#1 [excel_table]: {"status": "failed", "backend": "pipeline", '
+    '"error": "\'PageChars\' object is not iterable"}',
+]
+
+
+def test_pagechars_failure_is_recognized():
+    hint = _diagnose_mineru_failure(PAGECHARS_ERROR_LINES)
+
+    assert hint is not None
+    assert 'pip install -U "mineru[core]>=3.4.1"' in hint
+    assert "pdftext" in hint
+
+
+def test_diagnosis_accepts_a_plain_string():
+    hint = _diagnose_mineru_failure("TypeError: 'PageChars' object is not iterable")
+
+    assert hint is not None
+    assert "mineru[core]>=3.4.1" in hint
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        [],
+        ["Error: some unrelated mineru failure"],
+        "RuntimeError: CUDA out of memory",
+    ],
+)
+def test_unknown_failures_produce_no_hint(error_msg):
+    assert _diagnose_mineru_failure(error_msg) is None
+
+
+def test_execution_error_message_includes_hint():
+    exc = MineruExecutionError(1, PAGECHARS_ERROR_LINES)
+
+    assert exc.hint is not None
+    message = str(exc)
+    # Original diagnostic output is preserved ...
+    assert "Mineru command failed with return code 1" in message
+    assert "'PageChars' object is not iterable" in message
+    # ... and the remediation advice is appended.
+    assert 'pip install -U "mineru[core]>=3.4.1"' in message
+
+
+def test_execution_error_without_known_signature_has_no_hint():
+    exc = MineruExecutionError(1, ["Error: unrelated failure"])
+
+    assert exc.hint is None
+    assert (
+        str(exc) == "Mineru command failed with return code 1: "
+        "['Error: unrelated failure']"
+    )
+
+
+def test_execution_error_keeps_positional_signature():
+    """Backwards compatibility: `hint` is optional and inferred when omitted."""
+    exc = MineruExecutionError(2, ["boom"])
+
+    assert exc.return_code == 2
+    assert exc.error_msg == ["boom"]
+
+
+def test_explicit_hint_overrides_diagnosis():
+    exc = MineruExecutionError(1, PAGECHARS_ERROR_LINES, hint="custom advice")
+
+    assert exc.hint == "custom advice"
+    assert "custom advice" in str(exc)
+
+
+def _fake_mineru_process(stderr_lines, return_code=1):
+    """A Popen double that streams `stderr_lines` then exits with `return_code`."""
+    process = MagicMock()
+    process.poll.return_value = return_code  # already exited; drain path is used
+    process.wait.return_value = return_code
+    process.stdout.readline.side_effect = [""] * 10
+    process.stderr.readline.side_effect = [line + "\n" for line in stderr_lines] + [
+        ""
+    ] * 10
+    return process
+
+
+@patch("subprocess.Popen")
+@patch("pathlib.Path.mkdir")
+def test_hint_survives_the_real_stderr_capture_path(mock_mkdir, mock_popen):
+    """End-to-end guard for issue #304.
+
+    `_run_mineru_command` only keeps stderr lines containing "error", so this
+    asserts the PageChars traceback line actually survives that filter and
+    reaches the diagnosis rather than being dropped as noise.
+    """
+    mock_popen.return_value = _fake_mineru_process(PAGECHARS_ERROR_LINES)
+
+    with pytest.raises(MineruExecutionError) as excinfo:
+        MineruParser()._run_mineru_command("book.pdf", "out")
+
+    exc = excinfo.value
+    assert exc.return_code == 1
+    assert "'PageChars' object is not iterable" in "\n".join(exc.error_msg)
+    assert exc.hint is not None
+    assert 'pip install -U "mineru[core]>=3.4.1"' in str(exc)
+    assert 'parser="docling"' in str(exc)
+
+
+@patch("subprocess.Popen")
+@patch("pathlib.Path.mkdir")
+def test_unrelated_stderr_still_raises_without_a_hint(mock_mkdir, mock_popen):
+    mock_popen.return_value = _fake_mineru_process(
+        ["Error: model weights could not be downloaded"]
+    )
+
+    with pytest.raises(MineruExecutionError) as excinfo:
+        MineruParser()._run_mineru_command("book.pdf", "out")
+
+    assert excinfo.value.hint is None


### PR DESCRIPTION

Refs #304

## What this is

A diagnostics improvement, **not** a functional fix for #304. The crash happens
inside MinerU's own process and cannot be prevented from RAG-Anything. This PR
makes the failure self-diagnosing instead of opaque.

## Root cause

pdftext 0.7.0 changed its character-extraction API to return a `PageChars`
object instead of an iterable list. MinerU <= 3.4.0 iterates that value directly
in `_deduplicate_near_identical_chars` (`mineru/utils/pdf_text_tool.py`), giving
`TypeError: 'PageChars' object is not iterable`.

Fixed upstream in MinerU 3.4.1, which added compatibility shims and constrained
the dependency to `pdftext>=0.6.3,<0.8.0`:

- opendatalab/MinerU#5215
- opendatalab/MinerU#5218

#304 was filed one day before that release.

`.xlsx` reproduces it every time because Office formats have no native MinerU
path: `MineruParser.parse_office_doc` converts them to PDF via LibreOffice, and
that output is born-digital text, so MinerU's pipeline always takes the pdftext
route and never OCR. Scanned PDFs avoid the bug; converted spreadsheets cannot.

Since `mineru[core]` is unpinned in `pyproject.toml`, fresh installs now resolve
to a fixed MinerU. Only environments with an older pin still break — and today
they get an error naming neither MinerU's version nor pdftext.

## Changes

- `raganything/parser.py`: add `_MINERU_KNOWN_FAILURES` (signature to
  remediation) and `_diagnose_mineru_failure()`. `MineruExecutionError` takes an
  optional `hint`, inferring it when omitted and appending it to the message.
  `_run_mineru_command` logs the hint before raising.
- `raganything/processor.py`: append the hint to the persisted
  `doc_status.error_msg`, so it appears in the LightRAG UI, not just the logs.
- `tests/test_mineru_error_hints.py`: 11 tests driven by the verbatim stderr
  from #304, including one that runs `_run_mineru_command` against a mocked
  `Popen` to prove the traceback line survives the `"error"` substring filter.

The hint points at `pip install -U "mineru[core]>=3.4.1"`, the `pdftext==0.6.3`
pin as an alternative, and `parser="docling"` as an immediate workaround —
`DoclingParser.parse_office_doc` reads `.xlsx` natively without LibreOffice, PDF
conversion, or MinerU.

## Not included

I did not raise the `mineru[core]` floor to `>=3.4.1`. That would drop the
MinerU 2.x versions this code still accommodates (the field-name normalization
in `_read_output_files`), which is a maintainer policy call. Happy to add it if
you'd prefer.

## Testing

`pytest tests/` — 270 passed, 1 skipped. `ruff format` and
`ruff check --ignore=E402` clean, matching `.pre-commit-config.yaml`.
