### PR TITLE
fix: reject empty content lists before insertion

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -2135,6 +2135,9 @@ class ProcessorMixin:
             - page_idx represents the page number where the content appears (0-based indexing)
             - Items are processed in the order they appear in the list
         """
+        if len(content_list) == 0:
+            raise ValueError("content_list cannot be empty")
+
         callback_manager = getattr(self, "callback_manager", None)
         doc_start_time = time.time()
 

--- a/tests/test_insert_content_list.py
+++ b/tests/test_insert_content_list.py
@@ -4,6 +4,8 @@ import asyncio
 import sys
 import types
 
+import pytest
+
 
 class FakeLogger:
     def info(self, *args, **kwargs):
@@ -101,6 +103,7 @@ class FakeLightRAG:
 class DummyProcessor(ProcessorMixin):
     def __init__(self):
         self.events = []
+        self.init_calls = 0
         self.lightrag = FakeLightRAG(self.events)
         self.logger = FakeLogger()
         self.config = SimpleNamespace(
@@ -114,6 +117,7 @@ class DummyProcessor(ProcessorMixin):
         self.parsed_content_list = []
 
     async def _ensure_lightrag_initialized(self):
+        self.init_calls += 1
         return {"success": True}
 
     async def parse_document(
@@ -126,6 +130,17 @@ class DummyProcessor(ProcessorMixin):
 
     async def _process_multimodal_content(self, multimodal_items, file_ref, doc_id):
         self.events.append(("multimodal", doc_id, file_ref))
+
+
+def test_insert_content_list_rejects_empty_list_before_side_effects():
+    processor = DummyProcessor()
+
+    with pytest.raises(ValueError, match="content_list cannot be empty"):
+        asyncio.run(processor.insert_content_list([], file_path="/tmp/source.pdf"))
+
+    assert processor.init_calls == 0
+    assert processor.events == []
+    assert processor.lightrag.doc_status.records == {}
 
 
 def test_insert_content_list_defers_status_until_after_text_insert():


### PR DESCRIPTION
## Description

`insert_content_list([])` currently completes successfully and creates an empty document status record even though no text or multimodal item can be processed. The parsed-document path already rejects the same no-content condition.

This change rejects an empty `content_list` before callback setup, timing, LightRAG initialization, document ID generation, or status writes. Non-empty multimodal-only lists retain their existing behavior.

## Related Issues

No existing issue was found for this exact behavior.

## Changes Made

- Add a focused `ValueError("content_list cannot be empty")` guard at the public insertion boundary.
- Add a regression that verifies the error occurs before initialization and leaves events and document status untouched.

## Checklist

- [x] Changes tested locally
- [x] Code independently reviewed
- [x] Documentation is unchanged because the public method already requires a content list; this clarifies the empty-input error
- [x] Unit test added

## Test Results

```text
Pre-fix regression: failed with "DID NOT RAISE ValueError"
Focused regression: 1 passed
test_insert_content_list.py: 5 passed
Full test suite: 260 passed, 1 skipped
Targeted pre-commit: all applicable hooks passed
git diff --check: passed
```

## Additional Notes

The patch intentionally does not define new behavior for `None`, malformed items, or non-empty lists containing only blank text. It only prevents a structurally empty list from producing a successful ghost document.

PR #318 touches the same method for opt-in multimodal reprocessing but does not implement this validation; if it merges first, this branch may need a narrow rebase.
