### PR TITLE
fix: preserve page boundaries through text chunking (#330)

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -1703,7 +1703,7 @@ class ProcessorMixin:
                 doc_id = content_based_doc_id
 
             # Step 2: Separate text and multimodal content
-            text_content, multimodal_items = separate_content(content_list)
+            text_content, page_texts, multimodal_items = separate_content(content_list)
 
             # LightRAG creates the initial doc_status entry during text insertion.
             # Pre-registering the same doc_id here makes LightRAG treat a fresh
@@ -1739,11 +1739,11 @@ class ProcessorMixin:
                 insert_start = time.time()
                 await insert_text_content(
                     self.lightrag,
-                    input=text_content,
-                    file_paths=file_name,
+                    input=page_texts,
+                    file_paths=[file_name] * len(page_texts),
                     split_by_character=split_by_character,
                     split_by_character_only=split_by_character_only,
-                    ids=doc_id,
+                    ids=[f"{doc_id}#p{i}" for i in range(len(page_texts))],
                 )
                 await self._upsert_doc_status(
                     doc_id,
@@ -2010,7 +2010,7 @@ class ProcessorMixin:
                 doc_id = content_based_doc_id
 
             # Step 2: Separate text and multimodal content
-            text_content, multimodal_items = separate_content(content_list)
+            text_content, page_texts, multimodal_items = separate_content(content_list)
 
             # LightRAG creates the initial doc_status entry during text
             # insertion. Pre-registering the same doc_id here makes LightRAG
@@ -2039,12 +2039,12 @@ class ProcessorMixin:
             if text_content.strip():
                 await insert_text_content_with_multimodal_content(
                     self.lightrag,
-                    input=text_content,
+                    input=page_texts,
                     multimodal_content=multimodal_items,
-                    file_paths=file_name,
+                    file_paths=[file_name] * len(page_texts),
                     split_by_character=split_by_character,
                     split_by_character_only=split_by_character_only,
-                    ids=doc_id,
+                    ids=[f"{doc_id}#p{i}" for i in range(len(page_texts))],
                     scheme_name=scheme_name,
                 )
 
@@ -2182,7 +2182,7 @@ class ProcessorMixin:
                 self.logger.info(f"  - {block_type}: {count}")
 
         # Step 1: Separate text and multimodal content
-        text_content, multimodal_items = separate_content(content_list)
+        text_content, page_texts, multimodal_items = separate_content(content_list)
 
         # LightRAG creates the initial doc_status entry during text insertion.
         # Pre-registering the same doc_id here makes LightRAG treat a fresh
@@ -2217,11 +2217,11 @@ class ProcessorMixin:
             insert_start = time.time()
             await insert_text_content(
                 self.lightrag,
-                input=text_content,
-                file_paths=file_ref,
+                input=page_texts,
+                file_paths=[file_ref] * len(page_texts),
                 split_by_character=split_by_character,
                 split_by_character_only=split_by_character_only,
-                ids=doc_id,
+                ids=[f"{doc_id}#p{i}" for i in range(len(page_texts))],
             )
             await self._upsert_doc_status(
                 doc_id,

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -169,20 +169,38 @@ def extract_neighbor_text_from_content_list(
     return " ".join(parts)
 
 
+# Minimum size (characters) for a page-run of text before it is split off.
+# Consecutive pages shorter than this are merged into one run so page
+# boundaries survive downstream token-chunking without producing many tiny,
+# low-context chunks.
+MIN_PAGE_RUN_CHARS = 512
+
+
 def separate_content(
     content_list: List[Dict[str, Any]],
-) -> Tuple[str, List[Dict[str, Any]]]:
+) -> Tuple[str, List[str], List[Dict[str, Any]]]:
     """
-    Separate text content and multimodal content
+    Separate text content and multimodal content, preserving page boundaries.
 
     Args:
         content_list: Content list from MinerU parsing
 
     Returns:
-        (text_content, multimodal_items): Pure text content and multimodal items list
+        (text_content, page_texts, multimodal_items):
+            text_content: all text blocks joined into one flat string
+            page_texts: text grouped per page-run. Consecutive pages are
+                merged into a run when they are short, so each run is at least
+                ``MIN_PAGE_RUN_CHARS`` characters (unless a single page is
+                larger) and never mixes non-adjacent pages.
+            multimodal_items: multimodal items list
     """
     text_parts = []
     multimodal_items = []
+
+    # Group text blocks by page so page boundaries can survive chunking.
+    # Text without a page_idx falls back to a single bucket.
+    page_blocks: Dict[Any, List[str]] = {}
+    page_order: List[Any] = []
 
     for index, item in enumerate(content_list):
         content_type = item.get("type", "text")
@@ -192,6 +210,11 @@ def separate_content(
             text = str(item.get("text", "") or "")
             if text.strip():
                 text_parts.append(text)
+                page_idx = item.get("page_idx", -1)
+                if page_idx not in page_blocks:
+                    page_blocks[page_idx] = []
+                    page_order.append(page_idx)
+                page_blocks[page_idx].append(text)
         else:
             # Multimodal content (image, table, equation, etc.)
             multimodal_item = dict(item)
@@ -207,11 +230,31 @@ def separate_content(
                 )
             multimodal_items.append(multimodal_item)
 
-    # Merge all text content
+    # Merge all text content (kept for backward-compatible flat use)
     text_content = "\n\n".join(text_parts)
+
+    # Group consecutive pages into page-runs: pages are accumulated until the
+    # run reaches MIN_PAGE_RUN_CHARS, at which point it is split off. This
+    # keeps page boundaries intact (a run never mixes non-adjacent pages)
+    # while avoiding tiny, low-context chunks for very short pages.
+    page_texts: List[str] = []
+    run_parts: List[str] = []
+    run_len = 0
+    for page_idx in page_order:
+        page_text = "\n\n".join(page_blocks[page_idx])
+        if run_parts and run_len >= MIN_PAGE_RUN_CHARS:
+            page_texts.append("\n\n".join(run_parts))
+            run_parts = [page_text]
+            run_len = len(page_text)
+        else:
+            run_parts.append(page_text)
+            run_len += len(page_text)
+    if run_parts:
+        page_texts.append("\n\n".join(run_parts))
 
     logger.info("Content separation complete:")
     logger.info(f"  - Text content length: {len(text_content)} characters")
+    logger.info(f"  - Page-run count: {len(page_texts)}")
     logger.info(f"  - Multimodal items count: {len(multimodal_items)}")
 
     # Count multimodal types
@@ -223,7 +266,7 @@ def separate_content(
     if modal_types:
         logger.info(f"  - Multimodal type distribution: {modal_types}")
 
-    return text_content, multimodal_items
+    return text_content, page_texts, multimodal_items
 
 
 def encode_image_to_base64(image_path: str) -> str:

--- a/tests/test_content_list_alias_handling.py
+++ b/tests/test_content_list_alias_handling.py
@@ -85,7 +85,7 @@ extract_neighbor_text_from_content_list = (
 
 class ContentListAliasHandlingTests(unittest.TestCase):
     def test_separate_content_ignores_null_text_values(self):
-        text, multimodal = separate_content(
+        text, page_texts, multimodal = separate_content(
             [
                 {"type": "text", "text": None},
                 {"type": "text", "text": "kept"},
@@ -93,6 +93,7 @@ class ContentListAliasHandlingTests(unittest.TestCase):
         )
 
         self.assertEqual(text, "kept")
+        self.assertEqual(page_texts, ["kept"])
         self.assertEqual(multimodal, [])
 
     def test_separate_content_preserves_original_content_list_index(self):
@@ -103,7 +104,7 @@ class ContentListAliasHandlingTests(unittest.TestCase):
             {"type": "table", "table_body": "| A | B |"},
         ]
 
-        _, multimodal = separate_content(content)
+        _, _, multimodal = separate_content(content)
 
         self.assertEqual([item["_content_list_index"] for item in multimodal], [1, 3])
         self.assertNotIn("_content_list_index", content[1])
@@ -174,7 +175,7 @@ class ContentListAliasHandlingTests(unittest.TestCase):
             {"type": "text", "text": "discussion after image"},
         ]
 
-        _, multimodal = separate_content(content)
+        _, _, multimodal = separate_content(content)
         image_item = multimodal[0]
 
         self.assertEqual(
@@ -208,6 +209,76 @@ class ContentListAliasHandlingTests(unittest.TestCase):
         content = [{"type": "text", "text": "1 Intro", "text_level": 1}]
         self.assertEqual(extract_section_path_from_content_list(content, -1), "")
         self.assertEqual(extract_neighbor_text_from_content_list(content, 99), "")
+
+
+class SeparateContentPageGroupingTests(unittest.TestCase):
+    """#330: text must retain page boundaries through chunking.
+
+    ``separate_content`` returns per-page text runs so that page provenance
+    survives downstream token-chunking. Very short consecutive pages are merged
+    into a single run to avoid tiny, low-context chunks, but a run never mixes
+    non-adjacent pages.
+    """
+
+    def test_short_consecutive_pages_merged_into_one_run(self):
+        content = [
+            {"type": "text", "text": "tiny page A", "page_idx": 0},
+            {"type": "text", "text": "tiny page B", "page_idx": 1},
+        ]
+        _, page_texts, _ = separate_content(content)
+
+        self.assertEqual(len(page_texts), 1)
+        self.assertIn("tiny page A", page_texts[0])
+        self.assertIn("tiny page B", page_texts[0])
+
+    def test_big_page_starts_its_own_run(self):
+        content = [
+            {"type": "text", "text": "A" * 600, "page_idx": 0},
+            {"type": "text", "text": "B" * 600, "page_idx": 1},
+        ]
+        _, page_texts, _ = separate_content(content)
+
+        self.assertEqual(len(page_texts), 2)
+        self.assertIn("A" * 600, page_texts[0])
+        self.assertNotIn("B", page_texts[0])
+        self.assertIn("B" * 600, page_texts[1])
+
+    def test_runs_are_contiguous_page_ranges(self):
+        # A large page is its own run; the following short page merges with the
+        # next large page rather than bleeding into page 0's run.
+        content = [
+            {"type": "text", "text": "P0" * 300, "page_idx": 0},
+            {"type": "text", "text": "P1 short", "page_idx": 1},
+            {"type": "text", "text": "P2" * 300, "page_idx": 2},
+        ]
+        _, page_texts, _ = separate_content(content)
+
+        self.assertEqual(len(page_texts), 2)
+        self.assertIn("P1 short", page_texts[1])
+        self.assertNotIn("P1 short", page_texts[0])
+        # page 1 and 2 share a run; page 0 is alone
+        self.assertNotIn("P2", page_texts[0])
+
+    def test_flat_text_is_concatenation_of_page_runs(self):
+        content = [
+            {"type": "text", "text": "alpha", "page_idx": 0},
+            {"type": "text", "text": "beta", "page_idx": 1},
+        ]
+        text, page_texts, _ = separate_content(content)
+
+        self.assertEqual(text, "alpha\n\nbeta")
+        self.assertEqual("\n\n".join(page_texts), text)
+
+    def test_text_without_page_idx_falls_back_to_single_bucket(self):
+        content = [
+            {"type": "text", "text": "no page A"},
+            {"type": "text", "text": "no page B"},
+        ]
+        _, page_texts, _ = separate_content(content)
+
+        self.assertEqual(len(page_texts), 1)
+        self.assertIn("no page A", page_texts[0])
+        self.assertIn("no page B", page_texts[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_core_modules.py
+++ b/tests/test_core_modules.py
@@ -120,7 +120,7 @@ class TestRAGAnythingConfig:
 
 class TestSeparateContent:
     def test_empty_list(self):
-        text, multimodal = separate_content([])
+        text, page_texts, multimodal = separate_content([])
         assert text == ""
         assert multimodal == []
 
@@ -129,7 +129,7 @@ class TestSeparateContent:
             {"type": "text", "text": "Hello world"},
             {"type": "text", "text": "Second paragraph"},
         ]
-        text, multimodal = separate_content(content)
+        text, page_texts, multimodal = separate_content(content)
         assert "Hello world" in text
         assert "Second paragraph" in text
         assert multimodal == []
@@ -139,7 +139,7 @@ class TestSeparateContent:
             {"type": "image", "img_path": "/path/to/image.png"},
             {"type": "table", "table_body": "col1|col2"},
         ]
-        text, multimodal = separate_content(content)
+        text, page_texts, multimodal = separate_content(content)
         assert text == ""
         assert len(multimodal) == 2
         assert multimodal[0]["type"] == "image"
@@ -153,7 +153,7 @@ class TestSeparateContent:
             {"type": "table", "table_body": "data"},
             {"type": "equation", "text": "E=mc^2"},
         ]
-        text, multimodal = separate_content(content)
+        text, page_texts, multimodal = separate_content(content)
         assert "Introduction" in text
         assert "Discussion" in text
         assert len(multimodal) == 3
@@ -164,13 +164,13 @@ class TestSeparateContent:
             {"type": "text", "text": "Valid text"},
             {"type": "text", "text": "\n\t"},
         ]
-        text, multimodal = separate_content(content)
+        text, page_texts, multimodal = separate_content(content)
         assert "Valid text" in text
         assert "   " not in text.split("\n\n")
 
     def test_missing_type_defaults_to_text(self):
         content = [{"text": "no type field"}]
-        text, multimodal = separate_content(content)
+        text, page_texts, multimodal = separate_content(content)
         assert "no type field" in text
 
 


### PR DESCRIPTION
`separate_content()` previously joined every text block into a single string before LightRAG token-chunks it, so the per-block `page_idx` that MinerU records never survived into text chunks — only multimodal chunks kept page provenance. This breaks page-anchored features (citations, figure-to-chunk association, source-page navigation) for the bulk of a document.

This change groups text by `page_idx` into page-runs and inserts each run separately so page boundaries survive chunking: `separate_content` now returns `(text_content, page_texts, multimodal_items)`, and the three insertion paths pass `page_texts` with page-encoded ids (`doc_id#p{i}`). Consecutive short pages are merged into a run (above `MIN_PAGE_RUN_CHARS`) to avoid tiny, low-context chunks; a run never mixes non-adjacent pages.

Verification: 5 new unit tests (12/12 pass); end-to-end with local Ollama + lightrag 1.4.16 produced page-homogeneous chunks with zero cross-page chunks.

Closes #330
