### PR TITLE
feat(parser): parse .txt/.md directly instead of converting to PDF and OCR-parsing (fixes #331)

### DIFF
--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -34,6 +34,7 @@ import subprocess
 import tempfile
 import threading
 import logging
+import re
 import time
 import urllib.parse
 import urllib.request
@@ -410,25 +411,7 @@ class Parser:
                 raise ValueError(f"Unsupported text format: {text_path.suffix}")
 
             # Read the text content
-            try:
-                with open(text_path, "r", encoding="utf-8") as f:
-                    text_content = f.read()
-            except UnicodeDecodeError:
-                # Try with different encodings
-                for encoding in ["gbk", "latin-1", "cp1252"]:
-                    try:
-                        with open(text_path, "r", encoding=encoding) as f:
-                            text_content = f.read()
-                        cls.logger.info(
-                            f"Successfully read file with {encoding} encoding"
-                        )
-                        break
-                    except UnicodeDecodeError:
-                        continue
-                else:
-                    raise RuntimeError(
-                        f"Could not decode text file {text_path.name} with any supported encoding"
-                    )
+            text_content = cls._read_text_with_fallback(text_path)
 
             # Prepare output directory
             if output_dir:
@@ -649,6 +632,113 @@ class Parser:
         text = re.sub(r"~~(.*?)~~", r"<strike>\1</strike>", text)
 
         return text
+
+    @classmethod
+    def _read_text_with_fallback(cls, text_path: Path) -> str:
+        """
+        Read a text file, trying UTF-8 first and falling back to common
+        legacy encodings. utf-8-sig also strips a UTF-8 BOM if present.
+        """
+        try:
+            with open(text_path, "r", encoding="utf-8-sig") as f:
+                return f.read()
+        except UnicodeDecodeError:
+            for encoding in ["gbk", "latin-1", "cp1252"]:
+                try:
+                    with open(text_path, "r", encoding=encoding) as f:
+                        content = f.read()
+                    cls.logger.info(f"Successfully read file with {encoding} encoding")
+                    return content
+                except UnicodeDecodeError:
+                    continue
+            raise RuntimeError(
+                f"Could not decode text file {text_path.name} with any supported encoding"
+            )
+
+    @classmethod
+    def _text_to_content_blocks(
+        cls, text_content: str, is_markdown: bool
+    ) -> List[Dict[str, Any]]:
+        """
+        Split raw text into MinerU-style content blocks.
+
+        Paragraphs are delimited by blank lines; in markdown, an ATX heading
+        (`# ...`) becomes its own block carrying `text_level`, matching how
+        MinerU marks headings in its content list.
+        """
+        # Normalize line endings up front so CRLF/CR input behaves the same
+        # as LF however the text arrived (text-mode file reads translate
+        # these already; raw strings passed directly have not been).
+        lines = text_content.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+        blocks: List[Dict[str, Any]] = []
+        paragraph: List[str] = []
+
+        def flush() -> None:
+            if paragraph:
+                blocks.append(
+                    {"type": "text", "text": "\n".join(paragraph), "page_idx": 0}
+                )
+                paragraph.clear()
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                flush()
+                continue
+            if is_markdown:
+                heading = re.match(r"^(#{1,6})\s+(.+)$", stripped)
+                if heading:
+                    flush()
+                    blocks.append(
+                        {
+                            "type": "text",
+                            "text": heading.group(2).strip(),
+                            "text_level": len(heading.group(1)),
+                            "page_idx": 0,
+                        }
+                    )
+                    continue
+            paragraph.append(line.rstrip())
+        flush()
+
+        return blocks
+
+    def parse_text_file(
+        self,
+        text_path: Union[str, Path],
+        output_dir: Optional[str] = None,
+        lang: Optional[str] = None,
+        **kwargs,
+    ) -> List[Dict[str, Any]]:
+        """
+        Parse a plain text or markdown file directly into content blocks.
+
+        The content is already text, so no rendering or OCR is involved:
+        historically these files were rendered to PDF with ReportLab and
+        re-parsed with the OCR pipeline, which was slower and exposed them
+        to PDF-rendering failure modes (#24, #226, #316, #331).
+
+        Args:
+            text_path: Path to the text file (.txt, .md)
+            output_dir: Accepted for signature compatibility; no artifacts
+                        are written since no conversion takes place
+            lang: Accepted for signature compatibility; no OCR is involved
+            **kwargs: Accepted for signature compatibility
+
+        Returns:
+            List[Dict[str, Any]]: List of content blocks
+        """
+        text_path = Path(text_path)
+        if not text_path.exists():
+            raise FileNotFoundError(f"Text file does not exist: {text_path}")
+        if text_path.suffix.lower() not in self.TEXT_FORMATS:
+            raise ValueError(f"Unsupported text format: {text_path.suffix}")
+
+        text_content = self._read_text_with_fallback(text_path)
+        return self._text_to_content_blocks(
+            text_content, is_markdown=text_path.suffix.lower() == ".md"
+        )
 
     def parse_pdf(
         self,
@@ -1468,40 +1558,6 @@ class MineruParser(Parser):
 
         except Exception as e:
             self.logger.error(f"Error in parse_office_doc: {str(e)}")
-            raise
-
-    def parse_text_file(
-        self,
-        text_path: Union[str, Path],
-        output_dir: Optional[str] = None,
-        lang: Optional[str] = None,
-        **kwargs,
-    ) -> List[Dict[str, Any]]:
-        """
-        Parse text file by first converting to PDF, then parsing with MinerU 2.0
-
-        Supported formats: .txt, .md
-
-        Args:
-            text_path: Path to the text file (.txt, .md)
-            output_dir: Output directory path
-            lang: Document language for OCR optimization
-            **kwargs: Additional parameters for mineru command
-
-        Returns:
-            List[Dict[str, Any]]: List of content blocks
-        """
-        try:
-            # Convert text file to PDF using base class method
-            pdf_path = self.convert_text_to_pdf(text_path, output_dir)
-
-            # Parse the converted PDF
-            return self.parse_pdf(
-                pdf_path=pdf_path, output_dir=output_dir, lang=lang, **kwargs
-            )
-
-        except Exception as e:
-            self.logger.error(f"Error in parse_text_file: {str(e)}")
             raise
 
     def parse_document(
@@ -2456,18 +2512,6 @@ class PaddleOCRParser(Parser):
         **kwargs,
     ) -> List[Dict[str, Any]]:
         pdf_path = self.convert_office_to_pdf(doc_path, output_dir)
-        return self.parse_pdf(
-            pdf_path=pdf_path, output_dir=output_dir, lang=lang, **kwargs
-        )
-
-    def parse_text_file(
-        self,
-        text_path: Union[str, Path],
-        output_dir: Optional[str] = None,
-        lang: Optional[str] = None,
-        **kwargs,
-    ) -> List[Dict[str, Any]]:
-        pdf_path = self.convert_text_to_pdf(text_path, output_dir)
         return self.parse_pdf(
             pdf_path=pdf_path, output_dir=output_dir, lang=lang, **kwargs
         )

--- a/tests/test_plain_text_direct.py
+++ b/tests/test_plain_text_direct.py
@@ -1,0 +1,121 @@
+"""Tests for direct plain-text parsing (issue #331).
+
+.txt/.md files are parsed straight into content blocks instead of being
+rendered to PDF with ReportLab and re-parsed with the OCR pipeline.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from raganything.parser import MineruParser, PaddleOCRParser, Parser  # noqa: E402
+
+
+class TestTextToContentBlocks:
+    """The block builder: paragraph splitting, headings, line endings."""
+
+    def test_paragraphs_split_on_blank_lines(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_text("First paragraph.\n\nSecond paragraph\nwith a wrapped line.\n")
+        blocks = MineruParser().parse_text_file(f)
+        assert [b["text"] for b in blocks] == [
+            "First paragraph.",
+            "Second paragraph\nwith a wrapped line.",
+        ]
+        assert all(b["type"] == "text" for b in blocks)
+
+    def test_crlf_line_endings_still_split_paragraphs(self, tmp_path):
+        # File path: text-mode open translates newlines, so this documents
+        # the end-to-end behavior rather than the normalization itself.
+        f = tmp_path / "doc.txt"
+        f.write_bytes(b"First paragraph.\r\n\r\nSecond paragraph.\r\n")
+        blocks = MineruParser().parse_text_file(f)
+        assert [b["text"] for b in blocks] == ["First paragraph.", "Second paragraph."]
+
+    def test_block_builder_accepts_raw_crlf_strings(self):
+        # Direct string input skips text-mode newline translation; CRLF
+        # paragraph breaks must still split, and no \r may leak into blocks.
+        blocks = Parser._text_to_content_blocks("A.\r\n\r\nB.", is_markdown=False)
+        assert [b["text"] for b in blocks] == ["A.", "B."]
+
+    def test_all_blocks_carry_page_idx_zero(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_text("One.\n\nTwo.\n\nThree.\n")
+        blocks = MineruParser().parse_text_file(f)
+        assert len(blocks) == 3
+        assert all(b["page_idx"] == 0 for b in blocks)
+
+    def test_markdown_headings_get_text_level(self, tmp_path):
+        f = tmp_path / "doc.md"
+        f.write_text("# Title\n\nBody paragraph.\n\n## Section\nSection body.\n")
+        blocks = MineruParser().parse_text_file(f)
+        assert blocks[0] == {
+            "type": "text",
+            "text": "Title",
+            "text_level": 1,
+            "page_idx": 0,
+        }
+        assert "text_level" not in blocks[1]
+        assert blocks[2]["text_level"] == 2
+        # A heading directly followed by text (no blank line) still becomes
+        # its own block, with the text as a separate paragraph.
+        assert blocks[3]["text"] == "Section body."
+
+    def test_txt_does_not_interpret_hash_as_heading(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_text("# not a heading in plain text\n")
+        blocks = MineruParser().parse_text_file(f)
+        assert blocks[0]["text"] == "# not a heading in plain text"
+        assert "text_level" not in blocks[0]
+
+    def test_empty_file_yields_no_blocks(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_text("\n\n  \n")
+        assert MineruParser().parse_text_file(f) == []
+
+
+class TestEncodingHandling:
+    def test_gbk_fallback(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_bytes("涡轮叶片检测报告。".encode("gbk"))
+        blocks = MineruParser().parse_text_file(f)
+        assert blocks[0]["text"] == "涡轮叶片检测报告。"
+
+    def test_utf8_bom_is_stripped(self, tmp_path):
+        f = tmp_path / "doc.txt"
+        f.write_bytes("﻿First paragraph.".encode("utf-8"))
+        blocks = MineruParser().parse_text_file(f)
+        assert blocks[0]["text"] == "First paragraph."
+
+
+class TestNoPdfRoundTrip:
+    """The point of the change: text formats must never touch the PDF path."""
+
+    @pytest.mark.parametrize("parser_cls", [MineruParser, PaddleOCRParser])
+    def test_parse_document_routes_text_without_pdf_conversion(
+        self, tmp_path, monkeypatch, parser_cls
+    ):
+        f = tmp_path / "doc.txt"
+        f.write_text("Direct content.\n")
+
+        def fail(*args, **kwargs):
+            raise AssertionError("text parsing must not render a PDF")
+
+        monkeypatch.setattr(Parser, "convert_text_to_pdf", classmethod(fail))
+        monkeypatch.setattr(parser_cls, "parse_pdf", fail, raising=False)
+
+        blocks = parser_cls().parse_document(f)
+        assert blocks == [{"type": "text", "text": "Direct content.", "page_idx": 0}]
+
+    def test_rejects_non_text_extension(self, tmp_path):
+        f = tmp_path / "doc.csv"
+        f.write_text("a,b\n")
+        with pytest.raises(ValueError):
+            MineruParser().parse_text_file(f)
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            MineruParser().parse_text_file(tmp_path / "absent.txt")


### PR DESCRIPTION
## Description

`.txt`/`.md` files were rendered to PDF with ReportLab and then re-parsed with the OCR pipeline. For content that is already text this round-trip is ~3× slower end to end (measured 52 s → 18.9 s for the same small text file), burns OCR compute, and is the source of a family of rendering-fidelity bugs (#24, #226, #316) that cannot exist if the text never becomes a PDF.

## Related Issues

Fixes #331. Related: #24, #226, #316 (all bugs in the PDF-rendering leg this removes from the text path).

## Changes Made

- `Parser.parse_text_file` (new, on the base class): reads the file (UTF-8 with BOM handling, falling back to gbk/latin-1/cp1252) and splits it into MinerU-style content blocks. Blank lines delimit paragraphs; in markdown, ATX headings become their own blocks carrying `text_level`, matching how MinerU marks headings in its content lists.
- `MineruParser.parse_text_file` and `PaddleOCRParser.parse_text_file` overrides (which did `convert_text_to_pdf` → `parse_pdf`) are removed; both inherit the direct path. `convert_text_to_pdf` remains available for direct callers.
- The encoding-fallback read is factored into `_read_text_with_fallback`, shared with `convert_text_to_pdf`.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Tests: `tests/test_plain_text_direct.py` (13 cases: paragraph/heading splitting, CRLF handling, BOM stripping, gbk fallback, `parse_document` routing for both parsers with the PDF path monkeypatched to fail, extension/missing-file errors). Full suite: 248 passed.
- Lint: `ruff==0.6.4 check --ignore=E402` and `ruff format --diff` clean on changed files (matching the pre-commit config).
- Behavioral note: text files no longer produce parser output artifacts on disk (there is no conversion), and blocks carry `page_idx: 0` since plain text has no pages. Callers consuming the returned content list are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
