### PR TITLE
fix(query): prevent multimodal cache key collisions

### DIFF
--- a/raganything/query.py
+++ b/raganything/query.py
@@ -23,6 +23,39 @@ from raganything.utils import (
 class QueryMixin:
     """QueryMixin class containing query functionality for RAGAnything"""
 
+    @staticmethod
+    def _fingerprint_local_file(file_path: str) -> str | None:
+        """Return a content fingerprint for a readable local file."""
+        try:
+            path = Path(file_path).expanduser()
+            if not path.is_file():
+                return None
+
+            digest = hashlib.sha256()
+            with path.open("rb") as file:
+                for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            return digest.hexdigest()
+        except (OSError, RuntimeError):
+            return None
+
+    @staticmethod
+    def _normalize_query_options(options: Dict[str, Any]) -> Dict[str, Any]:
+        """Make query options cache-safe without dropping result-affecting values."""
+        normalized = dict(options)
+        model_func = normalized.get("model_func")
+        if model_func is not None:
+            normalized["model_func"] = {
+                "module": getattr(
+                    model_func, "__module__", type(model_func).__module__
+                ),
+                "qualname": getattr(
+                    model_func, "__qualname__", type(model_func).__qualname__
+                ),
+                "identity": id(model_func),
+            }
+        return normalized
+
     def _generate_multimodal_cache_key(
         self, query: str, multimodal_content: List[Dict[str, Any]], mode: str, **kwargs
     ) -> str:
@@ -51,13 +84,20 @@ class QueryMixin:
                 if isinstance(item, dict):
                     normalized_item = {}
                     for key, value in item.items():
-                        # For file paths, use basename to make cache more portable
+                        # File contents affect the answer, so use their digest instead
+                        # of the basename. Same-named files may contain different media.
                         if key in [
                             "img_path",
                             "image_path",
                             "file_path",
                         ] and isinstance(value, str):
-                            normalized_item[key] = Path(value).name
+                            file_fingerprint = self._fingerprint_local_file(value)
+                            if file_fingerprint is not None:
+                                normalized_item[f"{key}_sha256"] = file_fingerprint
+                            else:
+                                # Preserve the complete value for unavailable local
+                                # paths and URLs so equal basenames cannot collide.
+                                normalized_item[key] = value
                         # For large content, create a hash instead of storing directly
                         elif (
                             key in ["table_data", "table_body"]
@@ -75,23 +115,9 @@ class QueryMixin:
 
         cache_data["multimodal_content"] = normalized_content
 
-        # Add relevant kwargs to cache data
-        relevant_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k
-            in [
-                "stream",
-                "response_type",
-                "top_k",
-                "max_tokens",
-                "temperature",
-                "system_prompt",
-                # "only_need_context",
-                # "only_need_prompt",
-            ]
-        }
-        cache_data.update(relevant_kwargs)
+        # Every forwarded query option can affect retrieval or generation.
+        # Keep them nested so they cannot overwrite the core cache fields.
+        cache_data["query_options"] = self._normalize_query_options(kwargs)
 
         # Generate hash from the cache data
         cache_str = json.dumps(cache_data, sort_keys=True, ensure_ascii=False)

--- a/tests/test_multimodal_query_key.py
+++ b/tests/test_multimodal_query_key.py
@@ -1,0 +1,141 @@
+"""Tests for multimodal query cache key generation."""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from raganything.query import QueryMixin
+
+
+def _cache_key(file_path: str) -> str:
+    return QueryMixin()._generate_multimodal_cache_key(
+        "describe this image",
+        [{"type": "image", "img_path": file_path}],
+        "mix",
+    )
+
+
+def _query_options_key(**kwargs) -> str:
+    return QueryMixin()._generate_multimodal_cache_key(
+        "summarize this table",
+        [{"type": "table", "table_data": "name,value\nalpha,1"}],
+        "mix",
+        **kwargs,
+    )
+
+
+def test_cache_key_distinguishes_same_named_files_with_different_content(tmp_path):
+    first = tmp_path / "first" / "diagram.png"
+    second = tmp_path / "second" / "diagram.png"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_bytes(b"first image")
+    second.write_bytes(b"second image")
+
+    assert _cache_key(str(first)) != _cache_key(str(second))
+
+
+def test_cache_key_changes_when_file_content_changes(tmp_path):
+    image = tmp_path / "diagram.png"
+    image.write_bytes(b"original image")
+    original_key = _cache_key(str(image))
+
+    image.write_bytes(b"updated image")
+
+    assert _cache_key(str(image)) != original_key
+
+
+def test_cache_key_distinguishes_unavailable_paths_with_same_name(tmp_path):
+    first = tmp_path / "first" / "missing.png"
+    second = tmp_path / "second" / "missing.png"
+
+    assert _cache_key(str(first)) != _cache_key(str(second))
+
+
+@pytest.mark.parametrize(
+    ("first_options", "second_options"),
+    [
+        ({"only_need_context": False}, {"only_need_context": True}),
+        ({"only_need_prompt": False}, {"only_need_prompt": True}),
+        ({"chunk_top_k": 10}, {"chunk_top_k": 20}),
+        (
+            {"conversation_history": [{"role": "user", "content": "first"}]},
+            {"conversation_history": [{"role": "user", "content": "second"}]},
+        ),
+        ({"user_prompt": "be concise"}, {"user_prompt": "be detailed"}),
+        ({"enable_rerank": False}, {"enable_rerank": True}),
+        ({"include_references": False}, {"include_references": True}),
+    ],
+)
+def test_cache_key_distinguishes_result_affecting_query_options(
+    first_options, second_options
+):
+    assert _query_options_key(**first_options) != _query_options_key(**second_options)
+
+
+def test_cache_key_distinguishes_model_functions():
+    def first_model():
+        return None
+
+    def second_model():
+        return None
+
+    first_key = _query_options_key(model_func=first_model)
+
+    assert first_key == _query_options_key(model_func=first_model)
+    assert first_key != _query_options_key(model_func=second_model)
+
+
+class _MemoryCache:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache": True}
+        self.entries = {}
+
+    async def get_by_id(self, cache_key):
+        return self.entries.get(cache_key)
+
+    async def upsert(self, entries):
+        self.entries.update(entries)
+
+    async def index_done_callback(self):
+        return None
+
+
+class _QueryHarness(QueryMixin):
+    def __init__(self):
+        self.logger = logging.getLogger("test.multimodal_query_key")
+        self.lightrag = SimpleNamespace(llm_response_cache=_MemoryCache())
+        self.only_context_calls = []
+
+    async def _ensure_lightrag_initialized(self):
+        return {"success": True}
+
+    async def _process_multimodal_query_content(self, query, multimodal_content):
+        return f"enhanced: {query}"
+
+    async def aquery(self, query, mode="mix", system_prompt=None, **kwargs):
+        only_need_context = kwargs.get("only_need_context", False)
+        self.only_context_calls.append(only_need_context)
+        return "retrieved context" if only_need_context else "generated answer"
+
+
+@pytest.mark.asyncio
+async def test_context_only_cache_entry_is_not_reused_as_a_generated_answer():
+    harness = _QueryHarness()
+    content = [{"type": "table", "table_data": "name,value\nalpha,1"}]
+
+    context = await harness.aquery_with_multimodal(
+        "summarize this table",
+        content,
+        only_need_context=True,
+    )
+    answer = await harness.aquery_with_multimodal(
+        "summarize this table",
+        content,
+        only_need_context=False,
+    )
+
+    assert context == "retrieved context"
+    assert answer == "generated answer"
+    assert harness.only_context_calls == [True, False]


### PR DESCRIPTION
## Description

Prevent multimodal query cache collisions caused by incomplete media identity and omitted query options.

The previous cache key had two correctness problems:

1. It reduced `img_path`, `image_path`, and `file_path` values to `Path(value).name`. Different files such as `reports/a/diagram.png` and `reports/b/diagram.png` therefore shared a key, and replacing a file in place did not change that key.
2. It kept only a small allowlist of query options. Result-affecting values such as `only_need_context`, `only_need_prompt`, `chunk_top_k`, `conversation_history`, `user_prompt`, `enable_rerank`, and `include_references` were ignored. A context-only result could consequently be returned from cache for a later request that expected a generated answer.

## Related Issues

No existing issue found.

## Changes Made

- Fingerprint readable local media with SHA-256, streaming it in 1 MiB chunks.
- Preserve the complete value for unavailable local paths and URLs so equal basenames cannot collide.
- Include every forwarded query option under a dedicated `query_options` cache-key field instead of maintaining an incomplete allowlist.
- Represent an explicit `model_func` with its source name and process-local identity, keeping the key JSON-serializable while separating different callables.
- Add regression coverage for media changes, seven result-affecting query-option pairs, model functions, and an end-to-end context-only cache reuse scenario.

## Validation

- `python -m pytest tests/test_multimodal_query_key.py -q`: 12 passed
- `python -m pytest -q`: 271 passed, 1 skipped (Windows symlink privilege unavailable)
- `python -m pre_commit run --files raganything/query.py tests/test_multimodal_query_key.py`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; no public API changes)
- [x] Unit tests added

## Additional Notes

The cache key format is internal. Existing entries simply become misses after this change and are regenerated with complete media and query identities.
