### PR TITLE
build(deps): require mineru[core]>=3.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "huggingface_hub",
     "lightrag-hku<1.5",
-    "mineru[core]",
+    "mineru[core]>=3.4.1",
     "tqdm",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ huggingface_hub
 # LightRAG packages
 lightrag-hku
 # MinerU 2.0 packages (replaces magic-pdf) - handles PDF parsing with multiple backends
-mineru[core]
+# >=3.4.1: earlier versions iterate pdftext's PageChars return value directly and
+# crash with "TypeError: 'PageChars' object is not iterable" against pdftext>=0.7
+mineru[core]>=3.4.1
 # Progress bars for batch processing
 tqdm
 # Note: Optional dependencies are now defined in setup.py extras_require:


### PR DESCRIPTION
## Description

`mineru[core]` is unconstrained in both `pyproject.toml` and `requirements.txt`, so a fresh install resolves to whatever MinerU version pip picks. Paired with `pdftext>=0.7` that can land on a combination which crashes on every Office document.

pdftext 0.7.0 changed character extraction to return a `PageChars` object; MinerU <= 3.4.0 iterates that value directly in `_deduplicate_near_identical_chars`, raising `TypeError: 'PageChars' object is not iterable`. MinerU 3.4.1 added the compatibility shims and constrained the dependency to `pdftext>=0.6.3,<0.8.0` (opendatalab/MinerU#5215, opendatalab/MinerU#5218).

#321 (just merged) makes that failure self-diagnosing when it happens. This lower bound stops fresh installs from reaching it at all — the two are complementary, not alternatives.

## Related Issues

Refs #304, #321.

## Changes Made

- `pyproject.toml`: `mineru[core]` → `mineru[core]>=3.4.1`
- `requirements.txt`: same, with a comment recording why the bound exists

3.4.1 is available on PyPI (current latest is 3.4.4), so the bound does not strand anyone on an unreleased version. `setup.py:read_requirements()` filters `#` lines, so the added comment does not reach the dependency list — verified it still parses to `['huggingface_hub', 'lightrag-hku', 'mineru[core]>=3.4.1', 'tqdm']`.

## Checklist

- [x] Changes tested locally
- [x] Unit tests added (n/a — dependency metadata only)

## Tests

- `pytest tests/ -q` → 298 passed
- `pre-commit run --all-files` → all 5 hooks pass (including `requirements-txt-fixer`, which leaves the file unchanged)