### PR TITLE
feat(processor): opt-in page provenance for text chunks via LightRAG's sidecar pipeline (fixes #330)

### DIFF
--- a/raganything/config.py
+++ b/raganything/config.py
@@ -51,6 +51,16 @@ class RAGAnythingConfig:
     )
     """Enable equation content processing."""
 
+    preserve_page_provenance: bool = field(
+        default=get_env_value("PRESERVE_PAGE_PROVENANCE", False, bool)
+    )
+    """Insert text through LightRAG's sidecar pipeline so text chunks keep
+    block-level page provenance (``sidecar.refs`` joinable to page numbers
+    and bounding boxes — see issue #330). Requires a lightrag-hku build with
+    the sidecar subsystem and changes how text is chunked (paragraph-semantic
+    instead of fixed-token); falls back to plain insertion when unavailable
+    or when a custom ``split_by_character`` is requested."""
+
     # Batch Processing Configuration
     # ---
     max_concurrent_files: int = field(

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1749,14 +1749,54 @@ class ProcessorMixin:
                         doc_id=doc_id,
                     )
                 insert_start = time.time()
-                await insert_text_content(
-                    self.lightrag,
-                    input=text_content,
-                    file_paths=file_name,
-                    split_by_character=split_by_character,
-                    split_by_character_only=split_by_character_only,
-                    ids=doc_id,
-                )
+                inserted_via_sidecar = False
+                # Page-provenance path (#330): route the text through
+                # LightRAG's sidecar pipeline so chunks keep block-level page
+                # positions. Only when opted in, no custom split is requested
+                # (the P chunker owns splitting), and the installed lightrag
+                # ships the sidecar subsystem; any failure falls back to the
+                # plain insertion below.
+                if (
+                    getattr(self.config, "preserve_page_provenance", False)
+                    and split_by_character is None
+                ):
+                    from raganything.sidecar_ingest import (
+                        insert_text_with_sidecar,
+                        sidecar_available,
+                    )
+
+                    if sidecar_available():
+                        try:
+                            await insert_text_with_sidecar(
+                                self.lightrag,
+                                content_list=content_list,
+                                doc_id=doc_id,
+                                file_name=file_name,
+                                document_name=Path(file_path).name,
+                                sidecar_parent_dir=output_dir,
+                            )
+                            inserted_via_sidecar = True
+                        except Exception as sidecar_exc:
+                            self.logger.warning(
+                                "Sidecar insertion failed for "
+                                f"{file_path} ({sidecar_exc}); falling back "
+                                "to plain text insertion"
+                            )
+                    else:
+                        self.logger.info(
+                            "preserve_page_provenance is set but the "
+                            "installed lightrag lacks the sidecar pipeline; "
+                            "using plain text insertion"
+                        )
+                if not inserted_via_sidecar:
+                    await insert_text_content(
+                        self.lightrag,
+                        input=text_content,
+                        file_paths=file_name,
+                        split_by_character=split_by_character,
+                        split_by_character_only=split_by_character_only,
+                        ids=doc_id,
+                    )
                 await self._upsert_doc_status(
                     doc_id,
                     file_name,

--- a/raganything/sidecar_ingest.py
+++ b/raganything/sidecar_ingest.py
@@ -1,0 +1,176 @@
+"""Sidecar-backed text insertion: page provenance for text chunks (#330).
+
+``separate_content`` joins every text block into one string before LightRAG
+chunks it, so MinerU's per-block ``page_idx`` never reaches text chunks —
+page-anchored citations, reader jump-to-page and page-based figure
+association are unbuildable for exactly the chunks that carry the bulk of a
+document.
+
+LightRAG already ships the machinery that preserves this: parser adapters
+emit an IR whose blocks carry positions, ``write_sidecar`` persists it as a
+``*.parsed/`` directory, and the paragraph-semantic ("P") chunker records
+each chunk's source blocks as ``sidecar.refs`` — joinable back to page
+numbers and bounding boxes. Documents parsed by RAG-Anything bypass all of
+it because they are inserted as one raw string.
+
+This module routes RAG-Anything's own MinerU parse through that pipeline:
+
+    content_list (text blocks only)
+      → MinerUIRBuilder.normalize_from_workdir   (LightRAG's own adapter)
+      → write_sidecar                            (LightRAG's own writer)
+      → apipeline_enqueue_documents(process_options="P")
+      → full_docs row marked parse_format="lightrag" + sidecar_location
+      → pipeline dispatches by format to ReuseParser
+      → P chunker consumes blocks.jsonl → chunks carry sidecar.refs
+
+Multimodal items (images/tables/equations) are excluded from the IR: the
+modal processors own them, exactly as on the plain-insertion path, and their
+chunks already carry ``page_idx`` one-to-one.
+
+Requires a lightrag-hku build with the sidecar subsystem; callers check
+:func:`sidecar_available` and fall back to plain insertion otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+from lightrag.utils import logger
+
+
+def sidecar_available() -> bool:
+    """True when the installed lightrag build ships the sidecar pipeline."""
+    try:
+        from lightrag.parser.external.mineru.ir_builder import (  # noqa: F401
+            MinerUIRBuilder,
+        )
+        from lightrag.sidecar.writer import write_sidecar  # noqa: F401
+        from lightrag.utils_pipeline import (  # noqa: F401
+            make_lightrag_doc_content,
+            sidecar_uri_for,
+        )
+    except ImportError:
+        return False
+    return True
+
+
+def text_only_content_list(
+    content_list: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Keep only the text blocks, mirroring ``separate_content``'s split.
+
+    Everything non-text goes to the modal processors on both insertion
+    paths; feeding it to the IR builder as well would put tables/equations
+    into the text chunks a second time.
+    """
+    return [
+        item
+        for item in content_list
+        if item.get("type") == "text" and str(item.get("text") or "").strip()
+    ]
+
+
+async def insert_text_with_sidecar(
+    lightrag,
+    *,
+    content_list: List[Dict[str, Any]],
+    doc_id: str,
+    file_name: str,
+    document_name: str,
+    sidecar_parent_dir: str | Path,
+) -> str:
+    """Insert a document's text through LightRAG's sidecar pipeline.
+
+    Args:
+        lightrag: Initialized LightRAG instance.
+        content_list: Full MinerU content list; non-text items are filtered
+            out here (the modal processors own them).
+        doc_id: Content-based ``doc-<md5>`` id (also seeds sidecar block ids).
+        file_name: Citation file reference (``_get_file_reference`` output).
+        document_name: Original file name (e.g. ``report.pdf``) recorded in
+            the sidecar meta.
+        sidecar_parent_dir: Directory the ``<stem>.parsed/`` sidecar is
+            written under; must outlive the document (chunk provenance
+            resolves against it).
+
+    Returns:
+        ``"inserted"`` or ``"duplicate"`` (content already known to LightRAG
+        — same silent-skip semantics as ``ainsert``).
+
+    Raises:
+        Exception: any failure before the enqueue step; the caller is
+        expected to fall back to plain text insertion.
+    """
+    from lightrag.parser.external.mineru.ir_builder import MinerUIRBuilder
+    from lightrag.sidecar.writer import write_sidecar
+    from lightrag.utils_pipeline import (
+        make_lightrag_doc_content,
+        sidecar_uri_for,
+    )
+
+    text_items = text_only_content_list(content_list)
+    if not text_items:
+        return "duplicate"  # nothing textual to insert; caller's gate should
+        # have caught this, but never enqueue an empty document.
+
+    # The builder's public contract is a directory holding content_list.json;
+    # no assets are needed for text-only input.
+    with tempfile.TemporaryDirectory(prefix="ra_sidecar_") as tmp:
+        raw_dir = Path(tmp)
+        (raw_dir / "content_list.json").write_text(
+            json.dumps(text_items, ensure_ascii=False), encoding="utf-8"
+        )
+        ir = MinerUIRBuilder().normalize_from_workdir(
+            raw_dir, document_name=document_name
+        )
+
+    parsed_dir = Path(sidecar_parent_dir) / f"{Path(document_name).stem}.parsed"
+    parsed_data = write_sidecar(
+        ir, parsed_dir=parsed_dir, doc_id=doc_id, engine="mineru"
+    )
+    merged_text = parsed_data["content"]
+
+    # "P" selects the paragraph-semantic chunker — the only strategy that
+    # consumes blocks.jsonl and records per-chunk block refs; the default
+    # fixed-token chunker ignores the sidecar entirely.
+    await lightrag.apipeline_enqueue_documents(
+        input=[merged_text],
+        ids=[doc_id],
+        file_paths=[file_name],
+        process_options=["P"],
+    )
+
+    # Enqueue skipping the doc (content-hash duplicate) leaves no doc_status
+    # row; forging full_docs for a skipped document would strand an orphan
+    # record, so mirror ainsert's silent-skip semantics instead.
+    if not await lightrag.doc_status.get_by_id(doc_id):
+        logger.info(
+            f"Sidecar insertion: {document_name} already known to LightRAG "
+            f"({doc_id}); skipping"
+        )
+        return "duplicate"
+
+    # MERGE into the enqueued full_docs row, never replace it: enqueue stores
+    # process_options there and the chunking stage reads them back — a
+    # wholesale overwrite silently reverts the document to the default
+    # fixed-token chunker.
+    existing = await lightrag.full_docs.get_by_id(doc_id) or {}
+    await lightrag.full_docs.upsert(
+        {
+            doc_id: {
+                **existing,
+                "content": make_lightrag_doc_content(merged_text),
+                "file_path": file_name,
+                "parse_format": "lightrag",
+                "sidecar_location": sidecar_uri_for(parsed_dir),
+                "parse_engine": "mineru",
+            }
+        }
+    )
+    await lightrag.full_docs.index_done_callback()
+
+    await lightrag.apipeline_process_enqueue_documents()
+    return "inserted"

--- a/tests/test_sidecar_provenance.py
+++ b/tests/test_sidecar_provenance.py
@@ -1,0 +1,307 @@
+"""Tests for sidecar-backed text insertion (page provenance, issue #330).
+
+The real ``write_sidecar``/``MinerUIRBuilder`` from lightrag are exercised
+(skipped when the installed lightrag lacks the sidecar subsystem); LightRAG
+itself is a recording fake so the enqueue/merge contract is pinned without a
+live pipeline.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from raganything.sidecar_ingest import (  # noqa: E402
+    insert_text_with_sidecar,
+    sidecar_available,
+    text_only_content_list,
+)
+
+requires_sidecar = pytest.mark.skipif(
+    not sidecar_available(),
+    reason="installed lightrag lacks the sidecar subsystem",
+)
+
+
+CONTENT_LIST = [
+    {"type": "text", "text": "# Report Title", "text_level": 1, "page_idx": 0},
+    {"type": "text", "text": "First page prose.", "page_idx": 0},
+    {"type": "image", "img_path": "images/x.jpg", "page_idx": 1},
+    {"type": "table", "table_body": "<table></table>", "page_idx": 1},
+    {"type": "text", "text": "Second page prose.", "page_idx": 1},
+    {"type": "text", "text": "   ", "page_idx": 1},
+]
+
+
+def test_text_only_filter_mirrors_separate_content():
+    kept = text_only_content_list(CONTENT_LIST)
+    assert [i["text"] for i in kept] == [
+        "# Report Title",
+        "First page prose.",
+        "Second page prose.",
+    ]
+    assert all(i["type"] == "text" for i in kept)
+    # page_idx survives the filter — it is the whole point.
+    assert [i["page_idx"] for i in kept] == [0, 0, 1]
+
+
+class FakeKV:
+    def __init__(self):
+        self.records = {}
+
+    async def get_by_id(self, key):
+        return self.records.get(key)
+
+    async def upsert(self, payload):
+        self.records.update(payload)
+
+    async def index_done_callback(self):
+        pass
+
+
+class FakeLightRAG:
+    """Records the enqueue/process calls and simulates what enqueue persists
+    (full_docs row carrying process_options, plus a doc_status row)."""
+
+    def __init__(self, duplicate: bool = False):
+        self.duplicate = duplicate
+        self.enqueue_calls = []
+        self.process_calls = 0
+        self.full_docs = FakeKV()
+        self.doc_status = FakeKV()
+
+    async def apipeline_enqueue_documents(self, **kwargs):
+        self.enqueue_calls.append(kwargs)
+        if self.duplicate:
+            return "track-dup"
+        doc_id = kwargs["ids"][0]
+        await self.full_docs.upsert(
+            {
+                doc_id: {
+                    "content": kwargs["input"][0],
+                    "file_path": kwargs["file_paths"][0],
+                    "process_options": kwargs["process_options"][0],
+                }
+            }
+        )
+        await self.doc_status.upsert({doc_id: {"status": "pending"}})
+        return "track-1"
+
+    async def apipeline_process_enqueue_documents(self):
+        self.process_calls += 1
+
+
+DOC_ID = "doc-0123456789abcdef0123456789abcdef"
+
+
+@requires_sidecar
+def test_insert_writes_sidecar_and_merges_full_docs(tmp_path):
+    rag = FakeLightRAG()
+
+    result = asyncio.run(
+        insert_text_with_sidecar(
+            rag,
+            content_list=CONTENT_LIST,
+            doc_id=DOC_ID,
+            file_name="report.pdf",
+            document_name="report.pdf",
+            sidecar_parent_dir=tmp_path,
+        )
+    )
+
+    assert result == "inserted"
+    assert rag.process_calls == 1
+
+    # Enqueue selected the paragraph-semantic chunker.
+    (enqueue,) = rag.enqueue_calls
+    assert enqueue["ids"] == [DOC_ID]
+    assert enqueue["process_options"] == ["P"]
+
+    # The sidecar exists and its blocks carry page positions.
+    blocks_file = next((tmp_path / "report.parsed").glob("*.blocks.jsonl"))
+    rows = [json.loads(line) for line in blocks_file.open(encoding="utf-8")]
+    pages = {
+        pos.get("anchor")
+        for row in rows
+        for pos in row.get("positions") or []
+        if pos.get("type") == "bbox"
+    }
+    assert pages, "sidecar blocks carry no page positions"
+    block_rows = [r for r in rows if r.get("blockid")]
+    assert block_rows, "sidecar has no blockid rows"
+
+    # full_docs was MERGED: enqueue's process_options survives alongside the
+    # forged lightrag-format fields.
+    row = rag.full_docs.records[DOC_ID]
+    assert row["process_options"] == "P"
+    assert row["parse_format"] == "lightrag"
+    assert row["sidecar_location"].startswith("file://")
+    assert row["sidecar_location"].endswith(".parsed/")
+    assert row["content"].startswith("{{LRdoc}}")
+
+
+@requires_sidecar
+def test_duplicate_content_is_skipped_without_forging_state(tmp_path):
+    rag = FakeLightRAG(duplicate=True)
+
+    result = asyncio.run(
+        insert_text_with_sidecar(
+            rag,
+            content_list=CONTENT_LIST,
+            doc_id=DOC_ID,
+            file_name="report.pdf",
+            document_name="report.pdf",
+            sidecar_parent_dir=tmp_path,
+        )
+    )
+
+    assert result == "duplicate"
+    assert rag.full_docs.records == {}
+    assert rag.process_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Processor wiring: opt-in flag routes to the sidecar helper, and every
+# non-happy path falls back to plain insertion.
+# ---------------------------------------------------------------------------
+
+from raganything.processor import ProcessorMixin  # noqa: E402
+
+
+class RecordingLightRAG(FakeKV):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+        self.doc_status = FakeKV()
+
+    async def ainsert(self, **kwargs):
+        self.events.append(("ainsert", kwargs["ids"]))
+        await self.doc_status.upsert(
+            {
+                kwargs["ids"]: {
+                    "status": "processed",
+                    "file_path": kwargs["file_paths"],
+                }
+            }
+        )
+
+
+class DummyProcessor(ProcessorMixin):
+    def __init__(self, *, provenance: bool):
+        self.events = []
+        self.lightrag = RecordingLightRAG(self.events)
+        self.logger = SimpleNamespace(
+            info=lambda *a, **k: None,
+            warning=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+            debug=lambda *a, **k: None,
+        )
+        self.config = SimpleNamespace(
+            content_format="mineru",
+            display_content_stats=False,
+            parse_method="auto",
+            parser_output_dir="./output",
+            use_full_path=False,
+            preserve_page_provenance=provenance,
+        )
+        self.callback_manager = None
+
+    async def _ensure_lightrag_initialized(self):
+        return {"success": True}
+
+    async def parse_document(
+        self, file_path, output_dir, parse_method, display_stats, **kwargs
+    ):
+        return (
+            [{"type": "text", "text": "prose on page three", "page_idx": 3}],
+            DOC_ID,
+        )
+
+    async def _process_multimodal_content(self, multimodal_items, file_ref, doc_id):
+        self.events.append(("multimodal", doc_id))
+
+
+def _run(processor, **kwargs):
+    return asyncio.run(processor.process_document_complete("/tmp/report.pdf", **kwargs))
+
+
+def test_processor_routes_to_sidecar_when_opted_in(monkeypatch, tmp_path):
+    import raganything.sidecar_ingest as si
+
+    calls = []
+
+    async def fake_insert(lightrag, **kwargs):
+        calls.append(kwargs)
+        await lightrag.doc_status.upsert({kwargs["doc_id"]: {"status": "processed"}})
+        return "inserted"
+
+    monkeypatch.setattr(si, "insert_text_with_sidecar", fake_insert)
+    monkeypatch.setattr(si, "sidecar_available", lambda: True)
+
+    processor = DummyProcessor(provenance=True)
+    _run(processor, output_dir=str(tmp_path))
+
+    assert len(calls) == 1
+    assert calls[0]["doc_id"] == DOC_ID
+    assert calls[0]["document_name"] == "report.pdf"
+    assert ("ainsert", DOC_ID) not in processor.events
+
+
+def test_processor_falls_back_when_sidecar_raises(monkeypatch, tmp_path):
+    import raganything.sidecar_ingest as si
+
+    async def broken_insert(lightrag, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(si, "insert_text_with_sidecar", broken_insert)
+    monkeypatch.setattr(si, "sidecar_available", lambda: True)
+
+    processor = DummyProcessor(provenance=True)
+    _run(processor, output_dir=str(tmp_path))
+
+    assert ("ainsert", DOC_ID) in processor.events
+
+
+def test_processor_falls_back_when_sidecar_unavailable(monkeypatch, tmp_path):
+    import raganything.sidecar_ingest as si
+
+    monkeypatch.setattr(si, "sidecar_available", lambda: False)
+
+    processor = DummyProcessor(provenance=True)
+    _run(processor, output_dir=str(tmp_path))
+
+    assert ("ainsert", DOC_ID) in processor.events
+
+
+def test_custom_split_bypasses_sidecar(monkeypatch, tmp_path):
+    import raganything.sidecar_ingest as si
+
+    async def fake_insert(lightrag, **kwargs):
+        raise AssertionError("sidecar path must not run with a custom split")
+
+    monkeypatch.setattr(si, "insert_text_with_sidecar", fake_insert)
+    monkeypatch.setattr(si, "sidecar_available", lambda: True)
+
+    processor = DummyProcessor(provenance=True)
+    _run(processor, output_dir=str(tmp_path), split_by_character="\n")
+
+    assert ("ainsert", DOC_ID) in processor.events
+
+
+def test_flag_off_keeps_plain_insertion(monkeypatch, tmp_path):
+    import raganything.sidecar_ingest as si
+
+    async def fake_insert(lightrag, **kwargs):
+        raise AssertionError("sidecar path must not run when flag is off")
+
+    monkeypatch.setattr(si, "insert_text_with_sidecar", fake_insert)
+
+    processor = DummyProcessor(provenance=False)
+    _run(processor, output_dir=str(tmp_path))
+
+    assert ("ainsert", DOC_ID) in processor.events


### PR DESCRIPTION
## Description

`separate_content` joins every text block into one string before LightRAG chunks it, so MinerU's per-block `page_idx` never reaches text chunks (#330) — measured on a mixed corpus: all 128 multimodal chunks carried a `page_idx`, all 57 text chunks carried none. Page-anchored citations, reader jump-to-page and page-based figure association are unbuildable for exactly the chunks that carry the bulk of a document.

Rather than inventing a new provenance mechanism, this PR routes RAG-Anything's own MinerU parse through the provenance pipeline **LightRAG already ships**: engine adapters emit an IR whose blocks carry positions (page + bbox), `write_sidecar` persists it, and the paragraph-semantic chunker records each chunk's source blocks as `sidecar.refs` — joinable back to page numbers and bounding boxes. RAG-Anything documents currently bypass all of it because they are inserted as one raw string.

```
content_list (text blocks only)
  → MinerUIRBuilder.normalize_from_workdir   (LightRAG's own adapter)
  → write_sidecar                            (LightRAG's own writer)
  → apipeline_enqueue_documents(process_options="P")
  → full_docs row marked parse_format="lightrag" + sidecar_location
  → pipeline dispatches by format to ReuseParser
  → P chunker consumes blocks.jsonl → chunks carry sidecar.refs
```

Verified end to end on a real 61-page slide deck before wiring: **16/16 text chunks carried block refs resolving to page positions** (multi-block chunks correctly resolve to page ranges, e.g. `pages=[2,3,4,5,6]`).

## Related Issues

Fixes #330. Aligns with the direction of HKUDS/LightRAG#3081 (page-level positions in LightRAG's own MinerU path).

## Changes Made

- New `raganything/sidecar_ingest.py`: `sidecar_available()` (feature detection), `text_only_content_list()` (mirrors `separate_content`'s split — multimodal items stay with the modal processors exactly as before; their chunks already carry `page_idx` one-to-one), and `insert_text_with_sidecar()` (the pipeline above, with `ainsert`-equivalent duplicate-skip semantics).
- `process_document_complete` Step 3 routes through it when opted in; any failure falls back to plain insertion.
- New config flag `preserve_page_provenance` (`PRESERVE_PAGE_PROVENANCE`, **default off**) — opt-in because the chunking strategy changes from fixed-token to paragraph-semantic. Also bypassed when a custom `split_by_character` is requested (the P chunker owns splitting) or the installed lightrag predates the sidecar subsystem.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Tests: `tests/test_sidecar_provenance.py` (8 cases): the text-only filter; real `MinerUIRBuilder`+`write_sidecar` against a recording fake LightRAG asserting the enqueue/merge contract and that sidecar blocks carry page positions (skipped gracefully when the installed lightrag lacks the sidecar subsystem); duplicate-skip without forging state; processor wiring (opt-in routes, failure/unavailable/custom-split/flag-off all fall back to plain insertion).
- Two contracts are mutation-tested, each learned from a failed integration run: the full_docs update must **merge** (enqueue stores `process_options` there; replacing the row silently reverts the document to the fixed-token chunker), and enqueue must select `"P"` (the default chunker ignores the sidecar).
- Full suite: 243 passed.
- Lint: `ruff==0.6.4 check --ignore=E402` and `ruff format` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
