### PR TITLE
feat: parse .txt/.md directly instead of the PDF round trip (#331)

### DIFF
--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -19,6 +19,7 @@ from raganything.utils import (
     separate_content,
     insert_text_content,
     insert_text_content_with_multimodal_content,
+    build_content_list_from_text_file,
     get_processor_for_type,
     format_table_body,
     get_equation_text_and_format,
@@ -507,6 +508,15 @@ class ProcessorMixin:
                         output_dir=output_dir,
                         **kwargs,
                     )
+            elif ext in [".txt", ".md"]:
+                self.logger.info(
+                    "Detected plain text/markdown file, building content list "
+                    "directly (bypassing the text->PDF->OCR round trip)..."
+                )
+                content_list = await asyncio.to_thread(
+                    build_content_list_from_text_file,
+                    file_path,
+                )
             elif ext in [
                 ".doc",
                 ".docx",

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import inspect
+import re
 from typing import Dict, List, Any, Tuple
 from pathlib import Path
 from lightrag.utils import logger
@@ -224,6 +225,63 @@ def separate_content(
         logger.info(f"  - Multimodal type distribution: {modal_types}")
 
     return text_content, multimodal_items
+
+
+def build_content_list_from_text(
+    text: str,
+    page_idx: int = 0,
+) -> List[Dict[str, Any]]:
+    """
+    Build a content list directly from plain text or markdown.
+
+    Paragraphs are split on blank lines; each non-empty paragraph becomes a
+    ``text`` content block. This bypasses the text->PDF->OCR round trip that
+    is otherwise used for ``.txt`` / ``.md`` files, which is slower and
+    introduces fidelity bugs (e.g. CJK font rendering, markdown escaping).
+
+    Args:
+        text: Raw text / markdown content.
+        page_idx: ``page_idx`` stamped on every block (plain text has no page
+            concept, so a single synthetic page is used).
+
+    Returns:
+        A list of ``{"type": "text", "text": ..., "page_idx": ...}`` blocks.
+    """
+    content_list: List[Dict[str, Any]] = []
+    # Split on one or more blank lines (paragraph boundary).
+    paragraphs = re.split(r"\n\s*\n", text)
+    for para in paragraphs:
+        stripped = para.strip()
+        if stripped:
+            content_list.append(
+                {
+                    "type": "text",
+                    "text": stripped,
+                    "page_idx": page_idx,
+                }
+            )
+    return content_list
+
+
+def build_content_list_from_text_file(
+    file_path: Path,
+    page_idx: int = 0,
+) -> List[Dict[str, Any]]:
+    """
+    Read a plain text / markdown file and build its content list directly.
+
+    Reading is UTF-8 with invalid bytes replaced, so CJK and other non-ASCII
+    text survives without the PDF-rendering failure modes.
+
+    Args:
+        file_path: Path to the ``.txt`` / ``.md`` file.
+        page_idx: Synthetic page index stamped on every block.
+
+    Returns:
+        A content list built from the file's paragraphs.
+    """
+    text = Path(file_path).read_text(encoding="utf-8", errors="replace")
+    return build_content_list_from_text(text, page_idx=page_idx)
 
 
 def encode_image_to_base64(image_path: str) -> str:

--- a/raganything/utils.py
+++ b/raganything/utils.py
@@ -263,6 +263,25 @@ def build_content_list_from_text(
     return content_list
 
 
+def _read_text_file_robust(file_path: Path) -> str:
+    """Read a text file, falling back across common encodings.
+
+    Mirrors the encoding fallback used by the ReportLab text-to-PDF path so the
+    direct path does not regress on non-UTF-8 (e.g. GBK) text files.
+    """
+    try:
+        return Path(file_path).read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        for encoding in ["gbk", "latin-1", "cp1252"]:
+            try:
+                return Path(file_path).read_text(encoding=encoding)
+            except UnicodeDecodeError:
+                continue
+        raise RuntimeError(
+            f"Could not decode text file {file_path.name} with any supported encoding"
+        )
+
+
 def build_content_list_from_text_file(
     file_path: Path,
     page_idx: int = 0,
@@ -270,8 +289,9 @@ def build_content_list_from_text_file(
     """
     Read a plain text / markdown file and build its content list directly.
 
-    Reading is UTF-8 with invalid bytes replaced, so CJK and other non-ASCII
-    text survives without the PDF-rendering failure modes.
+    Reading tries UTF-8 first and falls back to GBK / latin-1 / cp1252 (the
+    same fallback the text-to-PDF path uses), so CJK and other non-ASCII text
+    survives without the PDF-rendering failure modes.
 
     Args:
         file_path: Path to the ``.txt`` / ``.md`` file.
@@ -280,7 +300,7 @@ def build_content_list_from_text_file(
     Returns:
         A content list built from the file's paragraphs.
     """
-    text = Path(file_path).read_text(encoding="utf-8", errors="replace")
+    text = _read_text_file_robust(file_path)
     return build_content_list_from_text(text, page_idx=page_idx)
 
 

--- a/tests/test_content_list_alias_handling.py
+++ b/tests/test_content_list_alias_handling.py
@@ -271,6 +271,29 @@ class TestBuildContentListFromText(unittest.TestCase):
         self.assertEqual(content[0]["text"], "# Title")
         self.assertEqual(content[1]["text"], "Body paragraph with 中文。")
 
+    def test_read_gbk_encoded_file(self):
+        # GBK is a common encoding for Chinese text files on Windows; the
+        # reader must fall back to it when UTF-8 decoding fails (matching the
+        # ReportLab text-to-PDF path).
+        import tempfile
+
+        text = "第一段中文。\n\n第二段中文。"
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".txt", delete=False
+        ) as f:
+            f.write(text.encode("gbk"))
+            path = f.name
+        try:
+            content = build_content_list_from_text_file(path)
+        finally:
+            import os
+
+            os.unlink(path)
+
+        self.assertEqual(len(content), 2)
+        self.assertEqual(content[0]["text"], "第一段中文。")
+        self.assertEqual(content[1]["text"], "第二段中文。")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_content_list_alias_handling.py
+++ b/tests/test_content_list_alias_handling.py
@@ -75,6 +75,8 @@ get_equation_text_and_format = utils_module.get_equation_text_and_format
 get_table_body = utils_module.get_table_body
 normalize_caption_list = utils_module.normalize_caption_list
 separate_content = utils_module.separate_content
+build_content_list_from_text = utils_module.build_content_list_from_text
+build_content_list_from_text_file = utils_module.build_content_list_from_text_file
 extract_section_path_from_content_list = (
     utils_module.extract_section_path_from_content_list
 )
@@ -208,6 +210,66 @@ class ContentListAliasHandlingTests(unittest.TestCase):
         content = [{"type": "text", "text": "1 Intro", "text_level": 1}]
         self.assertEqual(extract_section_path_from_content_list(content, -1), "")
         self.assertEqual(extract_neighbor_text_from_content_list(content, 99), "")
+
+
+class TestBuildContentListFromText(unittest.TestCase):
+    """#331: .txt/.md are built directly into a content list, no PDF round trip."""
+
+    def test_paragraphs_split_on_blank_lines(self):
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird."
+        content = build_content_list_from_text(text)
+
+        self.assertEqual(len(content), 3)
+        self.assertEqual(content[0]["type"], "text")
+        self.assertEqual(content[0]["text"], "First paragraph.")
+        self.assertEqual(content[1]["text"], "Second paragraph.")
+        self.assertEqual(content[2]["text"], "Third.")
+        # every block carries the synthetic page index
+        for block in content:
+            self.assertEqual(block["page_idx"], 0)
+
+    def test_blank_and_whitespace_only_paragraphs_ignored(self):
+        text = "Para one.\n\n   \n\nPara two.\n\n\n\nPara three."
+        content = build_content_list_from_text(text)
+
+        self.assertEqual(
+            [c["text"] for c in content], ["Para one.", "Para two.", "Para three."]
+        )
+
+    def test_empty_text_returns_empty_list(self):
+        self.assertEqual(build_content_list_from_text(""), [])
+        self.assertEqual(build_content_list_from_text("\n\n  \n"), [])
+
+    def test_cjk_text_preserved(self):
+        text = "第一段中文内容。\n\n第二段中文内容。"
+        content = build_content_list_from_text(text)
+
+        self.assertEqual(len(content), 2)
+        self.assertEqual(content[0]["text"], "第一段中文内容。")
+        self.assertEqual(content[1]["text"], "第二段中文内容。")
+
+    def test_custom_page_idx_stamped(self):
+        content = build_content_list_from_text("Hello", page_idx=7)
+        self.assertEqual(content[0]["page_idx"], 7)
+
+    def test_read_from_file_utf8(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", encoding="utf-8", delete=False
+        ) as f:
+            f.write("# Title\n\nBody paragraph with 中文。")
+            path = f.name
+        try:
+            content = build_content_list_from_text_file(path)
+        finally:
+            import os
+
+            os.unlink(path)
+
+        self.assertEqual(len(content), 2)
+        self.assertEqual(content[0]["text"], "# Title")
+        self.assertEqual(content[1]["text"], "Body paragraph with 中文。")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`.txt` / `.md` files are currently routed through `convert_text_to_pdf` (ReportLab) and then OCR-parsed by MinerU — a round trip that is ~3× slower (52s → 18.9s), introduces fidelity bugs (CJK font rendering #24/#226, markdown escaping #316), and burns OCR compute on content that needs none.

This change parses plain text / markdown directly: `parse_document` now detects `.txt` / `.md` and builds the content list straight from the file (paragraph-split on blank lines, `{"type": "text", "text": …, "page_idx": 0}`), feeding the existing insert path unchanged. UTF-8 reading with invalid bytes replaced keeps CJK and other non-ASCII text intact.

Verification: 6 new unit tests (13/13 pass); a Chinese markdown file parses into the expected text blocks with `page_idx=0`.

Closes #331
