### PR TITLE
fix(modalprocessors): enforce three-value processor contract

### DIFF
--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -13,7 +13,7 @@ import re
 import json
 import time
 import base64
-from typing import Dict, Any, Tuple, List
+from typing import Dict, Any, Tuple, List, Optional
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -480,7 +480,7 @@ class BaseModalProcessor:
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], Optional[List[Any]]]:
         """Create entity and text chunk"""
         # Create chunk
         chunk_id = compute_mdhash_id(str(modal_chunk), prefix="chunk-")
@@ -980,7 +980,7 @@ class ImageModalProcessor(BaseModalProcessor):
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], Optional[List[Any]]]:
         """Process image content with context support"""
         try:
             # Generate description and entity info
@@ -1035,7 +1035,7 @@ class ImageModalProcessor(BaseModalProcessor):
                 "entity_type": "image",
                 "summary": f"Image content: {str(modal_content)[:100]}",
             }
-            return str(modal_content), fallback_entity
+            return str(modal_content), fallback_entity, None
 
     def _parse_response(
         self, response: str, entity_name: str = None
@@ -1180,7 +1180,7 @@ class TableModalProcessor(BaseModalProcessor):
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], Optional[List[Any]]]:
         """Process table content with context support"""
         try:
             # Generate description and entity info
@@ -1230,7 +1230,7 @@ class TableModalProcessor(BaseModalProcessor):
                 "entity_type": "table",
                 "summary": f"Table content: {str(modal_content)[:100]}",
             }
-            return str(modal_content), fallback_entity
+            return str(modal_content), fallback_entity, None
 
     def _parse_table_response(
         self, response: str, entity_name: str = None
@@ -1368,7 +1368,7 @@ class EquationModalProcessor(BaseModalProcessor):
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], Optional[List[Any]]]:
         """Process equation content with context support"""
         try:
             # Generate description and entity info
@@ -1413,7 +1413,7 @@ class EquationModalProcessor(BaseModalProcessor):
                 "entity_type": "equation",
                 "summary": f"Equation content: {str(modal_content)[:100]}",
             }
-            return str(modal_content), fallback_entity
+            return str(modal_content), fallback_entity, None
 
     def _parse_equation_response(
         self, response: str, entity_name: str = None
@@ -1542,7 +1542,7 @@ class GenericModalProcessor(BaseModalProcessor):
         batch_mode: bool = False,
         doc_id: str = None,
         chunk_order_index: int = 0,
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> Tuple[str, Dict[str, Any], Optional[List[Any]]]:
         """Process generic modal content with context support"""
         try:
             # Generate description and entity info
@@ -1576,7 +1576,7 @@ class GenericModalProcessor(BaseModalProcessor):
                 "entity_type": content_type,
                 "summary": f"{content_type} content: {str(modal_content)[:100]}",
             }
-            return str(modal_content), fallback_entity
+            return str(modal_content), fallback_entity, None
 
     def _parse_generic_response(
         self, response: str, entity_name: str = None, content_type: str = "content"

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -741,6 +741,8 @@ class ProcessorMixin:
         # Collect all chunk results for batch processing (similar to text content processing)
         all_chunk_results = []
         multimodal_chunk_ids = []
+        processing_failures = []
+        successful_count = 0
 
         # Get current text chunks count to set proper order indexes for multimodal chunks
         existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
@@ -758,50 +760,66 @@ class ProcessorMixin:
                 # Select appropriate processor
                 processor = get_processor_for_type(self.modal_processors, content_type)
 
-                if processor:
-                    # Prepare item info for context extraction
-                    item_info = {
-                        "page_idx": item.get("page_idx", 0),
-                        "index": item.get("_content_list_index", i),
-                        "type": content_type,
-                    }
-
-                    # Process content and get chunk results instead of immediately merging
-                    (
-                        enhanced_caption,
-                        entity_info,
-                        chunk_results,
-                    ) = await processor.process_multimodal_content(
-                        modal_content=item,
-                        content_type=content_type,
-                        file_path=file_name,
-                        item_info=item_info,  # Pass item info for context extraction
-                        batch_mode=True,
-                        doc_id=doc_id,  # Pass doc_id for proper association
-                        chunk_order_index=existing_chunks_count
-                        + i,  # Proper order index
+                if not processor:
+                    raise RuntimeError(
+                        f"No multimodal processor found for type: {content_type}"
                     )
 
-                    # Collect chunk results for batch processing
-                    all_chunk_results.extend(chunk_results)
+                # Prepare item info for context extraction
+                item_info = {
+                    "page_idx": item.get("page_idx", 0),
+                    "index": item.get("_content_list_index", i),
+                    "type": content_type,
+                }
 
-                    # Extract chunk ID from the entity_info (actual chunk_id created by processor)
-                    if entity_info and "chunk_id" in entity_info:
-                        chunk_id = entity_info["chunk_id"]
-                        multimodal_chunk_ids.append(chunk_id)
+                # Process content and get chunk results instead of immediately merging
+                (
+                    enhanced_caption,
+                    entity_info,
+                    chunk_results,
+                ) = await processor.process_multimodal_content(
+                    modal_content=item,
+                    content_type=content_type,
+                    file_path=file_name,
+                    item_info=item_info,  # Pass item info for context extraction
+                    batch_mode=True,
+                    doc_id=doc_id,  # Pass doc_id for proper association
+                    chunk_order_index=existing_chunks_count + i,  # Proper order index
+                )
 
-                    self.logger.info(
-                        f"{content_type} processing complete: {entity_info.get('entity_name', 'Unknown')}"
+                if chunk_results is None:
+                    raise RuntimeError(
+                        f"{content_type} processor returned no chunk results"
                     )
-                else:
-                    self.logger.warning(
-                        f"No suitable processor found for {content_type} type content"
-                    )
 
-            except Exception as e:
-                self.logger.error(f"Error processing multimodal content: {str(e)}")
+                # Collect chunk results for batch processing
+                all_chunk_results.extend(chunk_results)
+
+                # Extract chunk ID from the entity_info (actual chunk_id created by processor)
+                if entity_info and "chunk_id" in entity_info:
+                    chunk_id = entity_info["chunk_id"]
+                    multimodal_chunk_ids.append(chunk_id)
+
+                successful_count += 1
+                self.logger.info(
+                    f"{content_type} processing complete: {entity_info.get('entity_name', 'Unknown')}"
+                )
+
+            except Exception as exc:
+                processing_failures.append(exc)
+                self.logger.error("Error processing multimodal content item")
                 self.logger.debug("Exception details:", exc_info=True)
                 continue
+
+        if processing_failures:
+            self.logger.error(
+                "Incomplete individual multimodal batch: "
+                f"{successful_count}/{len(multimodal_items)} succeeded"
+            )
+            raise RuntimeError(
+                "Individual multimodal processing failed closed: "
+                f"{successful_count}/{len(multimodal_items)} succeeded"
+            ) from processing_failures[0]
 
         # Update doc_status to include multimodal chunks in the standard
         # chunks_list (same merge semantics as the batch type-aware path)

--- a/tests/test_multimodal_individual_fail_closed.py
+++ b/tests/test_multimodal_individual_fail_closed.py
@@ -1,0 +1,67 @@
+"""Regression tests for the individual multimodal fallback pipeline."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from raganything.processor import ProcessorMixin
+
+
+class RecordingLogger:
+    """Minimal logger for processor tests."""
+
+    def debug(self, *args, **kwargs):
+        del args, kwargs
+
+    def error(self, *args, **kwargs):
+        del args, kwargs
+
+    def info(self, *args, **kwargs):
+        del args, kwargs
+
+    def warning(self, *args, **kwargs):
+        del args, kwargs
+
+
+class FakeDocStatus:
+    """Return the text-processing status used by the fallback pipeline."""
+
+    async def get_by_id(self, doc_id):
+        del doc_id
+        return {"chunks_count": 0}
+
+
+class FallbackModalProcessor:
+    """Model the public three-value fallback contract."""
+
+    async def process_multimodal_content(self, **kwargs):
+        del kwargs
+        return "fallback", {"entity_type": "image"}, None
+
+
+class DummyProcessor(ProcessorMixin):
+    """Processor with only the dependencies needed by the regression test."""
+
+    def __init__(self):
+        self.config = SimpleNamespace(use_full_path=False)
+        self.lightrag = SimpleNamespace(doc_status=FakeDocStatus())
+        self.logger = RecordingLogger()
+        self.modal_processors = {"image": FallbackModalProcessor()}
+
+
+@pytest.mark.asyncio
+async def test_individual_fallback_rejects_missing_chunk_results_before_completion():
+    processor = DummyProcessor()
+    processor._update_doc_status_with_chunks_type_aware = AsyncMock()
+    processor._mark_multimodal_processing_complete = AsyncMock()
+
+    with pytest.raises(RuntimeError, match=r"0/1 succeeded") as exc_info:
+        await processor._process_multimodal_content_individual(
+            [{"type": "image"}], "source.pdf", "doc-1"
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "returned no chunk results" in str(exc_info.value.__cause__)
+    processor._update_doc_status_with_chunks_type_aware.assert_not_awaited()
+    processor._mark_multimodal_processing_complete.assert_not_awaited()

--- a/tests/test_multimodal_processor_contract.py
+++ b/tests/test_multimodal_processor_contract.py
@@ -1,0 +1,183 @@
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+@dataclass
+class FakeLightRAG:
+    text_chunks: object = None
+    chunks_vdb: object = None
+    entities_vdb: object = None
+    relationships_vdb: object = None
+    chunk_entity_relation_graph: object = None
+    embedding_func: object = None
+    llm_model_func: object = None
+    llm_response_cache: object = None
+    tokenizer: object = None
+    working_dir: str = "workdir"
+
+    def _build_global_config(self):
+        return {"working_dir": self.working_dir}
+
+
+@pytest.fixture
+def modalprocessors(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+
+    raganything_package = types.ModuleType("raganything")
+    raganything_package.__path__ = [str(repo_root / "raganything")]
+
+    lightrag_package = types.ModuleType("lightrag")
+
+    utils_module = types.ModuleType("lightrag.utils")
+    utils_module.logger = FakeLogger()
+    utils_module.compute_mdhash_id = lambda value, prefix="": f"{prefix}hash"
+
+    lightrag_module = types.ModuleType("lightrag.lightrag")
+    lightrag_module.LightRAG = FakeLightRAG
+
+    kg_package = types.ModuleType("lightrag.kg")
+    shared_storage_module = types.ModuleType("lightrag.kg.shared_storage")
+    shared_storage_module.get_namespace_data = lambda *args, **kwargs: {}
+    shared_storage_module.get_pipeline_status_lock = lambda *args, **kwargs: None
+
+    operate_module = types.ModuleType("lightrag.operate")
+    operate_module.extract_entities = None
+    operate_module.merge_nodes_and_edges = None
+
+    for module_name in [
+        "raganything",
+        "raganything.prompt",
+        "raganything.utils",
+        "raganything.modalprocessors",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    monkeypatch.setitem(sys.modules, "raganything", raganything_package)
+    monkeypatch.setitem(sys.modules, "lightrag", lightrag_package)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "lightrag.lightrag", lightrag_module)
+    monkeypatch.setitem(sys.modules, "lightrag.kg", kg_package)
+    monkeypatch.setitem(
+        sys.modules, "lightrag.kg.shared_storage", shared_storage_module
+    )
+    monkeypatch.setitem(sys.modules, "lightrag.operate", operate_module)
+
+    module = importlib.import_module("raganything.modalprocessors")
+    yield module
+
+    for module_name in [
+        "raganything.prompt",
+        "raganything.utils",
+        "raganything.modalprocessors",
+    ]:
+        sys.modules.pop(module_name, None)
+
+
+PROCESSOR_CASES = [
+    (
+        "ImageModalProcessor",
+        "image",
+        {"img_path": "image.png", "image_caption": ["caption"]},
+    ),
+    (
+        "TableModalProcessor",
+        "table",
+        {"table_body": "| a | b |", "table_caption": ["caption"]},
+    ),
+    (
+        "EquationModalProcessor",
+        "equation",
+        {"text": "x + y = 1", "text_format": "latex"},
+    ),
+    ("GenericModalProcessor", "chart", {"content": "chart data"}),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("processor_name", "content_type", "modal_content"), PROCESSOR_CASES
+)
+async def test_public_processor_success_returns_three_values(
+    modalprocessors,
+    processor_name,
+    content_type,
+    modal_content,
+):
+    processor_class = getattr(modalprocessors, processor_name)
+    processor = processor_class.__new__(processor_class)
+
+    entity_info = {
+        "entity_name": "entity",
+        "entity_type": content_type,
+        "summary": "summary",
+    }
+    expected = (
+        "stored content",
+        {"entity_name": "entity", "entity_type": content_type},
+        [("nodes", "edges")],
+    )
+
+    async def generate_description_only(*args, **kwargs):
+        return "enhanced caption", entity_info
+
+    async def create_entity_and_chunk(*args, **kwargs):
+        return expected
+
+    processor.generate_description_only = generate_description_only
+    processor._create_entity_and_chunk = create_entity_and_chunk
+
+    result = await processor.process_multimodal_content(
+        modal_content=modal_content,
+        content_type=content_type,
+    )
+
+    assert len(result) == 3
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("processor_name", "content_type", "modal_content"), PROCESSOR_CASES
+)
+async def test_public_processor_fallback_returns_three_values(
+    modalprocessors,
+    processor_name,
+    content_type,
+    modal_content,
+):
+    processor_class = getattr(modalprocessors, processor_name)
+    processor = processor_class.__new__(processor_class)
+
+    async def fail_description(*args, **kwargs):
+        raise RuntimeError("forced public fallback")
+
+    processor.generate_description_only = fail_description
+
+    result = await processor.process_multimodal_content(
+        modal_content=modal_content,
+        content_type=content_type,
+    )
+
+    assert len(result) == 3
+    assert result[0] == str(modal_content)
+    assert result[1]["entity_type"] == content_type
+    assert result[2] is None


### PR DESCRIPTION
## Summary

- make Image, Table, Equation, and Generic public processors return one stable three-value result
- return `None` as the third value on public fallback instead of exposing an ambiguous two-value result
- make the individual ingestion consumer reject missing chunk results and fail before status updates, graph merge, or completion marking
- treat missing modal processors as item failures rather than silently skipping them
- add success/fallback contract coverage for all four processor types and a production-boundary regression test

## Why

The public processors already return three values on success, but their fallback paths returned only two. Adding a third `None` value makes the public shape stable. The individual ingestion consumer must then treat that sentinel as a failed item; otherwise `extend(None)` is caught by its per-item handler and the document can still be marked complete with content missing.

## Validation

Validated at exact head `0d3798e7f4ebb71e43769ab4183da5f14ed7bb2c`.

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.:/home/ubuntu/deeptutor/.venv/lib/python3.12/site-packages \
  uv run --no-project --with pytest==8.4.1 --with pytest-asyncio==1.4.0 \
  python -m pytest -q
# 307 passed

PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.:/home/ubuntu/deeptutor/.venv/lib/python3.12/site-packages \
  uv run --no-project --with pytest==8.4.1 --with pytest-asyncio==1.4.0 \
  python -m pytest \
  tests/test_multimodal_processor_contract.py \
  tests/test_multimodal_individual_fail_closed.py -q
# 9 passed

uvx --from ruff==0.6.4 ruff check \
  raganything/processor.py \
  tests/test_multimodal_processor_contract.py \
  tests/test_multimodal_individual_fail_closed.py
# All checks passed

uvx --from ruff==0.6.4 ruff format --check \
  raganything/processor.py \
  tests/test_multimodal_processor_contract.py \
  tests/test_multimodal_individual_fail_closed.py
# 3 files already formatted
```

The pull request changes `raganything/modalprocessors.py`, `raganything/processor.py`, `tests/test_multimodal_processor_contract.py`, and `tests/test_multimodal_individual_fail_closed.py`.
