### PR TITLE
fix(resilience): cap retry delay after jitter

### DIFF
--- a/raganything/resilience.py
+++ b/raganything/resilience.py
@@ -117,14 +117,12 @@ def retry(
                             exc,
                         )
                         raise
-                    delay = min(
-                        base_delay * (exponential_base ** (attempt - 1)),
-                        max_delay,
-                    )
+                    delay = base_delay * (exponential_base ** (attempt - 1))
                     if jitter:
                         import random
 
                         delay *= 1.0 + random.uniform(0, 0.5)
+                    delay = min(delay, max_delay)
                     if on_retry is not None:
                         on_retry(exc, attempt, delay)
                     logger.warning(
@@ -202,14 +200,12 @@ def async_retry(
                             exc,
                         )
                         raise
-                    delay = min(
-                        base_delay * (exponential_base ** (attempt - 1)),
-                        max_delay,
-                    )
+                    delay = base_delay * (exponential_base ** (attempt - 1))
                     if jitter:
                         import random
 
                         delay *= 1.0 + random.uniform(0, 0.5)
+                    delay = min(delay, max_delay)
                     if on_retry is not None:
                         result = on_retry(exc, attempt, delay)
                         if asyncio.iscoroutine(result):

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import raganything.resilience as resilience_module
 from raganything.resilience import CircuitBreaker, async_retry, retry
 
 
@@ -91,6 +92,31 @@ class TestSyncRetry:
         assert retries_seen[0] == ("OSError", 1)
         assert retries_seen[1] == ("OSError", 2)
 
+    def test_jitter_respects_max_delay(self, monkeypatch):
+        call_count = 0
+        retry_delays = []
+
+        monkeypatch.setattr("random.uniform", lambda *_args: 0.5)
+        monkeypatch.setattr(resilience_module.time, "sleep", lambda _delay: None)
+
+        @retry(
+            max_attempts=2,
+            base_delay=2.0,
+            max_delay=1.0,
+            jitter=True,
+            retryable_exceptions=[ConnectionError],
+            on_retry=lambda _exc, _attempt, delay: retry_delays.append(delay),
+        )
+        def flaky_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("transient")
+            return "recovered"
+
+        assert flaky_func() == "recovered"
+        assert retry_delays == [1.0]
+
 
 class TestAsyncRetry:
     @pytest.mark.asyncio
@@ -137,6 +163,35 @@ class TestAsyncRetry:
 
         with pytest.raises(TimeoutError, match="permanent"):
             await always_fail()
+
+    @pytest.mark.asyncio
+    async def test_jitter_respects_max_delay(self, monkeypatch):
+        call_count = 0
+        retry_delays = []
+
+        async def no_sleep(_delay):
+            return None
+
+        monkeypatch.setattr("random.uniform", lambda *_args: 0.5)
+        monkeypatch.setattr(resilience_module.asyncio, "sleep", no_sleep)
+
+        @async_retry(
+            max_attempts=2,
+            base_delay=2.0,
+            max_delay=1.0,
+            jitter=True,
+            retryable_exceptions=[ConnectionError],
+            on_retry=lambda _exc, _attempt, delay: retry_delays.append(delay),
+        )
+        async def flaky_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("transient")
+            return "recovered"
+
+        assert await flaky_func() == "recovered"
+        assert retry_delays == [1.0]
 
 
 class TestRetryParameterValidation:


### PR DESCRIPTION
## Description

Keep `max_delay` as a hard upper bound when retry jitter is enabled.

Previously, both `retry` and `async_retry` capped exponential backoff before applying up to 50% jitter. As a result, a configured `max_delay=1.0` could produce an actual delay of `1.5` seconds.

## Related Issues

No existing issue found.

## Changes Made

- Apply exponential backoff and jitter before clamping the final delay to `max_delay`.
- Cover both synchronous and asynchronous retry decorators with deterministic regression tests.
- Verify that retry callbacks receive the same capped delay used for logging and sleeping.

## Validation

- `python -m pytest tests/test_resilience.py -q`: 22 passed
- `python -m pytest -q`: 261 passed, 1 skipped (Windows symlink privilege unavailable)
- `python -m pre_commit run --files raganything/resilience.py tests/test_resilience.py`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; the existing `max_delay` contract is unchanged)
- [x] Unit tests added

## Additional Notes

Retry behavior is unchanged when jitter does not push the computed delay past the configured maximum. Logging, callbacks, and sleep now all observe the same capped delay.
