### PR TITLE
fix(batch): allow disabling recursive CLI scans

### DIFF
--- a/docs/batch_processing.md
+++ b/docs/batch_processing.md
@@ -131,6 +131,9 @@ python -m raganything.batch_parser examples/sample_docs/ --parser paddleocr --me
 # Without progress bar
 python -m raganything.batch_parser examples/sample_docs/ --output ./output --no-progress
 
+# Only process files directly inside the specified directories
+python -m raganything.batch_parser examples/sample_docs/ --output ./output --no-recursive
+
 # Dry run (list supported files without processing)
 python -m raganything.batch_parser examples/sample_docs/ --output ./output --dry-run
 

--- a/raganything/batch_parser.py
+++ b/raganything/batch_parser.py
@@ -604,9 +604,9 @@ def main():
     )
     parser.add_argument(
         "--recursive",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
-        help="Search directories recursively",
+        help="Search directories recursively (use --no-recursive to disable)",
     )
     parser.add_argument(
         "--timeout", type=int, default=300, help="Timeout per file (seconds)"

--- a/tests/testbatch_incremental.py
+++ b/tests/testbatch_incremental.py
@@ -22,7 +22,7 @@ class FakeParser:
         return [{"type": "text", "text": Path(file_path).read_text()}]
 
 
-def _make_batch_parser(monkeypatch):
+def _load_batch_parser_module(monkeypatch):
     fake_parser = FakeParser()
     repo_root = Path(__file__).parents[1]
 
@@ -43,6 +43,12 @@ def _make_batch_parser(monkeypatch):
     monkeypatch.setitem(sys.modules, "raganything.batch_parser", batch_parser_module)
     spec.loader.exec_module(batch_parser_module)
 
+    return batch_parser_module, fake_parser
+
+
+def _make_batch_parser(monkeypatch):
+    batch_parser_module, fake_parser = _load_batch_parser_module(monkeypatch)
+
     batch_parser = batch_parser_module.BatchParser(
         parser_type="fake",
         max_workers=1,
@@ -50,6 +56,44 @@ def _make_batch_parser(monkeypatch):
         skip_installation_check=True,
     )
     return batch_parser, fake_parser
+
+
+def test_cli_can_disable_recursive_scan(monkeypatch, tmp_path):
+    batch_parser_module, _ = _load_batch_parser_module(monkeypatch)
+    captured = {}
+
+    class FakeResult:
+        successful_files = []
+        failed_files = []
+        skipped_files = []
+
+        @staticmethod
+        def summary():
+            return "Batch processing results"
+
+    class FakeBatchParser:
+        def __init__(self, **kwargs):
+            pass
+
+        def process_batch(self, **kwargs):
+            captured.update(kwargs)
+            return FakeResult()
+
+    monkeypatch.setattr(batch_parser_module, "BatchParser", FakeBatchParser)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "raganything.batch_parser",
+            str(tmp_path / "docs"),
+            "--output",
+            str(tmp_path / "output"),
+            "--no-recursive",
+        ],
+    )
+
+    assert batch_parser_module.main() == 0
+    assert captured["recursive"] is False
 
 
 def test_incremental_batch_skips_unchanged_files(monkeypatch, tmp_path):


### PR DESCRIPTION
## Description

The batch CLI currently defines `--recursive` with `action="store_true"` and `default=True`, so recursive scanning is always enabled. Users cannot restrict a directory input to files directly inside that directory.

This change uses `argparse.BooleanOptionalAction` to expose `--no-recursive` while preserving the current recursive default and the existing `--recursive` option.

## Related Issues

N/A — no existing issue or pull request covers this CLI behavior.

## Changes Made

- Add the `--no-recursive` CLI option without changing the default behavior.
- Add a regression test that verifies the CLI passes `recursive=False` to the batch processor.
- Document non-recursive batch usage.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [x] Unit tests added

## Tests

- `python -m pytest tests/testbatch_incremental.py -q` on Python 3.10, 3.11, and 3.12 — 9 passed on each version
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

## Additional Notes

This is backward compatible and does not change the library API.