### PR TITLE
fix(processor): fingerprint files in parse cache keys

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -32,6 +32,15 @@ from lightrag.utils import compute_mdhash_id
 class ProcessorMixin:
     """ProcessorMixin class containing document processing functionality for RAGAnything"""
 
+    @staticmethod
+    def _file_content_fingerprint(file_path: Path) -> str:
+        """Return a streaming SHA-256 fingerprint for parse-cache identity."""
+        digest = hashlib.sha256()
+        with file_path.open("rb") as file_obj:
+            for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
     def _get_file_reference(self, file_path: str) -> str:
         """
         Get file reference based on use_full_path configuration.
@@ -51,7 +60,7 @@ class ProcessorMixin:
         self, file_path: Path, parse_method: str = None, **kwargs
     ) -> str:
         """
-        Generate cache key based on file path and parsing configuration
+        Generate cache key based on file content, path, and parsing configuration
 
         Args:
             file_path: Path to the file
@@ -69,6 +78,7 @@ class ProcessorMixin:
         config_dict = {
             "file_path": str(file_path.absolute()),
             "mtime": mtime,
+            "file_sha256": self._file_content_fingerprint(file_path),
             "parser": self.config.parser,
             "parse_method": parse_method or self.config.parse_method,
         }

--- a/tests/testparse_cache_key.py
+++ b/tests/testparse_cache_key.py
@@ -1,0 +1,103 @@
+"""Regression tests for parse-cache file identity."""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from raganything.processor import ProcessorMixin
+
+
+class _Logger:
+    def debug(self, *args, **kwargs):
+        pass
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class _MemoryCache:
+    def __init__(self):
+        self.entries = {}
+
+    async def get_by_id(self, key):
+        return self.entries.get(key)
+
+    async def upsert(self, entries):
+        self.entries.update(entries)
+
+    async def index_done_callback(self):
+        pass
+
+
+class _TextParser:
+    def __init__(self):
+        self.calls = 0
+
+    def parse_document(self, file_path, **kwargs):
+        self.calls += 1
+        return [{"type": "text", "text": Path(file_path).read_text(encoding="utf-8")}]
+
+
+class _Processor(ProcessorMixin):
+    pass
+
+
+def _make_processor(tmp_path):
+    processor = _Processor()
+    processor.config = SimpleNamespace(
+        parser="test",
+        parser_output_dir=str(tmp_path / "output"),
+        parse_method="auto",
+        display_content_stats=False,
+        use_full_path=False,
+    )
+    processor.logger = _Logger()
+    processor.parse_cache = _MemoryCache()
+    processor.doc_parser = _TextParser()
+    return processor
+
+
+@pytest.mark.asyncio
+async def test_parse_cache_reuses_unchanged_file(tmp_path):
+    processor = _make_processor(tmp_path)
+    document = tmp_path / "document.txt"
+    document.write_text("alpha", encoding="utf-8")
+
+    first_result = await processor.parse_document(str(document))
+    second_result = await processor.parse_document(str(document))
+
+    assert processor.doc_parser.calls == 1
+    assert second_result == first_result
+
+
+@pytest.mark.asyncio
+async def test_parse_cache_invalidates_when_content_changes_with_preserved_mtime(
+    tmp_path,
+):
+    processor = _make_processor(tmp_path)
+    document = tmp_path / "document.txt"
+    document.write_text("alpha", encoding="utf-8")
+    original_stat = document.stat()
+
+    first_content, first_doc_id = await processor.parse_document(str(document))
+
+    document.write_text("bravo", encoding="utf-8")
+    os.utime(
+        document,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+
+    second_content, second_doc_id = await processor.parse_document(str(document))
+
+    assert processor.doc_parser.calls == 2
+    assert first_content != second_content
+    assert first_doc_id != second_doc_id
+    assert second_content == [{"type": "text", "text": "bravo"}]


### PR DESCRIPTION
# RAG-Anything Parse-Cache PR

## Description

Invalidate the document parse cache when file contents change even if the file modification time is preserved.

The current parse-cache key uses the absolute path, modification time, parser, parse method, and selected parser options. If a file is replaced in place while retaining its original modification time, the key remains unchanged and the old parsed content is returned for the new file.

## Related Issues

No existing issue or pull request was found for this exact parse-cache content-identity failure.

## Changes Made

- Add a streaming SHA-256 fingerprint of the source file to the parse-cache key.
- Read the file in 1 MiB chunks so the fingerprint does not load the entire document into memory.
- Preserve the existing path, modification-time, parser, parse-method, and parser-option components.
- Add regression coverage for both unchanged-file cache reuse and content replacement with a preserved modification time.

## Validation

- Before the fix: the preserved-mtime regression reproduced the stale-cache result and the parser was called only once.
- python -m pytest tests/testparse_cache_key.py tests/testparser_wiring.py -q: 5 passed
- python -m pytest -q: 261 passed, 1 skipped (Windows symlink privilege unavailable)
- python -m pre_commit run --files raganything/processor.py tests/testparse_cache_key.py
- git diff --check origin/main...HEAD

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; no public API changes)
- [x] Unit tests added

## Additional Notes

The cache key format is internal. Existing parse-cache entries become misses after this change and are regenerated with a content-aware identity. Unchanged files still reuse cached results.
