### PR TITLE
fix(processor): harden multimodal chunks_list merge against reprocessing and absent records (refs #332)

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -803,45 +803,12 @@ class ProcessorMixin:
                 self.logger.debug("Exception details:", exc_info=True)
                 continue
 
-        # Update doc_status to include multimodal chunks in the standard chunks_list
+        # Update doc_status to include multimodal chunks in the standard
+        # chunks_list (same merge semantics as the batch type-aware path)
         if multimodal_chunk_ids:
-            try:
-                # Get current document status
-                current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
-
-                if current_doc_status:
-                    existing_chunks_list = current_doc_status.get("chunks_list", [])
-                    existing_chunks_count = current_doc_status.get("chunks_count", 0)
-
-                    # Add multimodal chunks to the standard chunks_list
-                    updated_chunks_list = existing_chunks_list + multimodal_chunk_ids
-                    updated_chunks_count = existing_chunks_count + len(
-                        multimodal_chunk_ids
-                    )
-
-                    # Update document status with integrated chunk list
-                    await self.lightrag.doc_status.upsert(
-                        {
-                            doc_id: {
-                                **current_doc_status,  # Keep existing fields
-                                "chunks_list": updated_chunks_list,  # Integrated chunks list
-                                "chunks_count": updated_chunks_count,  # Updated total count
-                                "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
-                            }
-                        }
-                    )
-
-                    # Ensure doc_status update is persisted to disk
-                    await self.lightrag.doc_status.index_done_callback()
-
-                    self.logger.info(
-                        f"Updated doc_status with {len(multimodal_chunk_ids)} multimodal chunks integrated into chunks_list"
-                    )
-
-            except Exception as e:
-                self.logger.warning(
-                    f"Error updating doc_status with multimodal chunks: {e}"
-                )
+            await self._update_doc_status_with_chunks_type_aware(
+                doc_id, multimodal_chunk_ids
+            )
 
         # Batch merge all multimodal content results (similar to text content processing)
         if all_chunk_results:
@@ -1498,38 +1465,59 @@ class ProcessorMixin:
     async def _update_doc_status_with_chunks_type_aware(
         self, doc_id: str, chunk_ids: List[str]
     ):
-        """Update document status with multimodal chunks"""
+        """Merge multimodal chunk ids into the document's chunks_list."""
         try:
             # Get current document status
             current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
 
-            if current_doc_status:
-                existing_chunks_list = current_doc_status.get("chunks_list", [])
-                existing_chunks_count = current_doc_status.get("chunks_count", 0)
+            if not current_doc_status:
+                # An absent record is a linkage failure worth surfacing:
+                # every consumer that enumerates the document's chunks via
+                # chunks_list will silently orphan these (#332).
+                self.logger.warning(
+                    f"doc_status record {doc_id} not found; "
+                    f"{len(chunk_ids)} multimodal chunk(s) will be missing "
+                    "from its chunks_list"
+                )
+                return
 
-                # Add multimodal chunks to the standard chunks_list
-                updated_chunks_list = existing_chunks_list + chunk_ids
-                updated_chunks_count = existing_chunks_count + len(chunk_ids)
+            existing_chunks_list = current_doc_status.get("chunks_list", [])
+            existing_chunks_count = current_doc_status.get("chunks_count", 0)
 
-                # Update document status with integrated chunk list
-                await self.lightrag.doc_status.upsert(
-                    {
-                        doc_id: {
-                            **current_doc_status,  # Keep existing fields
-                            "chunks_list": updated_chunks_list,  # Integrated chunks list
-                            "chunks_count": updated_chunks_count,  # Updated total count
-                            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
-                        }
+            # Merge rather than append: chunk ids are content-hashed, so
+            # reprocessing the same multimodal content produces the same ids
+            # and a blind append would duplicate them in chunks_list.
+            already_listed = set(existing_chunks_list)
+            new_chunk_ids = [cid for cid in chunk_ids if cid not in already_listed]
+            if not new_chunk_ids:
+                self.logger.debug(
+                    f"All {len(chunk_ids)} multimodal chunks already listed "
+                    f"in doc_status for {doc_id}"
+                )
+                return
+
+            updated_chunks_list = existing_chunks_list + new_chunk_ids
+            updated_chunks_count = existing_chunks_count + len(new_chunk_ids)
+
+            # Update document status with integrated chunk list
+            await self.lightrag.doc_status.upsert(
+                {
+                    doc_id: {
+                        **current_doc_status,  # Keep existing fields
+                        "chunks_list": updated_chunks_list,  # Integrated chunks list
+                        "chunks_count": updated_chunks_count,  # Updated total count
+                        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                     }
-                )
+                }
+            )
 
-                # Ensure doc_status update is persisted to disk
-                await self.lightrag.doc_status.index_done_callback()
+            # Ensure doc_status update is persisted to disk
+            await self.lightrag.doc_status.index_done_callback()
 
-                self.logger.info(
-                    f"Updated doc_status: added {len(chunk_ids)} multimodal chunks to standard chunks_list "
-                    f"(total chunks: {updated_chunks_count})"
-                )
+            self.logger.info(
+                f"Updated doc_status: added {len(new_chunk_ids)} multimodal chunks to standard chunks_list "
+                f"(total chunks: {updated_chunks_count})"
+            )
 
         except Exception as e:
             self.logger.warning(

--- a/tests/test_multimodal_chunks_list_merge.py
+++ b/tests/test_multimodal_chunks_list_merge.py
@@ -1,0 +1,147 @@
+"""Tests for merging multimodal chunk ids into doc_status chunks_list (#332).
+
+The merge helper must tolerate reprocessing (content-hashed chunk ids come
+back identical, so a blind append duplicates them) and must surface — not
+silently swallow — the case where the doc_status record is absent.
+"""
+
+from types import SimpleNamespace
+from pathlib import Path
+import asyncio
+import sys
+import types
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.warnings = []
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, message, *args, **kwargs):
+        self.warnings.append(message)
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+def _install_minimal_lightrag_stubs():
+    fake_lightrag = types.ModuleType("lightrag")
+    fake_lightrag.LightRAG = object
+    fake_lightrag_utils = types.ModuleType("lightrag.utils")
+    fake_lightrag_utils.compute_mdhash_id = lambda content, prefix="": f"{prefix}fake"
+    fake_lightrag_utils.get_env_value = (
+        lambda key, default=None, value_type=str: default
+    )
+    fake_lightrag_utils.logger = RecordingLogger()
+    sys.modules["lightrag"] = fake_lightrag
+    sys.modules["lightrag.utils"] = fake_lightrag_utils
+
+    fake_raganything = types.ModuleType("raganything")
+    fake_raganything.__path__ = [
+        str(Path(__file__).resolve().parents[1] / "raganything")
+    ]
+    sys.modules["raganything"] = fake_raganything
+
+
+try:
+    from raganything.processor import ProcessorMixin
+except ModuleNotFoundError as exc:
+    if exc.name != "lightrag":
+        raise
+    for module_name in list(sys.modules):
+        if module_name == "raganything" or module_name.startswith("raganything."):
+            sys.modules.pop(module_name, None)
+    _install_minimal_lightrag_stubs()
+    from raganything.processor import ProcessorMixin  # noqa: E402
+
+
+class FakeDocStatus:
+    def __init__(self):
+        self.records = {}
+
+    async def get_by_id(self, doc_id):
+        return self.records.get(doc_id)
+
+    async def upsert(self, payload):
+        self.records.update(payload)
+
+    async def index_done_callback(self):
+        pass
+
+
+class DummyProcessor(ProcessorMixin):
+    def __init__(self):
+        self.lightrag = SimpleNamespace(doc_status=FakeDocStatus())
+        self.logger = RecordingLogger()
+        self.config = SimpleNamespace(use_full_path=False)
+
+
+def _record(chunks_list, chunks_count=None):
+    return {
+        "status": "processed",
+        "chunks_list": list(chunks_list),
+        "chunks_count": len(chunks_list) if chunks_count is None else chunks_count,
+        "file_path": "doc.pdf",
+    }
+
+
+def test_merge_appends_new_chunk_ids_and_updates_count():
+    processor = DummyProcessor()
+    processor.lightrag.doc_status.records["doc-1"] = _record(["chunk-a", "chunk-b"])
+
+    asyncio.run(
+        processor._update_doc_status_with_chunks_type_aware(
+            "doc-1", ["chunk-m1", "chunk-m2"]
+        )
+    )
+
+    record = processor.lightrag.doc_status.records["doc-1"]
+    assert record["chunks_list"] == ["chunk-a", "chunk-b", "chunk-m1", "chunk-m2"]
+    assert record["chunks_count"] == 4
+
+
+def test_reprocessing_same_ids_does_not_duplicate():
+    processor = DummyProcessor()
+    processor.lightrag.doc_status.records["doc-1"] = _record(["chunk-a"])
+
+    for _ in range(3):
+        asyncio.run(
+            processor._update_doc_status_with_chunks_type_aware("doc-1", ["chunk-m1"])
+        )
+
+    record = processor.lightrag.doc_status.records["doc-1"]
+    assert record["chunks_list"] == ["chunk-a", "chunk-m1"]
+    assert record["chunks_count"] == 2
+
+
+def test_partial_overlap_appends_only_missing_ids():
+    processor = DummyProcessor()
+    processor.lightrag.doc_status.records["doc-1"] = _record(["chunk-a", "chunk-m1"])
+
+    asyncio.run(
+        processor._update_doc_status_with_chunks_type_aware(
+            "doc-1", ["chunk-m1", "chunk-m2"]
+        )
+    )
+
+    record = processor.lightrag.doc_status.records["doc-1"]
+    assert record["chunks_list"] == ["chunk-a", "chunk-m1", "chunk-m2"]
+    assert record["chunks_count"] == 3
+
+
+def test_missing_record_warns_instead_of_silently_skipping():
+    processor = DummyProcessor()
+
+    asyncio.run(
+        processor._update_doc_status_with_chunks_type_aware("doc-absent", ["chunk-m1"])
+    )
+
+    assert processor.lightrag.doc_status.records == {}
+    assert any(
+        "doc-absent" in message for message in processor.logger.warnings
+    ), processor.logger.warnings


### PR DESCRIPTION
## Description

The multimodal `chunks_list` integration exists in both multimodal paths but has two soft spots, duplicated inline in each (see the correction posted on #332 — the integration itself works on current main; these are the residual defects):

1. **Blind append**: chunk ids are content-hashed, so reprocessing the same multimodal content produces identical ids and every re-run duplicates them in `chunks_list` (and inflates `chunks_count`). Relevant to retries and to the `force_multimodal_reprocess` flag proposed in #318.
2. **Silent no-op when the doc_status record is absent**: the `if current_doc_status:` guard has no else branch and the enclosing `except` only warns, so the multimodal chunks quietly end up missing from `chunks_list` — every consumer that enumerates a document's chunks from the record (deletion, audits, exporters) then orphans them with no trace.

## Related Issues

Refs #332 (re-scoped per my comment there). Related: #318.

## Changes Made

- `_update_doc_status_with_chunks_type_aware` now merges instead of appending (only ids not already listed are added; counts increment by the newly added ids only) and logs a warning when the doc_status record is missing instead of silently skipping.
- The individual multimodal path delegates to that helper instead of carrying its own inline copy of the same logic.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Tests: `tests/test_multimodal_chunks_list_merge.py` (4 cases: merge appends and updates count; three re-runs do not duplicate; partial overlap appends only missing ids; absent record warns and writes nothing). Mutation-verified: removing the dedup fails two tests.
- Full suite: 239 passed. Lint: `ruff==0.6.4 check --ignore=E402` and `ruff format` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
