### PR TITLE
chore(docs): drop the Star History section from both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,22 +1265,6 @@ If you find RAG-Anything useful in your research, please cite our paper:
 
 ---
 
-## ⭐ Star History
-
-*Community Growth Trajectory*
-
-<div align="center">
-  <a href="https://star-history.com/#HKUDS/RAG-Anything&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=HKUDS/RAG-Anything&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=HKUDS/RAG-Anything&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=HKUDS/RAG-Anything&type=Date" style="border-radius: 15px; box-shadow: 0 0 30px rgba(0, 217, 255, 0.3);" />
-    </picture>
-  </a>
-</div>
-
----
-
 ## 🤝 Contribution
 
 *Join the Innovation*

--- a/README_zh.md
+++ b/README_zh.md
@@ -1207,22 +1207,6 @@ await rag.process_document_complete(
 
 ---
 
-## ⭐ Star History
-
-*社区增长轨迹*
-
-<div align="center">
-  <a href="https://star-history.com/#HKUDS/RAG-Anything&Date">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=HKUDS/RAG-Anything&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=HKUDS/RAG-Anything&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=HKUDS/RAG-Anything&type=Date" style="border-radius: 15px; box-shadow: 0 0 30px rgba(0, 217, 255, 0.3);" />
-    </picture>
-  </a>
-</div>
-
----
-
 ## 🤝 贡献者
 
 *加入创新*


### PR DESCRIPTION
## Description

GitHub's stargazer API rules changed, so the star-history chart is no longer something this project wants to depend on. Rather than repoint it at a third-party mirror, the section is removed outright from `README.md` and `README_zh.md`.

This supersedes #339, which proposed swapping both the chart's image source and its click-through target to `star-history.dera.page`, an unaffiliated domain. That PR's stated premise did not hold up — the current `api.star-history.com` endpoint still returns HTTP 200 with a valid 60 KB SVG — and pointing a README image and link at an unrelated third party is not a trade worth making.

## Changes Made

- Remove the `## ⭐ Star History` section (heading, caption, and `<picture>` block) plus one redundant `---` separator from `README.md`
- Same removal from `README_zh.md`

16 lines from each file, symmetric. No other content is touched, and no table of contents or anchor referenced the section.

## Checklist

- [x] Changes tested locally
- [x] Documentation updated (this is the documentation change)
- [x] Unit tests added (n/a — README only)

## Tests

- `pre-commit run --all-files` → all 5 hooks pass
- `grep` confirms no remaining `star-history` / `Star History` / `社区增长轨迹` references in either README