### PR TITLE
fix(processor): fail closed on incomplete multimodal ingestion

### DIFF
--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -974,60 +974,45 @@ class ImageModalProcessor(BaseModalProcessor):
         chunk_order_index: int = 0,
     ) -> Tuple[str, Dict[str, Any]]:
         """Process image content with context support"""
-        try:
-            # Generate description and entity info
-            enhanced_caption, entity_info = await self.generate_description_only(
-                modal_content, content_type, item_info, entity_name
-            )
+        enhanced_caption, entity_info = await self.generate_description_only(
+            modal_content, content_type, item_info, entity_name
+        )
 
-            # Build complete image content
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"description": modal_content}
-            else:
-                content_data = modal_content
+        if isinstance(modal_content, str):
+            try:
+                content_data = json.loads(modal_content)
+            except json.JSONDecodeError:
+                content_data = {"description": modal_content}
+        else:
+            content_data = modal_content
 
-            image_path = content_data.get("img_path", "")
-            captions = content_data.get(
-                "image_caption", content_data.get("img_caption", [])
-            )
-            footnotes = content_data.get(
-                "image_footnote", content_data.get("img_footnote", [])
-            )
-            section_path = content_data.get("_section_path", "")
-            neighbor_text = content_data.get("_neighbor_text", "")
+        image_path = content_data.get("img_path", "")
+        captions = content_data.get(
+            "image_caption", content_data.get("img_caption", [])
+        )
+        footnotes = content_data.get(
+            "image_footnote", content_data.get("img_footnote", [])
+        )
+        section_path = content_data.get("_section_path", "")
+        neighbor_text = content_data.get("_neighbor_text", "")
 
-            modal_chunk = PROMPTS["image_chunk"].format(
-                section_path=section_path if section_path else "None",
-                neighbor_text=neighbor_text if neighbor_text else "None",
-                image_path=image_path,
-                captions=", ".join(captions) if captions else "None",
-                footnotes=", ".join(footnotes) if footnotes else "None",
-                enhanced_caption=enhanced_caption,
-            )
+        modal_chunk = PROMPTS["image_chunk"].format(
+            section_path=section_path if section_path else "None",
+            neighbor_text=neighbor_text if neighbor_text else "None",
+            image_path=image_path,
+            captions=", ".join(captions) if captions else "None",
+            footnotes=", ".join(footnotes) if footnotes else "None",
+            enhanced_caption=enhanced_caption,
+        )
 
-            return await self._create_entity_and_chunk(
-                modal_chunk,
-                entity_info,
-                file_path,
-                batch_mode,
-                doc_id,
-                chunk_order_index,
-            )
-
-        except Exception as e:
-            logger.error(f"Error processing image content: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"image_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": "image",
-                "summary": f"Image content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+        return await self._create_entity_and_chunk(
+            modal_chunk,
+            entity_info,
+            file_path,
+            batch_mode,
+            doc_id,
+            chunk_order_index,
+        )
 
     def _parse_response(
         self, response: str, entity_name: str = None
@@ -1166,55 +1151,39 @@ class TableModalProcessor(BaseModalProcessor):
         chunk_order_index: int = 0,
     ) -> Tuple[str, Dict[str, Any]]:
         """Process table content with context support"""
-        try:
-            # Generate description and entity info
-            enhanced_caption, entity_info = await self.generate_description_only(
-                modal_content, content_type, item_info, entity_name
-            )
+        enhanced_caption, entity_info = await self.generate_description_only(
+            modal_content, content_type, item_info, entity_name
+        )
 
-            # Parse table content for building complete chunk
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"table_body": modal_content}
-            else:
-                content_data = modal_content
+        if isinstance(modal_content, str):
+            try:
+                content_data = json.loads(modal_content)
+            except json.JSONDecodeError:
+                content_data = {"table_body": modal_content}
+        else:
+            content_data = modal_content
 
-            table_img_path = content_data.get("img_path")
-            table_caption = normalize_caption_list(content_data.get("table_caption"))
-            table_body = format_table_body(get_table_body(content_data))
-            table_footnote = normalize_caption_list(content_data.get("table_footnote"))
+        table_img_path = content_data.get("img_path")
+        table_caption = normalize_caption_list(content_data.get("table_caption"))
+        table_body = format_table_body(get_table_body(content_data))
+        table_footnote = normalize_caption_list(content_data.get("table_footnote"))
 
-            # Build complete table content
-            modal_chunk = PROMPTS["table_chunk"].format(
-                table_img_path=table_img_path,
-                table_caption=", ".join(table_caption) if table_caption else "None",
-                table_body=table_body,
-                table_footnote=", ".join(table_footnote) if table_footnote else "None",
-                enhanced_caption=enhanced_caption,
-            )
+        modal_chunk = PROMPTS["table_chunk"].format(
+            table_img_path=table_img_path,
+            table_caption=", ".join(table_caption) if table_caption else "None",
+            table_body=table_body,
+            table_footnote=", ".join(table_footnote) if table_footnote else "None",
+            enhanced_caption=enhanced_caption,
+        )
 
-            return await self._create_entity_and_chunk(
-                modal_chunk,
-                entity_info,
-                file_path,
-                batch_mode,
-                doc_id,
-                chunk_order_index,
-            )
-
-        except Exception as e:
-            logger.error(f"Error processing table content: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"table_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": "table",
-                "summary": f"Table content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+        return await self._create_entity_and_chunk(
+            modal_chunk,
+            entity_info,
+            file_path,
+            batch_mode,
+            doc_id,
+            chunk_order_index,
+        )
 
     def _parse_table_response(
         self, response: str, entity_name: str = None
@@ -1346,50 +1315,34 @@ class EquationModalProcessor(BaseModalProcessor):
         chunk_order_index: int = 0,
     ) -> Tuple[str, Dict[str, Any]]:
         """Process equation content with context support"""
-        try:
-            # Generate description and entity info
-            enhanced_caption, entity_info = await self.generate_description_only(
-                modal_content, content_type, item_info, entity_name
-            )
+        enhanced_caption, entity_info = await self.generate_description_only(
+            modal_content, content_type, item_info, entity_name
+        )
 
-            # Parse equation content for building complete chunk
-            if isinstance(modal_content, str):
-                try:
-                    content_data = json.loads(modal_content)
-                except json.JSONDecodeError:
-                    content_data = {"equation": modal_content}
-            else:
-                content_data = modal_content
+        if isinstance(modal_content, str):
+            try:
+                content_data = json.loads(modal_content)
+            except json.JSONDecodeError:
+                content_data = {"equation": modal_content}
+        else:
+            content_data = modal_content
 
-            equation_text, equation_format = get_equation_text_and_format(content_data)
+        equation_text, equation_format = get_equation_text_and_format(content_data)
 
-            # Build complete equation content
-            modal_chunk = PROMPTS["equation_chunk"].format(
-                equation_text=equation_text,
-                equation_format=equation_format,
-                enhanced_caption=enhanced_caption,
-            )
+        modal_chunk = PROMPTS["equation_chunk"].format(
+            equation_text=equation_text,
+            equation_format=equation_format,
+            enhanced_caption=enhanced_caption,
+        )
 
-            return await self._create_entity_and_chunk(
-                modal_chunk,
-                entity_info,
-                file_path,
-                batch_mode,
-                doc_id,
-                chunk_order_index,
-            )
-
-        except Exception as e:
-            logger.error(f"Error processing equation content: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"equation_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": "equation",
-                "summary": f"Equation content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+        return await self._create_entity_and_chunk(
+            modal_chunk,
+            entity_info,
+            file_path,
+            batch_mode,
+            doc_id,
+            chunk_order_index,
+        )
 
     def _parse_equation_response(
         self, response: str, entity_name: str = None
@@ -1512,39 +1465,24 @@ class GenericModalProcessor(BaseModalProcessor):
         chunk_order_index: int = 0,
     ) -> Tuple[str, Dict[str, Any]]:
         """Process generic modal content with context support"""
-        try:
-            # Generate description and entity info
-            enhanced_caption, entity_info = await self.generate_description_only(
-                modal_content, content_type, item_info, entity_name
-            )
+        enhanced_caption, entity_info = await self.generate_description_only(
+            modal_content, content_type, item_info, entity_name
+        )
 
-            # Build complete content
-            modal_chunk = PROMPTS["generic_chunk"].format(
-                content_type=content_type.title(),
-                content=str(modal_content),
-                enhanced_caption=enhanced_caption,
-            )
+        modal_chunk = PROMPTS["generic_chunk"].format(
+            content_type=content_type.title(),
+            content=str(modal_content),
+            enhanced_caption=enhanced_caption,
+        )
 
-            return await self._create_entity_and_chunk(
-                modal_chunk,
-                entity_info,
-                file_path,
-                batch_mode,
-                doc_id,
-                chunk_order_index,
-            )
-
-        except Exception as e:
-            logger.error(f"Error processing {content_type} content: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"{content_type}_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": content_type,
-                "summary": f"{content_type} content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+        return await self._create_entity_and_chunk(
+            modal_chunk,
+            entity_info,
+            file_path,
+            batch_mode,
+            doc_id,
+            chunk_order_index,
+        )
 
     def _parse_generic_response(
         self, response: str, entity_name: str = None, content_type: str = "content"

--- a/raganything/modalprocessors.py
+++ b/raganything/modalprocessors.py
@@ -960,15 +960,7 @@ class ImageModalProcessor(BaseModalProcessor):
 
         except Exception as e:
             logger.error(f"Error generating image description: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"image_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": "image",
-                "summary": f"Image content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+            raise
 
     async def process_multimodal_content(
         self,
@@ -1160,15 +1152,7 @@ class TableModalProcessor(BaseModalProcessor):
 
         except Exception as e:
             logger.error(f"Error generating table description: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"table_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": "table",
-                "summary": f"Table content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+            raise
 
     async def process_multimodal_content(
         self,
@@ -1348,15 +1332,7 @@ class EquationModalProcessor(BaseModalProcessor):
 
         except Exception as e:
             logger.error(f"Error generating equation description: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"equation_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": "equation",
-                "summary": f"Equation content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+            raise
 
     async def process_multimodal_content(
         self,
@@ -1522,15 +1498,7 @@ class GenericModalProcessor(BaseModalProcessor):
 
         except Exception as e:
             logger.error(f"Error generating {content_type} description: {e}")
-            # Fallback processing
-            fallback_entity = {
-                "entity_name": entity_name
-                if entity_name
-                else f"{content_type}_{compute_mdhash_id(str(modal_content))}",
-                "entity_type": content_type,
-                "summary": f"{content_type} content: {str(modal_content)[:100]}",
-            }
-            return str(modal_content), fallback_entity
+            raise
 
     async def process_multimodal_content(
         self,

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -642,10 +642,9 @@ class ProcessorMixin:
         # Ensure LightRAG is initialized before accessing its storages
         init_result = await self._ensure_lightrag_initialized()
         if not init_result or not init_result.get("success"):
-            self.logger.error(
-                "LightRAG initialization failed; skipping multimodal processing"
+            raise RuntimeError(
+                "LightRAG initialization failed during multimodal processing"
             )
-            return
 
         # Check multimodal processing status - handle LightRAG's early DocStatus.PROCESSED marking
         try:
@@ -677,8 +676,8 @@ class ProcessorMixin:
                     return
 
         except Exception as e:
-            self.logger.debug(f"Error checking document status for {doc_id}: {e}")
-            # Continue with processing if cache check fails
+            self.logger.error(f"Error checking document status for {doc_id}: {e}")
+            raise
 
         # Use ProcessorMixin's own batch processing that can handle multiple content types
         log_message = "Starting multimodal content processing..."
@@ -715,14 +714,7 @@ class ProcessorMixin:
 
         except Exception as e:
             self.logger.error(f"Error in multimodal processing: {e}")
-            # Fallback to individual processing if batch processing fails
-            self.logger.warning("Falling back to individual multimodal processing")
-            await self._process_multimodal_content_individual(
-                multimodal_items, file_path, doc_id
-            )
-
-            # Mark multimodal content as processed even after fallback
-            await self._mark_multimodal_processing_complete(doc_id)
+            raise
 
     async def _process_multimodal_content_individual(
         self, multimodal_items: List[Dict[str, Any]], file_path: str, doc_id: str
@@ -864,14 +856,12 @@ class ProcessorMixin:
             self.logger.debug("No multimodal content to process")
             return
 
-        # Get existing chunks count for proper order indexing
-        try:
-            existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
-            existing_chunks_count = (
-                existing_doc_status.get("chunks_count", 0) if existing_doc_status else 0
-            )
-        except Exception:
-            existing_chunks_count = 0
+        # Get existing chunks count for proper order indexing. A status read
+        # failure must stop the pipeline instead of silently changing indexes.
+        existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
+        existing_chunks_count = (
+            existing_doc_status.get("chunks_count", 0) if existing_doc_status else 0
+        )
 
         # Use LightRAG's concurrency control
         semaphore = asyncio.Semaphore(getattr(self.lightrag, "max_parallel_insert", 2))
@@ -900,10 +890,9 @@ class ProcessorMixin:
                     )
 
                     if not processor:
-                        self.logger.warning(
-                            f"No processor found for type: {content_type}"
+                        raise ValueError(
+                            f"No multimodal processor found for type: {content_type}"
                         )
-                        return None
 
                     item_info = {
                         "page_idx": item.get("page_idx", 0),
@@ -922,18 +911,6 @@ class ProcessorMixin:
                         entity_name=None,  # Let LLM auto-generate
                     )
 
-                    # Update progress (non-blocking)
-                    async with progress_lock:
-                        completed_count += 1
-                        if (
-                            completed_count % max(1, total_items // 10) == 0
-                            or completed_count == total_items
-                        ):
-                            progress_percent = (completed_count / total_items) * 100
-                            self.logger.info(
-                                f"Multimodal chunk generation progress: {completed_count}/{total_items} ({progress_percent:.1f}%)"
-                            )
-
                     return {
                         "index": index,
                         "content_type": content_type,
@@ -945,9 +922,8 @@ class ProcessorMixin:
                         "processor": processor,  # Keep reference to the processor used
                         "file_path": file_path,  # Add file_path to the result
                     }
-
-                except Exception as e:
-                    # Update progress even on error (non-blocking)
+                finally:
+                    # Update progress for both successful and failed tasks.
                     async with progress_lock:
                         completed_count += 1
                         if (
@@ -959,11 +935,6 @@ class ProcessorMixin:
                                 f"Multimodal chunk generation progress: {completed_count}/{total_items} ({progress_percent:.1f}%)"
                             )
 
-                    self.logger.error(
-                        f"Error generating description for {content_type} item {index}: {e}"
-                    )
-                    return None
-
         # Process all items concurrently with correct processors
         tasks = [
             asyncio.create_task(
@@ -974,18 +945,22 @@ class ProcessorMixin:
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Filter successful results
-        multimodal_data_list = []
-        for result in results:
-            if isinstance(result, Exception):
-                self.logger.error(f"Task failed: {result}")
-                continue
-            if result is not None:
-                multimodal_data_list.append(result)
+        failures = [result for result in results if isinstance(result, Exception)]
+        multimodal_data_list = [
+            result for result in results if not isinstance(result, Exception)
+        ]
 
-        if not multimodal_data_list:
-            self.logger.warning("No valid multimodal descriptions generated")
-            return
+        if failures or len(multimodal_data_list) != total_items:
+            successful_count = len(multimodal_data_list)
+            self.logger.error(
+                "Incomplete multimodal description batch: "
+                f"{successful_count}/{total_items} succeeded"
+            )
+            first_failure = failures[0] if failures else None
+            raise RuntimeError(
+                "Multimodal description batch failed closed: "
+                f"{successful_count}/{total_items} succeeded"
+            ) from first_failure
 
         self.logger.info(
             f"Generated descriptions for {len(multimodal_data_list)}/{len(multimodal_items)} multimodal items using correct processors"
@@ -1011,11 +986,21 @@ class ProcessorMixin:
         chunk_results = await self._batch_extract_entities_lightrag_style_type_aware(
             lightrag_chunks
         )
+        if len(chunk_results) != len(lightrag_chunks):
+            raise RuntimeError(
+                "Multimodal entity extraction failed closed: "
+                f"{len(chunk_results)}/{len(lightrag_chunks)} chunks succeeded"
+            )
 
         # Stage 5: Add belongs_to relations (multimodal-specific)
         enhanced_chunk_results = await self._batch_add_belongs_to_relations_type_aware(
             chunk_results, multimodal_data_list
         )
+        if len(enhanced_chunk_results) != len(chunk_results):
+            raise RuntimeError(
+                "Multimodal relation enhancement failed closed: "
+                f"{len(enhanced_chunk_results)}/{len(chunk_results)} chunks succeeded"
+            )
 
         # Stage 6: Use LightRAG's batch merge
         await self._batch_merge_lightrag_style_type_aware(
@@ -1466,104 +1451,94 @@ class ProcessorMixin:
         self, doc_id: str, chunk_ids: List[str]
     ):
         """Merge multimodal chunk ids into the document's chunks_list."""
-        try:
-            # Get current document status
-            current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
+        # Get current document status
+        current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
 
-            if not current_doc_status:
-                # An absent record is a linkage failure worth surfacing:
-                # every consumer that enumerates the document's chunks via
-                # chunks_list will silently orphan these (#332).
-                self.logger.warning(
-                    f"doc_status record {doc_id} not found; "
-                    f"{len(chunk_ids)} multimodal chunk(s) will be missing "
-                    "from its chunks_list"
-                )
-                return
+        if not current_doc_status:
+            raise RuntimeError(
+                f"doc_status record {doc_id} not found; "
+                f"cannot link {len(chunk_ids)} multimodal chunk(s)"
+            )
 
-            existing_chunks_list = current_doc_status.get("chunks_list", [])
-            existing_chunks_count = current_doc_status.get("chunks_count", 0)
+        existing_chunks_list = current_doc_status.get("chunks_list", [])
+        existing_chunks_count = current_doc_status.get("chunks_count", 0)
 
-            # Merge rather than append: chunk ids are content-hashed, so
-            # reprocessing the same multimodal content produces the same ids
-            # and a blind append would duplicate them in chunks_list.
-            already_listed = set(existing_chunks_list)
-            new_chunk_ids = [cid for cid in chunk_ids if cid not in already_listed]
-            if not new_chunk_ids:
-                self.logger.debug(
-                    f"All {len(chunk_ids)} multimodal chunks already listed "
-                    f"in doc_status for {doc_id}"
-                )
-                return
+        # Merge rather than append: chunk ids are content-hashed, so
+        # reprocessing the same multimodal content produces the same ids
+        # and a blind append would duplicate them in chunks_list.
+        already_listed = set(existing_chunks_list)
+        new_chunk_ids = [cid for cid in chunk_ids if cid not in already_listed]
+        if not new_chunk_ids:
+            self.logger.debug(
+                f"All {len(chunk_ids)} multimodal chunks already listed "
+                f"in doc_status for {doc_id}"
+            )
+            return
 
-            updated_chunks_list = existing_chunks_list + new_chunk_ids
-            updated_chunks_count = existing_chunks_count + len(new_chunk_ids)
+        updated_chunks_list = existing_chunks_list + new_chunk_ids
+        updated_chunks_count = existing_chunks_count + len(new_chunk_ids)
 
-            # Update document status with integrated chunk list
-            await self.lightrag.doc_status.upsert(
-                {
-                    doc_id: {
-                        **current_doc_status,  # Keep existing fields
-                        "chunks_list": updated_chunks_list,  # Integrated chunks list
-                        "chunks_count": updated_chunks_count,  # Updated total count
-                        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
-                    }
+        # Update document status with integrated chunk list
+        await self.lightrag.doc_status.upsert(
+            {
+                doc_id: {
+                    **current_doc_status,  # Keep existing fields
+                    "chunks_list": updated_chunks_list,  # Integrated chunks list
+                    "chunks_count": updated_chunks_count,  # Updated total count
+                    "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
                 }
-            )
+            }
+        )
 
-            # Ensure doc_status update is persisted to disk
-            await self.lightrag.doc_status.index_done_callback()
+        # Ensure doc_status update is persisted to disk
+        await self.lightrag.doc_status.index_done_callback()
 
-            self.logger.info(
-                f"Updated doc_status: added {len(new_chunk_ids)} multimodal chunks to standard chunks_list "
-                f"(total chunks: {updated_chunks_count})"
-            )
-
-        except Exception as e:
-            self.logger.warning(
-                f"Error updating doc_status with multimodal chunks: {e}"
-            )
+        self.logger.info(
+            f"Updated doc_status: added {len(new_chunk_ids)} multimodal chunks to standard chunks_list "
+            f"(total chunks: {updated_chunks_count})"
+        )
 
     async def _mark_multimodal_processing_complete(self, doc_id: str):
         """Mark multimodal content processing as complete in the document status."""
-        try:
-            current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
-            if current_doc_status:
-                final_status = current_doc_status.get("status") or DocStatus.PROCESSED
-                if final_status != DocStatus.FAILED:
-                    final_status = DocStatus.PROCESSED
-                update_payload = {
-                    **current_doc_status,
-                    "status": final_status,
-                    "multimodal_processed": True,
-                    "updated_at": self._current_doc_status_timestamp(),
-                }
-                try:
-                    await self.lightrag.doc_status.upsert({doc_id: update_payload})
-                except Exception as exc:
-                    # Older LightRAG versions reject unknown doc_status fields such as
-                    # multimodal_processed. Fall back to a schema-compatible status-only
-                    # update so image-only and multimodal documents still complete.
-                    self.logger.debug(
-                        "Falling back to schema-compatible doc_status update for %s: %s",
-                        doc_id,
-                        exc,
-                    )
-                    fallback_payload = {
-                        **current_doc_status,
-                        "status": final_status,
-                        "updated_at": self._current_doc_status_timestamp(),
-                    }
-                    await self.lightrag.doc_status.upsert({doc_id: fallback_payload})
-                    await self._set_multimodal_status_record(doc_id, True)
-                await self.lightrag.doc_status.index_done_callback()
-                self.logger.debug(
-                    f"Marked multimodal content processing as complete for document {doc_id}"
-                )
-        except Exception as e:
-            self.logger.warning(
-                f"Error marking multimodal processing as complete for document {doc_id}: {e}"
+        current_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
+        if not current_doc_status:
+            raise RuntimeError(
+                f"doc_status record {doc_id} not found; cannot mark multimodal complete"
             )
+
+        final_status = current_doc_status.get("status") or DocStatus.PROCESSED
+        if final_status != DocStatus.FAILED:
+            final_status = DocStatus.PROCESSED
+        update_payload = {
+            **current_doc_status,
+            "status": final_status,
+            "multimodal_processed": True,
+            "updated_at": self._current_doc_status_timestamp(),
+        }
+        try:
+            await self.lightrag.doc_status.upsert({doc_id: update_payload})
+        except Exception as exc:
+            # Older LightRAG versions reject unknown doc_status fields such as
+            # multimodal_processed. Only that explicit schema mismatch is safe
+            # to route through the compatibility status cache.
+            if "multimodal_processed" not in str(exc):
+                raise
+            self.logger.debug(
+                "Falling back to schema-compatible doc_status update for %s: %s",
+                doc_id,
+                exc,
+            )
+            fallback_payload = {
+                **current_doc_status,
+                "status": final_status,
+                "updated_at": self._current_doc_status_timestamp(),
+            }
+            await self.lightrag.doc_status.upsert({doc_id: fallback_payload})
+            await self._set_multimodal_status_record(doc_id, True)
+        await self.lightrag.doc_status.index_done_callback()
+        self.logger.debug(
+            f"Marked multimodal content processing as complete for document {doc_id}"
+        )
 
     async def is_document_fully_processed(self, doc_id: str) -> bool:
         """

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -655,25 +655,20 @@ class ProcessorMixin:
                     doc_id, existing_doc_status
                 )
 
-                if multimodal_processed:
+                doc_status = existing_doc_status.get("status", "")
+                if doc_status == DocStatus.PROCESSED and multimodal_processed:
                     self.logger.info(
-                        f"Document {doc_id} multimodal content is already processed"
+                        f"Document {doc_id} is fully processed (text + multimodal)"
                     )
                     return
 
                 # Even if status is DocStatus.PROCESSED (text processing done),
                 # we still need to process multimodal content if not yet done
-                doc_status = existing_doc_status.get("status", "")
-                if doc_status == DocStatus.PROCESSED and not multimodal_processed:
+                if doc_status == DocStatus.PROCESSED:
                     self.logger.info(
                         f"Document {doc_id} text processing is complete, but multimodal content still needs processing"
                     )
                     # Continue with multimodal processing
-                elif doc_status == DocStatus.PROCESSED and multimodal_processed:
-                    self.logger.info(
-                        f"Document {doc_id} is fully processed (text + multimodal)"
-                    )
-                    return
 
         except Exception as e:
             self.logger.error(f"Error checking document status for {doc_id}: {e}")
@@ -859,9 +854,11 @@ class ProcessorMixin:
         # Get existing chunks count for proper order indexing. A status read
         # failure must stop the pipeline instead of silently changing indexes.
         existing_doc_status = await self.lightrag.doc_status.get_by_id(doc_id)
-        existing_chunks_count = (
-            existing_doc_status.get("chunks_count", 0) if existing_doc_status else 0
-        )
+        if not existing_doc_status:
+            raise RuntimeError(
+                f"doc_status record {doc_id} not found; cannot process multimodal content"
+            )
+        existing_chunks_count = existing_doc_status.get("chunks_count", 0)
 
         # Use LightRAG's concurrency control
         semaphore = asyncio.Semaphore(getattr(self.lightrag, "max_parallel_insert", 2))
@@ -870,6 +867,8 @@ class ProcessorMixin:
         total_items = len(multimodal_items)
         completed_count = 0
         progress_lock = asyncio.Lock()
+        description_failed = asyncio.Event()
+        first_description_failure = None
 
         # Log processing start
         self.logger.info(f"Starting to process {total_items} multimodal content items")
@@ -879,9 +878,14 @@ class ProcessorMixin:
             item: Dict[str, Any], index: int, file_path: str
         ):
             """Process single item using the correct processor for its type"""
-            nonlocal completed_count
+            nonlocal completed_count, first_description_failure
             async with semaphore:
                 try:
+                    if description_failed.is_set():
+                        raise RuntimeError(
+                            "Skipped multimodal description after an earlier failure"
+                        )
+
                     content_type = item.get("type", "unknown")
 
                     # Select the correct processor based on content type
@@ -922,6 +926,11 @@ class ProcessorMixin:
                         "processor": processor,  # Keep reference to the processor used
                         "file_path": file_path,  # Add file_path to the result
                     }
+                except Exception as exc:
+                    if first_description_failure is None:
+                        first_description_failure = exc
+                    description_failed.set()
+                    raise
                 finally:
                     # Update progress for both successful and failed tasks.
                     async with progress_lock:
@@ -943,24 +952,49 @@ class ProcessorMixin:
             for i, item in enumerate(multimodal_items)
         ]
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        multimodal_data_list = []
+        pending_tasks = set(tasks)
+        try:
+            while pending_tasks:
+                done_tasks, pending_tasks = await asyncio.wait(
+                    pending_tasks,
+                    return_when=asyncio.FIRST_EXCEPTION,
+                )
+                for task in done_tasks:
+                    try:
+                        result = task.result()
+                    except Exception:
+                        continue
+                    multimodal_data_list.append(result)
 
-        failures = [result for result in results if isinstance(result, Exception)]
-        multimodal_data_list = [
-            result for result in results if not isinstance(result, Exception)
-        ]
+                if first_description_failure is not None:
+                    for task in pending_tasks:
+                        task.cancel()
+                    if pending_tasks:
+                        await asyncio.gather(*pending_tasks, return_exceptions=True)
+                    break
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
-        if failures or len(multimodal_data_list) != total_items:
+        if (
+            first_description_failure is not None
+            or len(multimodal_data_list) != total_items
+        ):
             successful_count = len(multimodal_data_list)
             self.logger.error(
                 "Incomplete multimodal description batch: "
                 f"{successful_count}/{total_items} succeeded"
             )
-            first_failure = failures[0] if failures else None
             raise RuntimeError(
                 "Multimodal description batch failed closed: "
                 f"{successful_count}/{total_items} succeeded"
-            ) from first_failure
+            ) from first_description_failure
+
+        multimodal_data_list.sort(key=lambda result: result["index"])
 
         self.logger.info(
             f"Generated descriptions for {len(multimodal_data_list)}/{len(multimodal_items)} multimodal items using correct processors"
@@ -1505,6 +1539,7 @@ class ProcessorMixin:
             raise RuntimeError(
                 f"doc_status record {doc_id} not found; cannot mark multimodal complete"
             )
+        previous_doc_status = dict(current_doc_status)
 
         final_status = current_doc_status.get("status") or DocStatus.PROCESSED
         if final_status != DocStatus.FAILED:
@@ -1515,27 +1550,56 @@ class ProcessorMixin:
             "multimodal_processed": True,
             "updated_at": self._current_doc_status_timestamp(),
         }
+        compatibility_status = await self._get_multimodal_status_record(doc_id)
+        previous_compatibility_status = (
+            dict(compatibility_status) if compatibility_status is not None else None
+        )
+        used_compatibility_cache = False
         try:
-            await self.lightrag.doc_status.upsert({doc_id: update_payload})
-        except Exception as exc:
-            # Older LightRAG versions reject unknown doc_status fields such as
-            # multimodal_processed. Only that explicit schema mismatch is safe
-            # to route through the compatibility status cache.
-            if "multimodal_processed" not in str(exc):
-                raise
-            self.logger.debug(
-                "Falling back to schema-compatible doc_status update for %s: %s",
-                doc_id,
-                exc,
-            )
-            fallback_payload = {
-                **current_doc_status,
-                "status": final_status,
-                "updated_at": self._current_doc_status_timestamp(),
-            }
-            await self.lightrag.doc_status.upsert({doc_id: fallback_payload})
-            await self._set_multimodal_status_record(doc_id, True)
-        await self.lightrag.doc_status.index_done_callback()
+            try:
+                await self.lightrag.doc_status.upsert({doc_id: update_payload})
+            except Exception as exc:
+                # Older LightRAG versions reject unknown doc_status fields such as
+                # multimodal_processed. Only that explicit schema mismatch is safe
+                # to route through the compatibility status cache.
+                if "multimodal_processed" not in str(exc):
+                    raise
+                used_compatibility_cache = True
+                self.logger.debug(
+                    "Falling back to schema-compatible doc_status update for %s",
+                    doc_id,
+                )
+                fallback_payload = {
+                    **current_doc_status,
+                    "status": final_status,
+                    "updated_at": self._current_doc_status_timestamp(),
+                }
+                await self.lightrag.doc_status.upsert({doc_id: fallback_payload})
+
+            await self.lightrag.doc_status.index_done_callback()
+            if used_compatibility_cache:
+                await self._set_multimodal_status_record(doc_id, True)
+        except Exception:
+            try:
+                await self.lightrag.doc_status.upsert({doc_id: previous_doc_status})
+                await self.lightrag.doc_status.index_done_callback()
+            except Exception:
+                self.logger.error(
+                    "Failed to restore doc_status after completion persistence failure"
+                )
+
+            if used_compatibility_cache:
+                previous_processed = bool(
+                    previous_compatibility_status
+                    and previous_compatibility_status.get("multimodal_processed", False)
+                )
+                try:
+                    await self._set_multimodal_status_record(doc_id, previous_processed)
+                except Exception:
+                    self.logger.error(
+                        "Failed to restore compatibility completion status"
+                    )
+            raise
         self.logger.debug(
             f"Marked multimodal content processing as complete for document {doc_id}"
         )

--- a/tests/test_multimodal_chunks_list_merge.py
+++ b/tests/test_multimodal_chunks_list_merge.py
@@ -11,6 +11,8 @@ import asyncio
 import sys
 import types
 
+import pytest
+
 
 class RecordingLogger:
     def __init__(self):
@@ -134,14 +136,14 @@ def test_partial_overlap_appends_only_missing_ids():
     assert record["chunks_count"] == 3
 
 
-def test_missing_record_warns_instead_of_silently_skipping():
+def test_missing_record_fails_instead_of_silently_skipping():
     processor = DummyProcessor()
 
-    asyncio.run(
-        processor._update_doc_status_with_chunks_type_aware("doc-absent", ["chunk-m1"])
-    )
+    with pytest.raises(RuntimeError, match="doc_status record doc-absent not found"):
+        asyncio.run(
+            processor._update_doc_status_with_chunks_type_aware(
+                "doc-absent", ["chunk-m1"]
+            )
+        )
 
     assert processor.lightrag.doc_status.records == {}
-    assert any(
-        "doc-absent" in message for message in processor.logger.warnings
-    ), processor.logger.warnings

--- a/tests/test_multimodal_fail_closed.py
+++ b/tests/test_multimodal_fail_closed.py
@@ -1,5 +1,6 @@
 """Focused tests for fail-closed multimodal ingestion."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -80,12 +81,52 @@ async def test_description_generation_reraises_without_fabricated_fallback(
     assert exc_info.value is expected
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("processor_class", "content_type", "modal_content"),
+    [
+        (ImageModalProcessor, "image", {"img_path": "image.png"}),
+        (TableModalProcessor, "table", {"table_body": "| a | b |"}),
+        (
+            EquationModalProcessor,
+            "equation",
+            {"text": "x + y = 1", "text_format": "latex"},
+        ),
+        (GenericModalProcessor, "chart", {"content": "chart data"}),
+    ],
+)
+async def test_public_processor_reraises_description_failure(
+    processor_class,
+    content_type,
+    modal_content,
+):
+    expected = DescriptionFailure(content_type)
+
+    async def fail_description(*args, **kwargs):
+        del args, kwargs
+        raise expected
+
+    processor = processor_class.__new__(processor_class)
+    processor.generate_description_only = fail_description
+    processor._create_entity_and_chunk = AsyncMock()
+
+    with pytest.raises(DescriptionFailure) as exc_info:
+        await processor.process_multimodal_content(modal_content, content_type)
+
+    assert exc_info.value is expected
+    processor._create_entity_and_chunk.assert_not_awaited()
+
+
 class FakeDocStatus:
-    """Status store that returns an uninitialized document."""
+    """Status store with an initialized text-processing record."""
 
     async def get_by_id(self, doc_id):
         del doc_id
-        return None
+        return {
+            "status": "processed",
+            "chunks_count": 0,
+            "chunks_list": [],
+        }
 
 
 class FakeDescriptionProcessor:
@@ -191,6 +232,60 @@ async def test_incomplete_description_batch_stops_before_storage(failure_flags):
 
 
 @pytest.mark.asyncio
+async def test_missing_initial_doc_status_stops_before_description_and_storage():
+    class MissingDocStatus:
+        async def get_by_id(self, doc_id):
+            del doc_id
+            return None
+
+    processor = DummyProcessor()
+    configure_pipeline(processor)
+    processor.lightrag.doc_status = MissingDocStatus()
+    generate_description = AsyncMock()
+    processor.modal_processors = {
+        "image": SimpleNamespace(generate_description_only=generate_description)
+    }
+
+    with pytest.raises(RuntimeError, match=r"doc_status record doc-1 not found"):
+        await processor._process_multimodal_content_batch_type_aware(
+            multimodal_items(False), "source.pdf", "doc-1"
+        )
+
+    generate_description.assert_not_awaited()
+    processor._store_chunks_to_lightrag_storage_type_aware.assert_not_awaited()
+    processor._batch_extract_entities_lightrag_style_type_aware.assert_not_awaited()
+    processor._batch_merge_lightrag_style_type_aware.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_first_description_failure_cancels_queued_remote_calls():
+    expected = DescriptionFailure("first")
+    started_indexes = []
+
+    class FirstFailureProcessor:
+        async def generate_description_only(self, modal_content, **kwargs):
+            del kwargs
+            started_indexes.append(modal_content["index"])
+            if modal_content["index"] == 0:
+                raise expected
+            await asyncio.Event().wait()
+
+    processor = DummyProcessor()
+    configure_pipeline(processor)
+    processor.lightrag.max_parallel_insert = 1
+    processor.modal_processors = {"image": FirstFailureProcessor()}
+
+    with pytest.raises(RuntimeError, match=r"0/3 succeeded") as exc_info:
+        await processor._process_multimodal_content_batch_type_aware(
+            multimodal_items(True, False, False), "source.pdf", "doc-1"
+        )
+
+    assert exc_info.value.__cause__ is expected
+    assert started_indexes == [0]
+    processor._store_chunks_to_lightrag_storage_type_aware.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("failure_stage", ["storage", "merge", "status"])
 async def test_downstream_failure_blocks_completion_and_individual_fallback(
     failure_stage,
@@ -227,3 +322,57 @@ async def test_completion_status_backend_failure_propagates():
         await processor._mark_multimodal_processing_complete("doc-1")
 
     assert exc_info.value is expected
+
+
+@pytest.mark.asyncio
+async def test_completion_callback_failure_rolls_back_flag_for_immediate_retry():
+    expected = StageFailure("completion callback")
+
+    class MutatingDocStatus:
+        def __init__(self):
+            self.records = {
+                "doc-1": {
+                    "status": "processed",
+                    "chunks_count": 0,
+                    "chunks_list": [],
+                }
+            }
+            self.callback_calls = 0
+
+        async def get_by_id(self, doc_id):
+            return self.records.get(doc_id)
+
+        async def upsert(self, payload):
+            for doc_id, record in payload.items():
+                if doc_id in self.records:
+                    self.records[doc_id].clear()
+                    self.records[doc_id].update(record)
+                else:
+                    self.records[doc_id] = record
+
+        async def index_done_callback(self):
+            self.callback_calls += 1
+            if self.callback_calls == 1:
+                raise expected
+
+    processor = DummyProcessor()
+    processor.lightrag.doc_status = MutatingDocStatus()
+
+    with pytest.raises(StageFailure) as exc_info:
+        await processor._mark_multimodal_processing_complete("doc-1")
+
+    assert exc_info.value is expected
+    assert not processor.lightrag.doc_status.records["doc-1"].get(
+        "multimodal_processed", False
+    )
+
+    processor._ensure_lightrag_initialized = AsyncMock(return_value={"success": True})
+    processor._process_multimodal_content_batch_type_aware = AsyncMock()
+    processor._mark_multimodal_processing_complete = AsyncMock()
+
+    await processor._process_multimodal_content(
+        multimodal_items(False), "source.pdf", "doc-1"
+    )
+
+    processor._process_multimodal_content_batch_type_aware.assert_awaited_once()
+    processor._mark_multimodal_processing_complete.assert_awaited_once_with("doc-1")

--- a/tests/test_multimodal_fail_closed.py
+++ b/tests/test_multimodal_fail_closed.py
@@ -1,0 +1,229 @@
+"""Focused tests for fail-closed multimodal ingestion."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from raganything.modalprocessors import (
+    EquationModalProcessor,
+    GenericModalProcessor,
+    ImageModalProcessor,
+    TableModalProcessor,
+)
+from raganything.processor import ProcessorMixin
+
+
+class RecordingLogger:
+    """Minimal logger used by processor tests."""
+
+    def debug(self, *args, **kwargs):
+        del args, kwargs
+
+    def error(self, *args, **kwargs):
+        del args, kwargs
+
+    def info(self, *args, **kwargs):
+        del args, kwargs
+
+    def warning(self, *args, **kwargs):
+        del args, kwargs
+
+
+class DescriptionFailure(Exception):
+    """Sentinel description failure."""
+
+
+class StageFailure(Exception):
+    """Sentinel downstream stage failure."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("processor_class", "content_type"),
+    [
+        (ImageModalProcessor, "image"),
+        (TableModalProcessor, "table"),
+        (EquationModalProcessor, "equation"),
+        (GenericModalProcessor, "chart"),
+    ],
+)
+async def test_description_generation_reraises_without_fabricated_fallback(
+    processor_class,
+    content_type,
+    tmp_path,
+):
+    expected = DescriptionFailure(content_type)
+
+    async def fail_description(*args, **kwargs):
+        del args, kwargs
+        raise expected
+
+    processor = processor_class.__new__(processor_class)
+    processor.context_extractor = None
+    processor.modal_caption_func = fail_description
+
+    if content_type == "image":
+        image_path = tmp_path / "image.png"
+        image_path.write_bytes(b"not-a-real-image-but-readable")
+        modal_content = {"img_path": str(image_path)}
+    elif content_type == "table":
+        modal_content = {"table_body": "| a | b |"}
+    elif content_type == "equation":
+        modal_content = {"text": "x + y = 1", "text_format": "latex"}
+    else:
+        modal_content = {"content": "chart data"}
+
+    with pytest.raises(DescriptionFailure) as exc_info:
+        await processor.generate_description_only(modal_content, content_type)
+
+    assert exc_info.value is expected
+
+
+class FakeDocStatus:
+    """Status store that returns an uninitialized document."""
+
+    async def get_by_id(self, doc_id):
+        del doc_id
+        return None
+
+
+class FakeDescriptionProcessor:
+    """Description processor controlled by each input item."""
+
+    async def generate_description_only(self, modal_content, **kwargs):
+        del kwargs
+        if modal_content.get("fail"):
+            raise DescriptionFailure(str(modal_content["index"]))
+        index = modal_content["index"]
+        return f"description-{index}", {
+            "entity_name": f"entity-{index}",
+            "entity_type": "image",
+            "summary": f"summary-{index}",
+        }
+
+
+class DummyProcessor(ProcessorMixin):
+    """Processor with fake storage and deterministic stages."""
+
+    def __init__(self):
+        self.callback_manager = None
+        self.config = SimpleNamespace(use_full_path=False)
+        self.lightrag = SimpleNamespace(
+            doc_status=FakeDocStatus(),
+            max_parallel_insert=2,
+        )
+        self.logger = RecordingLogger()
+        self.modal_processors = {"image": FakeDescriptionProcessor()}
+
+
+def configure_pipeline(processor, *, failure_stage=None):
+    """Install deterministic downstream stages on a dummy processor."""
+    processor._ensure_lightrag_initialized = AsyncMock(return_value={"success": True})
+    processor._convert_to_lightrag_chunks_type_aware = Mock(
+        return_value={"chunk-0": {}, "chunk-1": {}}
+    )
+    processor._store_chunks_to_lightrag_storage_type_aware = AsyncMock()
+    processor._store_multimodal_main_entities = AsyncMock()
+    processor._batch_extract_entities_lightrag_style_type_aware = AsyncMock(
+        return_value=[({}, {}), ({}, {})]
+    )
+    processor._batch_add_belongs_to_relations_type_aware = AsyncMock(
+        return_value=[({}, {}), ({}, {})]
+    )
+    processor._batch_merge_lightrag_style_type_aware = AsyncMock()
+    processor._update_doc_status_with_chunks_type_aware = AsyncMock()
+    processor._mark_multimodal_processing_complete = AsyncMock()
+    processor._process_multimodal_content_individual = AsyncMock()
+
+    stage_methods = {
+        "storage": processor._store_chunks_to_lightrag_storage_type_aware,
+        "merge": processor._batch_merge_lightrag_style_type_aware,
+        "status": processor._update_doc_status_with_chunks_type_aware,
+    }
+    if failure_stage:
+        stage_methods[failure_stage].side_effect = StageFailure(failure_stage)
+
+
+def multimodal_items(*failure_flags):
+    """Build input with selected description failures."""
+    return [
+        {"type": "image", "index": index, "fail": should_fail}
+        for index, should_fail in enumerate(failure_flags)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_complete_n_of_n_batch_runs_every_stage_and_marks_complete():
+    processor = DummyProcessor()
+    configure_pipeline(processor)
+
+    await processor._process_multimodal_content(
+        multimodal_items(False, False), "source.pdf", "doc-1"
+    )
+
+    processor._store_chunks_to_lightrag_storage_type_aware.assert_awaited_once()
+    processor._store_multimodal_main_entities.assert_awaited_once()
+    processor._batch_extract_entities_lightrag_style_type_aware.assert_awaited_once()
+    processor._batch_add_belongs_to_relations_type_aware.assert_awaited_once()
+    processor._batch_merge_lightrag_style_type_aware.assert_awaited_once()
+    processor._update_doc_status_with_chunks_type_aware.assert_awaited_once()
+    processor._mark_multimodal_processing_complete.assert_awaited_once_with("doc-1")
+    processor._process_multimodal_content_individual.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_flags", [(True, True), (False, True)])
+async def test_incomplete_description_batch_stops_before_storage(failure_flags):
+    processor = DummyProcessor()
+    configure_pipeline(processor)
+
+    with pytest.raises(RuntimeError, match=r"[01]/2 succeeded"):
+        await processor._process_multimodal_content(
+            multimodal_items(*failure_flags), "source.pdf", "doc-1"
+        )
+
+    processor._store_chunks_to_lightrag_storage_type_aware.assert_not_awaited()
+    processor._batch_merge_lightrag_style_type_aware.assert_not_awaited()
+    processor._update_doc_status_with_chunks_type_aware.assert_not_awaited()
+    processor._mark_multimodal_processing_complete.assert_not_awaited()
+    processor._process_multimodal_content_individual.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["storage", "merge", "status"])
+async def test_downstream_failure_blocks_completion_and_individual_fallback(
+    failure_stage,
+):
+    processor = DummyProcessor()
+    configure_pipeline(processor, failure_stage=failure_stage)
+
+    with pytest.raises(StageFailure, match=failure_stage):
+        await processor._process_multimodal_content(
+            multimodal_items(False, False), "source.pdf", "doc-1"
+        )
+
+    processor._mark_multimodal_processing_complete.assert_not_awaited()
+    processor._process_multimodal_content_individual.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_completion_status_backend_failure_propagates():
+    expected = StageFailure("status backend")
+
+    class FailingDocStatus:
+        async def get_by_id(self, doc_id):
+            del doc_id
+            return {"status": "processed", "chunks_list": []}
+
+        async def upsert(self, payload):
+            del payload
+            raise expected
+
+    processor = DummyProcessor()
+    processor.lightrag.doc_status = FailingDocStatus()
+
+    with pytest.raises(StageFailure) as exc_info:
+        await processor._mark_multimodal_processing_complete("doc-1")
+
+    assert exc_info.value is expected


### PR DESCRIPTION
## Summary

- propagate description-generation failures through both description-only and public processor APIs
- require an existing document-status record before any multimodal description or storage work begins
- require every item in a multimodal batch to complete before storage, extraction, merge, or status updates continue
- cancel pending description tasks and block queued remote calls after the first failure
- roll back in-memory completion state when its persistence callback fails so an immediate retry cannot short-circuit
- stop batch failures from entering the individual fallback or marking the document complete

## Why

An incomplete multimodal stage must not look successful. Previously, public processor wrappers could fabricate fallback content, a missing initial status record could be discovered only after storage and merge, all queued description requests continued after the first failure, and a mutating status backend could leave `multimodal_processed=True` in memory even when persistence failed.

This change makes those boundaries fail closed and preserves the original exception as the cause.

## Validation

Validated at exact head `36078eaae2c4f34415ee66da64460cdb420d725a`.

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.:/home/ubuntu/deeptutor/.venv/lib/python3.12/site-packages \
  uv run --no-project --with pytest==8.4.1 --with pytest-asyncio==1.4.0 \
  python -m pytest -q
# 316 passed

PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.:/home/ubuntu/deeptutor/.venv/lib/python3.12/site-packages \
  uv run --no-project --with pytest==8.4.1 --with pytest-asyncio==1.4.0 \
  python -m pytest \
  tests/test_multimodal_fail_closed.py \
  tests/test_multimodal_chunks_list_merge.py -q
# 22 passed

uvx --from ruff==0.6.4 ruff check \
  raganything/processor.py \
  raganything/modalprocessors.py \
  tests/test_multimodal_fail_closed.py \
  tests/test_multimodal_chunks_list_merge.py
# All checks passed

uvx --from ruff==0.6.4 ruff format --check \
  raganything/processor.py \
  raganything/modalprocessors.py \
  tests/test_multimodal_fail_closed.py \
  tests/test_multimodal_chunks_list_merge.py
# 4 files already formatted
```

The same local command environment ran base commit `62af3dd4c660b4459784df3b1ccca9014dba2d1f` with 298 passing tests. This pull request adds 18 passing test cases; the head has 316 passing tests.

Full-repository Ruff still has the base repository's existing diagnostics; the changed paths above pass both check and format gates.
