### PR TITLE
feat(parser): support native MinerU content list v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,7 @@ await rag.process_document_complete(
     backend="pipeline",          # Parsing backend: pipeline|hybrid-auto-engine|hybrid-http-client|vlm-auto-engine|vlm-http-client.
     source="huggingface",        # Model source: "huggingface", "modelscope", "local"
     # vlm_url="http://127.0.0.1:3000" # Service address when using backend=vlm-http-client
+    include_layout_blocks=False,  # Keep MinerU v2 headers, footers, and page numbers only when needed
 
     # Standard RAGAnything parameters
     display_stats=True,          # Display content statistics
@@ -1162,6 +1163,22 @@ await rag.process_document_complete(
 ```
 
 > **Note**: MinerU 2.0 no longer uses the `magic-pdf.json` configuration file. All settings are now passed as command-line parameters or function arguments. RAG-Anything supports multiple document parsers, including MinerU, Docling, and PaddleOCR.
+
+#### MinerU 3.x Content List v2
+
+RAG-Anything natively reads MinerU 3.x `*_content_list_v2.json` and `content_list_v2.json` outputs when they are available, ahead of the legacy flat content list. Document-scoped output directories are preferred over shared roots; within one bundle, v2 is preferred over legacy and exact stem filenames are preferred over generic filenames. The v2 page-grouped representation is converted to the existing flat `content_list` contract while preserving page indexes, bounding boxes, anchors, heading levels, visual metadata, captions, and footnotes. Algorithm blocks use the compatible `type="code", sub_type="algorithm"` representation.
+
+Page headers, footers, page numbers, aside text, and page footnotes are excluded by default so repeated layout artifacts do not enter semantic retrieval or graph construction. Set `include_layout_blocks=True` only when those blocks are meaningful for your use case:
+
+```python
+await rag.process_document_complete(
+    file_path="document.pdf",
+    parser="mineru",
+    include_layout_blocks=True,
+)
+```
+
+MinerU marks v2 as an evolving output schema. RAG-Anything skips unknown future block types with a warning, but falls back to the legacy content list when a v2 file is malformed, structurally invalid, or yields no supported semantic blocks and a legacy file is present.
 
 ### Processing Requirements
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1098,6 +1098,7 @@ await rag.process_document_complete(
     backend="pipeline",          # 解析后端：pipeline|hybrid-auto-engine|hybrid-http-client|vlm-auto-engine|vlm-http-client
     source="huggingface",        # 模型源："huggingface", "modelscope", "local"
     # vlm_url="http://127.0.0.1:3000" # 当backend=vlm-http-client时，需指定服务地址
+    include_layout_blocks=False,  # 仅在确有需要时保留 MinerU v2 的页眉、页脚和页码
 
     # RAGAnything标准参数
     display_stats=True,          # 显示内容统计信息
@@ -1107,6 +1108,22 @@ await rag.process_document_complete(
 ```
 
 > **注意**：MinerU 2.0不再使用 `magic-pdf.json` 配置文件。所有设置现在通过命令行参数或函数参数传递。RAG-Anything现在支持多种文档解析器 - 你可以根据需要在MinerU和Docling之间选择。
+
+#### MinerU 3.x Content List v2
+
+当 MinerU 3.x 产出 `*_content_list_v2.json` 或 `content_list_v2.json` 时，RAG-Anything 会优先读取它们，而不是旧的扁平 content list。文件发现遵循确定性优先级：文档专属目录优先于共享根目录；同一 bundle 内 v2 优先于 legacy，同一 schema 内精确文件名优先于 generic 文件名。v2 按页分组的结构会被转换为现有的扁平 `content_list` 契约，同时保留页码、边界框、锚点、标题层级、视觉元数据、标题说明和脚注。算法块会兼容归一为 `type="code", sub_type="algorithm"`。
+
+默认会排除页眉、页脚、页码、旁注和页脚注，避免重复版面噪声进入语义检索或图谱构建。只有这些信息确实有业务意义时，才开启 `include_layout_blocks=True`：
+
+```python
+await rag.process_document_complete(
+    file_path="document.pdf",
+    parser="mineru",
+    include_layout_blocks=True,
+)
+```
+
+MinerU 将 v2 标记为持续演进的输出 schema。RAG-Anything 会记录并跳过未来的未知块；当 v2 文件损坏、结构无效，或没有生成任何可支持的语义块且存在旧版文件时，会自动回退到 legacy content list。
 
 ### 处理要求
 

--- a/raganything/mineru_content.py
+++ b/raganything/mineru_content.py
@@ -1,0 +1,505 @@
+"""Adapters for MinerU structured content-list output.
+
+MinerU 3.x can emit ``*_content_list_v2.json`` as a list of pages, while
+RAG-Anything's processing pipeline consumes a flat list of content blocks.
+This module keeps that schema conversion independent from file-system access
+so it can be tested without installing or running MinerU.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class MineruContentListV2Error(ValueError):
+    """Raised when a value cannot be interpreted as a MinerU v2 content list."""
+
+
+MINERU_V2_LAYOUT_TYPES = frozenset(
+    {
+        "page_header",
+        "page_footer",
+        "page_number",
+        "page_aside_text",
+        "page_footnote",
+    }
+)
+
+_TEXT_TYPES = frozenset(
+    {
+        "title",
+        "paragraph",
+        # Keep direct block forms for forward compatibility with backends that
+        # expose the pre-normalized layout types instead of paragraph.
+        "abstract",
+        "phonetic",
+        "text",
+    }
+)
+_LIST_TYPES = frozenset({"list", "index"})
+_INLINE_EQUATION_TYPES = frozenset({"equation_inline", "inline_equation"})
+_REFERENCE_TYPES = frozenset({"ref_text"})
+
+_KNOWN_BLOCK_TYPES = frozenset(
+    {
+        *_TEXT_TYPES,
+        *_LIST_TYPES,
+        *_INLINE_EQUATION_TYPES,
+        *_REFERENCE_TYPES,
+        "image",
+        "table",
+        "equation_interline",
+        "chart",
+        "code",
+        "algorithm",
+        *MINERU_V2_LAYOUT_TYPES,
+    }
+)
+
+
+def convert_mineru_content_list_v2(
+    payload: Any,
+    *,
+    include_layout_blocks: bool = False,
+) -> list[dict[str, Any]]:
+    """Convert MinerU's page-grouped v2 output to RAG-Anything's flat schema.
+
+    Args:
+        payload: Parsed JSON value. The v2 schema is ``list[list[dict]]``.
+        include_layout_blocks: Keep page headers, footers, page numbers,
+            aside text, and page footnotes when ``True``. They are excluded
+            by default because they are layout artifacts rather than semantic
+            document content.
+
+    Returns:
+        A flat list compatible with :func:`raganything.utils.separate_content`.
+
+    Raises:
+        MineruContentListV2Error: If the top-level shape is not a valid v2
+            content list.
+    """
+    _validate_payload(payload)
+
+    converted: list[dict[str, Any]] = []
+    for page_idx, page in enumerate(payload):
+        for block in page:
+            item = _convert_block(
+                block,
+                page_idx,
+                include_layout_blocks=include_layout_blocks,
+            )
+            if item is not None:
+                converted.append(item)
+
+    if not converted:
+        raise MineruContentListV2Error(
+            "MinerU content_list_v2 does not contain any supported content blocks"
+        )
+
+    return converted
+
+
+def _validate_payload(payload: Any) -> None:
+    if not isinstance(payload, list) or not payload:
+        raise MineruContentListV2Error(
+            "MinerU content_list_v2 must be a non-empty list of pages"
+        )
+
+    has_block = False
+    for page_idx, page in enumerate(payload):
+        if not isinstance(page, list):
+            raise MineruContentListV2Error(
+                f"MinerU content_list_v2 page {page_idx} must be a list"
+            )
+        for block_idx, block in enumerate(page):
+            has_block = True
+            if not isinstance(block, Mapping):
+                raise MineruContentListV2Error(
+                    "MinerU content_list_v2 block "
+                    f"{page_idx}:{block_idx} must be an object"
+                )
+
+    if not has_block:
+        raise MineruContentListV2Error(
+            "MinerU content_list_v2 does not contain any content blocks"
+        )
+
+
+def _convert_block(
+    block: Mapping[str, Any],
+    page_idx: int,
+    *,
+    include_layout_blocks: bool,
+) -> dict[str, Any] | None:
+    block_type = block.get("type")
+    if not isinstance(block_type, str) or not block_type.strip():
+        logger.warning("Skipping MinerU content_list_v2 block without a type")
+        return None
+    block_type = block_type.strip()
+
+    if block_type not in _KNOWN_BLOCK_TYPES:
+        logger.warning(
+            "Skipping unsupported MinerU content_list_v2 type: %s", block_type
+        )
+        return None
+
+    if block_type in MINERU_V2_LAYOUT_TYPES:
+        if not include_layout_blocks:
+            return None
+        content = _block_content(block)
+        text = _text_value(
+            content.get(f"{block_type}_content", content.get("text", content))
+        ).strip()
+        if not text:
+            return None
+        return _finish_item(
+            {"type": block_type, "text": text}, block, page_idx, block_type
+        )
+
+    content = _block_content(block)
+
+    if block_type in _INLINE_EQUATION_TYPES:
+        equation_text = _text_value(
+            content.get("math_content", content.get("text", content))
+        ).strip()
+        if not equation_text:
+            return None
+        if not equation_text.startswith("$"):
+            equation_text = f"${equation_text}$"
+        return _finish_item(
+            {"type": "text", "text": equation_text},
+            block,
+            page_idx,
+            block_type,
+        )
+
+    if block_type in _TEXT_TYPES:
+        content_key = f"{block_type}_content"
+        text = _text_value(
+            content.get(
+                content_key, content.get("text", content.get("content", content))
+            )
+        ).strip()
+        if not text:
+            return None
+
+        item: dict[str, Any] = {"type": "text", "text": text}
+        if block_type == "title":
+            level = _positive_int(content.get("level", block.get("level")))
+            if level is not None:
+                item["text_level"] = level
+        return _finish_item(item, block, page_idx, block_type)
+
+    if block_type in _LIST_TYPES:
+        list_items = _list_items(content.get("list_items", []))
+        if not list_items:
+            fallback_text = _text_value(content.get("text", content)).strip()
+            if fallback_text:
+                list_items = [fallback_text]
+        if not list_items:
+            return None
+
+        item = {
+            "type": "text",
+            "text": "\n".join(list_items),
+            "list_items": list_items,
+        }
+        list_type = content.get("list_type")
+        if isinstance(list_type, str) and list_type:
+            item["list_type"] = list_type
+        attribute = content.get("attribute")
+        if isinstance(attribute, str) and attribute:
+            item["list_attribute"] = attribute
+        return _finish_item(item, block, page_idx, block_type)
+
+    if block_type in _REFERENCE_TYPES:
+        text = _text_value(
+            content.get(
+                "ref_text_content", content.get("text", content.get("content", content))
+            )
+        ).strip()
+        if not text:
+            return None
+        return _finish_item(
+            {"type": "text", "text": text, "list_type": "reference_list"},
+            block,
+            page_idx,
+            block_type,
+        )
+
+    if block_type == "image":
+        item = {"type": "image", "img_path": ""}
+        image_path = _source_path(content.get("image_source"))
+        if image_path:
+            item["img_path"] = image_path
+        visual_content = _text_value(content.get("content", "")).strip()
+        if visual_content:
+            item["content"] = visual_content
+        _copy_captions(item, content, "image")
+        return _finish_item(item, block, page_idx, block_type)
+
+    if block_type == "table":
+        item = {"type": "table"}
+        table_path = _source_path(content.get("image_source"))
+        if table_path:
+            item["img_path"] = table_path
+        table_body = content.get("html")
+        if table_body in (None, ""):
+            table_body = content.get("table_body", content.get("table_data"))
+        if table_body not in (None, ""):
+            item["table_body"] = table_body
+        _copy_captions(item, content, "table")
+        for key in ("table_type", "table_nest_level"):
+            if key in content:
+                item[key] = content[key]
+        return _finish_item(item, block, page_idx, block_type)
+
+    if block_type == "equation_interline":
+        item = {"type": "equation"}
+        equation_text = _text_value(
+            content.get("math_content", content.get("text", content.get("latex", "")))
+        ).strip()
+        if equation_text:
+            item["text"] = equation_text
+        equation_format = content.get("math_type", content.get("text_format"))
+        if isinstance(equation_format, str) and equation_format:
+            item["text_format"] = equation_format
+        equation_path = _source_path(content.get("image_source"))
+        if equation_path:
+            item["img_path"] = equation_path
+        return _finish_item(item, block, page_idx, block_type)
+
+    if block_type == "chart":
+        item = {"type": "chart"}
+        chart_path = _source_path(content.get("image_source"))
+        if chart_path:
+            item["img_path"] = chart_path
+        chart_content = _text_value(
+            content.get("chart_content", content.get("content", ""))
+        ).strip()
+        if chart_content:
+            item["content"] = chart_content
+        _copy_captions(item, content, "chart")
+        return _finish_item(item, block, page_idx, block_type)
+
+    if block_type in {"code", "algorithm"}:
+        content_key = "code_content" if block_type == "code" else "algorithm_content"
+        code_content = _text_value(content.get(content_key, content.get("content", "")))
+        item = {
+            # The legacy flat contract represents algorithms as code blocks
+            # distinguished by sub_type. Keep that contract for downstream
+            # processors while retaining the original v2 type in metadata.
+            "type": "code",
+            "sub_type": block_type,
+            "code_body": code_content.strip(),
+        }
+        if code_content.strip():
+            item["content"] = code_content.strip()
+        if block_type == "code" and content.get("code_language"):
+            item["code_language"] = content["code_language"]
+        caption_key = "code_caption" if block_type == "code" else "algorithm_caption"
+        captions = _caption_values(content.get(caption_key))
+        if captions:
+            # Keep the source-specific field as well as the canonical legacy
+            # alias so callers can inspect either representation.
+            item[caption_key] = captions
+            item["code_caption"] = captions
+        footnote_key = "code_footnote" if block_type == "code" else "algorithm_footnote"
+        footnotes = _caption_values(content.get(footnote_key))
+        if footnotes:
+            item[footnote_key] = footnotes
+            item["code_footnote"] = footnotes
+        return _finish_item(item, block, page_idx, block_type)
+
+    raise AssertionError(f"Unhandled known MinerU content_list_v2 type: {block_type}")
+
+
+def _finish_item(
+    item: dict[str, Any],
+    block: Mapping[str, Any],
+    page_idx: int,
+    block_type: str,
+) -> dict[str, Any]:
+    item["page_idx"] = _page_idx(block.get("page_idx"), page_idx)
+    item["_mineru_v2_type"] = block_type
+
+    bbox = block.get("bbox")
+    if isinstance(bbox, (list, tuple)) and len(bbox) == 4:
+        item["bbox"] = list(bbox)
+
+    anchor = block.get("anchor")
+    if isinstance(anchor, str) and anchor.strip():
+        item["anchor"] = anchor.strip()
+
+    sub_type = block.get("sub_type")
+    if sub_type is None and isinstance(block.get("content"), Mapping):
+        sub_type = block["content"].get("sub_type")
+    if isinstance(sub_type, str) and sub_type.strip():
+        item["sub_type"] = sub_type.strip()
+
+    return item
+
+
+def _block_content(block: Mapping[str, Any]) -> dict[str, Any]:
+    content = block.get("content", {})
+    if isinstance(content, Mapping):
+        return dict(content)
+    if content in (None, ""):
+        return {}
+    return {"content": content}
+
+
+def _page_idx(value: Any, fallback: int) -> int:
+    try:
+        return int(value) if value is not None else fallback
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _text_value(value: Any) -> str:
+    """Extract visible text while retaining inline-equation semantics."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, Mapping):
+        span_type = value.get("type")
+        if isinstance(span_type, str) and span_type in _INLINE_EQUATION_TYPES:
+            equation = _text_value(value.get("content", value.get("text", "")))
+            if not equation:
+                return ""
+            if equation.startswith("$"):
+                return equation
+            return f"${equation}$"
+
+        content = value.get("content")
+        if content not in (None, ""):
+            text = _text_value(content)
+            if text:
+                return text
+        children = value.get("children")
+        if children:
+            return _text_value(children)
+        for key in (
+            "title_content",
+            "paragraph_content",
+            "math_content",
+            "code_content",
+            "algorithm_content",
+            "text",
+        ):
+            if key in value:
+                text = _text_value(value[key])
+                if text:
+                    return text
+        return ""
+    if isinstance(value, (list, tuple)):
+        return _join_text_parts([_text_value(part) for part in value])
+    return str(value).strip()
+
+
+def _join_text_parts(parts: list[str]) -> str:
+    """Join v2 spans without merging adjacent Latin words together."""
+    result = ""
+    for part in parts:
+        if not part:
+            continue
+        if (
+            result
+            and not result[-1].isspace()
+            and not part[0].isspace()
+            and _needs_span_separator(result[-1], part[0])
+        ):
+            result += " "
+        result += part
+    return result.strip()
+
+
+def _needs_span_separator(left: str, right: str) -> bool:
+    if left.isspace() or right.isspace():
+        return False
+    if _is_cjk(left) or _is_cjk(right):
+        return False
+    return not (right in ",.;:!?)]}" or left in "([{")
+
+
+def _is_cjk(char: str) -> bool:
+    return "\u3400" <= char <= "\u9fff"
+
+
+def _list_items(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        text = _text_value(value)
+        return [text] if text else []
+
+    result: list[str] = []
+    for entry in value:
+        if isinstance(entry, Mapping):
+            entry = entry.get(
+                "item_content", entry.get("content", entry.get("text", entry))
+            )
+        text = _text_value(entry).strip()
+        if text:
+            result.append(text)
+    return result
+
+
+def _caption_values(value: Any) -> list[str]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, Mapping):
+        text = _text_value(value)
+        text = text.strip()
+        return [text] if text else []
+    if isinstance(value, (list, tuple)):
+        if any(isinstance(entry, Mapping) and "type" in entry for entry in value):
+            text = _text_value(value)
+            return [text] if text else []
+        result: list[str] = []
+        for entry in value:
+            result.extend(_caption_values(entry))
+        return result
+    text = _text_value(value)
+    return [text] if text else []
+
+
+def _copy_captions(
+    item: dict[str, Any], content: Mapping[str, Any], prefix: str
+) -> None:
+    captions = _caption_values(content.get(f"{prefix}_caption"))
+    footnotes = _caption_values(content.get(f"{prefix}_footnote"))
+    if captions:
+        item[f"{prefix}_caption"] = captions
+    if footnotes:
+        item[f"{prefix}_footnote"] = footnotes
+
+
+def _source_path(source: Any) -> str:
+    if isinstance(source, Mapping):
+        source = source.get("path", source.get("source", source.get("url", "")))
+    if isinstance(source, str):
+        return source.strip()
+    return ""
+
+
+__all__ = [
+    "MINERU_V2_LAYOUT_TYPES",
+    "MineruContentListV2Error",
+    "convert_mineru_content_list_v2",
+]

--- a/raganything/mineru_content.py
+++ b/raganything/mineru_content.py
@@ -8,6 +8,8 @@ so it can be tested without installing or running MinerU.
 
 from __future__ import annotations
 
+import posixpath
+
 import logging
 from collections.abc import Mapping
 from typing import Any
@@ -494,7 +496,13 @@ def _source_path(source: Any) -> str:
     if isinstance(source, Mapping):
         source = source.get("path", source.get("source", source.get("url", "")))
     if isinstance(source, str):
-        return source.strip()
+        source = source.strip()
+        # A path with an empty basename (e.g. "images/") would resolve to a
+        # directory downstream and surface as a misleading per-item
+        # description error; treat it as no source.
+        if posixpath.basename(source.replace("\\", "/")) in ("", ".", ".."):
+            return ""
+        return source
     return ""
 
 

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -54,6 +54,10 @@ if TYPE_CHECKING:
     from PIL import Image
 
 from raganything.asset_urls import attach_public_media_urls
+from raganything.mineru_content import (
+    MineruContentListV2Error,
+    convert_mineru_content_list_v2,
+)
 
 _IS_WINDOWS: bool = platform.system() == "Windows"
 
@@ -1169,8 +1173,135 @@ class MineruParser(Parser):
             raise RuntimeError(error_message) from e
 
     @classmethod
+    def _find_mineru_output_files(
+        cls, output_dir: Path, file_stem: str, method: str
+    ) -> Tuple[Path, Path, Optional[Path], Path, bool]:
+        """Locate MinerU outputs, preferring the structured v2 content list."""
+        output_dir = Path(output_dir)
+        file_stem_subdir = output_dir / file_stem
+
+        search_dirs = [output_dir]
+        if file_stem_subdir.is_dir():
+            method_dir = file_stem_subdir / method
+            nested_dirs = sorted(
+                (path for path in file_stem_subdir.iterdir() if path.is_dir()),
+                key=lambda path: path.name,
+            )
+            # Prefer the requested backend directory, then inspect any actual
+            # directory emitted by newer MinerU backends.
+            search_dirs.extend(
+                path
+                for path in [method_dir, file_stem_subdir, *nested_dirs]
+                if path not in search_dirs
+            )
+
+        # Keep all candidates instead of resolving each filename independently.
+        # MinerU bundles can contain the exact legacy file and a generic v2 file
+        # side by side, in which case v2 must win. Conversely, a generic file in
+        # a shared output root must not shadow an exact artifact in the
+        # document-scoped `<output>/<stem>/...` tree.
+        candidate_specs = (
+            ("v2", True, f"{file_stem}_content_list_v2.json"),
+            ("v2", False, "content_list_v2.json"),
+            ("legacy", True, f"{file_stem}_content_list.json"),
+            ("legacy", False, "content_list.json"),
+        )
+        candidates = []
+        seen_paths = set()
+        for directory_index, directory in enumerate(search_dirs):
+            for content_version, is_exact, filename in candidate_specs:
+                candidate = directory / filename
+                if not candidate.is_file() or candidate in seen_paths:
+                    continue
+                seen_paths.add(candidate)
+                is_document_scoped = (
+                    file_stem_subdir.is_dir()
+                    and candidate.parent.is_relative_to(file_stem_subdir)
+                )
+                candidates.append(
+                    {
+                        "path": candidate,
+                        "version": content_version,
+                        "is_exact": is_exact,
+                        "is_document_scoped": is_document_scoped,
+                        "directory_index": directory_index,
+                    }
+                )
+
+        def candidate_key(
+            candidate: Dict[str, Any],
+        ) -> Tuple[int, int, int, int]:
+            """Rank candidates by bundle scope, schema version, and specificity."""
+            return (
+                int(candidate["is_document_scoped"]),
+                int(candidate["version"] == "v2"),
+                int(candidate["is_exact"]),
+                -candidate["directory_index"],
+            )
+
+        selected_candidate = max(candidates, key=candidate_key, default=None)
+        v2_candidate = (
+            selected_candidate
+            if selected_candidate is not None and selected_candidate["version"] == "v2"
+            else None
+        )
+        v2_file = v2_candidate["path"] if v2_candidate is not None else None
+
+        legacy_candidates = [
+            candidate for candidate in candidates if candidate["version"] == "legacy"
+        ]
+        if v2_candidate is not None:
+            # A legacy companion in the same directory is the safest fallback
+            # (and handles generic/exact pairs produced by one MinerU run).
+            legacy_file_candidate = max(
+                legacy_candidates,
+                key=lambda candidate: (
+                    int(candidate["path"].parent == v2_candidate["path"].parent),
+                    *candidate_key(candidate),
+                ),
+                default=None,
+            )
+        else:
+            legacy_file_candidate = selected_candidate
+        legacy_file = (
+            legacy_file_candidate["path"]
+            if legacy_file_candidate is not None
+            and legacy_file_candidate["version"] == "legacy"
+            else None
+        )
+
+        selected_file = v2_file or legacy_file
+
+        if selected_file is None:
+            fallback_dir = (
+                file_stem_subdir / method if file_stem_subdir.is_dir() else output_dir
+            )
+            selected_file = fallback_dir / f"{file_stem}_content_list.json"
+            images_base_dir = fallback_dir
+        else:
+            images_base_dir = selected_file.parent
+
+        markdown_file = selected_file.parent / f"{file_stem}.md"
+        if not markdown_file.is_file():
+            full_markdown_file = selected_file.parent / "full.md"
+            if full_markdown_file.is_file():
+                markdown_file = full_markdown_file
+
+        return (
+            markdown_file,
+            selected_file,
+            legacy_file if v2_file is not None else None,
+            images_base_dir,
+            v2_file is not None,
+        )
+
+    @classmethod
     def _read_output_files(
-        cls, output_dir: Path, file_stem: str, method: str = "auto"
+        cls,
+        output_dir: Path,
+        file_stem: str,
+        method: str = "auto",
+        include_layout_blocks: bool = False,
     ) -> Tuple[List[Dict[str, Any]], str]:
         """
         Read the output files generated by mineru
@@ -1179,82 +1310,134 @@ class MineruParser(Parser):
             output_dir: Output directory
             file_stem: File name without extension
             method: Parsing method (used as fallback if subdirectory scan fails)
+            include_layout_blocks: Keep v2 page headers, footers, page numbers,
+                aside text, and page footnotes when true.
 
         Returns:
             Tuple containing (content list JSON, Markdown text)
         """
-        # Look for the generated files
-        md_file = output_dir / f"{file_stem}.md"
-        json_file = output_dir / f"{file_stem}_content_list.json"
-        images_base_dir = output_dir  # Base directory for images
+        (
+            md_file,
+            json_file,
+            legacy_json_file,
+            images_base_dir,
+            is_v2,
+        ) = cls._find_mineru_output_files(output_dir, file_stem, method)
 
-        file_stem_subdir = output_dir / file_stem
-        if file_stem_subdir.is_dir():
-            # Scan for actual output subdirectory instead of assuming method name
-            found = False
-            for subdir in file_stem_subdir.iterdir():
-                if not subdir.is_dir():
-                    continue
-                # Check if this subdirectory contains the expected JSON output file
-                candidate_json = subdir / f"{file_stem}_content_list.json"
-                if candidate_json.exists():
-                    # Found the actual output directory
-                    md_file = subdir / f"{file_stem}.md"
-                    json_file = candidate_json
-                    images_base_dir = subdir
-                    found = True
-                    cls.logger.info(
-                        f"Found MinerU output in subdirectory: {subdir.name}"
+        if is_v2:
+            cls.logger.info(f"Using MinerU structured content list: {json_file}")
+        elif not json_file.is_file():
+            cls.logger.debug(
+                f"No MinerU content list found, checked output directory: {json_file}"
+            )
+
+        def read_markdown(path: Path) -> str:
+            if not path.is_file():
+                return ""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    return f.read()
+            except OSError as e:
+                cls.logger.warning(f"Could not read markdown file {path}: {e}")
+                return ""
+
+        # Read markdown content. If v2 later falls back to a legacy file in a
+        # different directory, this value is refreshed alongside the content list.
+        md_content = read_markdown(md_file)
+
+        # Read JSON content list. A malformed or empty v2 file should not make
+        # otherwise usable legacy MinerU output unreadable.
+        content_list: List[Dict[str, Any]] = []
+        content_file_used = json_file
+        if json_file.is_file():
+            try:
+
+                def load_json(path: Path) -> Any:
+                    with open(path, "r", encoding="utf-8") as f:
+                        return json.load(f)
+
+                try:
+                    raw_content = load_json(json_file)
+                except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+                    if (
+                        not is_v2
+                        or legacy_json_file is None
+                        or not legacy_json_file.is_file()
+                    ):
+                        raise
+                    cls.logger.warning(
+                        f"Could not read MinerU v2 content list {json_file}: {error}"
                     )
-                    break
+                    raw_content = load_json(legacy_json_file)
+                    content_file_used = legacy_json_file
+                    images_base_dir = legacy_json_file.parent
+                    is_v2 = False
+                    fallback_md = legacy_json_file.parent / f"{file_stem}.md"
+                    if not fallback_md.is_file():
+                        fallback_md = legacy_json_file.parent / "full.md"
+                    if fallback_md.is_file():
+                        md_file = fallback_md
+                        md_content = read_markdown(md_file)
+                    cls.logger.info(
+                        f"Falling back to legacy MinerU content list: {legacy_json_file}"
+                    )
 
-            # Fallback to method-based path if scanning didn't find output
-            if not found:
-                cls.logger.debug(
-                    f"No output found by scanning, falling back to method-based path: {method}"
-                )
-                md_file = file_stem_subdir / method / f"{file_stem}.md"
-                json_file = file_stem_subdir / method / f"{file_stem}_content_list.json"
-                images_base_dir = file_stem_subdir / method
+                if is_v2:
+                    try:
+                        content_list = convert_mineru_content_list_v2(
+                            raw_content,
+                            include_layout_blocks=include_layout_blocks,
+                        )
+                    except MineruContentListV2Error as error:
+                        cls.logger.warning(
+                            f"Could not parse MinerU v2 content list {json_file}: {error}"
+                        )
+                        content_list = []
 
-        # Read markdown content
-        md_content = ""
-        if md_file.exists():
-            try:
-                with open(md_file, "r", encoding="utf-8") as f:
-                    md_content = f.read()
-            except Exception as e:
-                cls.logger.warning(f"Could not read markdown file {md_file}: {e}")
+                    # A valid v2 file containing only filtered layout blocks is
+                    # not useful to ingestion either, so use legacy output when
+                    # it is available.
+                    if (
+                        not content_list
+                        and legacy_json_file is not None
+                        and legacy_json_file.is_file()
+                    ):
+                        raw_content = load_json(legacy_json_file)
+                        content_list = raw_content
+                        content_file_used = legacy_json_file
+                        images_base_dir = legacy_json_file.parent
+                        fallback_md = legacy_json_file.parent / f"{file_stem}.md"
+                        if not fallback_md.is_file():
+                            fallback_md = legacy_json_file.parent / "full.md"
+                        if fallback_md.is_file():
+                            md_file = fallback_md
+                            md_content = read_markdown(md_file)
+                        cls.logger.info(
+                            f"Falling back to legacy MinerU content list: {legacy_json_file}"
+                        )
+                else:
+                    content_list = raw_content
 
-        # Read JSON content list
-        content_list = []
-        if json_file.exists():
-            try:
-                with open(json_file, "r", encoding="utf-8") as f:
-                    content_list = json.load(f)
+                if not isinstance(content_list, list):
+                    raise ValueError("MinerU content list must be a JSON array")
 
-                # Normalize MinerU 2.0 field names to expected names for backward compatibility.
-                # MinerU 2.0 renamed: img_caption -> image_caption, img_footnote -> image_footnote
-                # The codebase primarily uses image_caption/image_footnote with img_caption/img_footnote
-                # as fallback, but we ensure both fields exist so downstream code works regardless.
-                _FIELD_ALIASES = {
-                    # MinerU 1.x name -> MinerU 2.0 name (canonical)
+                # Normalize MinerU field aliases to the names expected by the
+                # existing modal processors.
+                field_aliases = {
                     "img_caption": "image_caption",
                     "img_footnote": "image_footnote",
                 }
                 for item in content_list:
                     if isinstance(item, dict):
-                        for old_name, new_name in _FIELD_ALIASES.items():
-                            # If only the old field exists, copy it to the new field name
+                        for old_name, new_name in field_aliases.items():
                             if old_name in item and new_name not in item:
                                 item[new_name] = item[old_name]
-                            # If only the new field exists, copy it to the old field name (for any legacy code)
                             elif new_name in item and old_name not in item:
                                 item[old_name] = item[new_name]
 
-                # Always fix relative paths in content_list to absolute paths
+                # Always fix relative paths in content_list to absolute paths.
                 cls.logger.info(
-                    f"Fixing image paths in {json_file} with base directory: {images_base_dir}"
+                    f"Fixing image paths in {content_file_used} with base directory: {images_base_dir}"
                 )
                 for item in content_list:
                     if isinstance(item, dict):
@@ -1269,13 +1452,13 @@ class MineruParser(Parser):
                                     images_base_dir / img_path
                                 ).resolve()
 
-                                # Security check: ensure the image path is within the base directory
+                                # Security check: ensure the image path is within the base directory.
                                 resolved_base = images_base_dir.resolve()
                                 if not absolute_img_path.is_relative_to(resolved_base):
                                     cls.logger.warning(
                                         f"Potential path traversal detected in {field_name}: {img_path}. Skipping."
                                     )
-                                    item[field_name] = ""  # Clear unsafe path
+                                    item[field_name] = ""
                                     continue
 
                                 item[field_name] = str(absolute_img_path)
@@ -1293,6 +1476,7 @@ class MineruParser(Parser):
         output_dir: Optional[str] = None,
         method: str = "auto",
         lang: Optional[str] = None,
+        include_layout_blocks: bool = False,
         **kwargs,
     ) -> List[Dict[str, Any]]:
         """
@@ -1303,6 +1487,8 @@ class MineruParser(Parser):
             output_dir: Output directory path
             method: Parsing method (auto, txt, ocr)
             lang: Document language for OCR optimization
+            include_layout_blocks: Keep MinerU v2 page-level layout blocks
+                such as headers and page numbers.
             **kwargs: Additional parameters for mineru command
 
         Returns:
@@ -1355,7 +1541,10 @@ class MineruParser(Parser):
                     method = "hybrid_auto"
 
                 content_list, _ = self._read_output_files(
-                    base_output_dir, file_stem, method=method
+                    base_output_dir,
+                    file_stem,
+                    method=method,
+                    include_layout_blocks=include_layout_blocks,
                 )
                 return content_list
             finally:
@@ -1372,6 +1561,7 @@ class MineruParser(Parser):
         image_path: Union[str, Path],
         output_dir: Optional[str] = None,
         lang: Optional[str] = None,
+        include_layout_blocks: bool = False,
         **kwargs,
     ) -> List[Dict[str, Any]]:
         """
@@ -1384,6 +1574,8 @@ class MineruParser(Parser):
             image_path: Path to the image file
             output_dir: Output directory path
             lang: Document language for OCR optimization
+            include_layout_blocks: Keep MinerU v2 page-level layout blocks
+                such as headers and page numbers.
             **kwargs: Additional parameters for mineru command
 
         Returns:
@@ -1487,7 +1679,10 @@ class MineruParser(Parser):
 
                 # Read the generated output files
                 content_list, _ = self._read_output_files(
-                    base_output_dir, file_stem, method="ocr"
+                    base_output_dir,
+                    file_stem,
+                    method="ocr",
+                    include_layout_blocks=include_layout_blocks,
                 )
                 return content_list
 

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -29,8 +29,33 @@ import asyncio
 from lightrag.utils import compute_mdhash_id
 
 
+_PARSER_CACHE_KWARGS = frozenset(
+    {
+        "lang",
+        "device",
+        "start_page",
+        "end_page",
+        "formula",
+        "table",
+        "backend",
+        "source",
+        "include_layout_blocks",
+    }
+)
+
+
 class ProcessorMixin:
     """ProcessorMixin class containing document processing functionality for RAGAnything"""
+
+    @staticmethod
+    def _relevant_parser_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Return parser options that change the persisted parse result."""
+        return {
+            key: value
+            for key, value in kwargs.items()
+            if key in _PARSER_CACHE_KWARGS
+            and not (key == "include_layout_blocks" and not value)
+        }
 
     def _get_file_reference(self, file_path: str) -> str:
         """
@@ -74,22 +99,7 @@ class ProcessorMixin:
         }
 
         # Add relevant kwargs to config
-        relevant_kwargs = {
-            k: v
-            for k, v in kwargs.items()
-            if k
-            in [
-                "lang",
-                "device",
-                "start_page",
-                "end_page",
-                "formula",
-                "table",
-                "backend",
-                "source",
-            ]
-        }
-        config_dict.update(relevant_kwargs)
+        config_dict.update(self._relevant_parser_kwargs(kwargs))
 
         # Generate hash from config
         config_str = json.dumps(config_dict, sort_keys=True)
@@ -277,22 +287,7 @@ class ProcessorMixin:
             }
 
             # Add relevant kwargs to current config
-            relevant_kwargs = {
-                k: v
-                for k, v in kwargs.items()
-                if k
-                in [
-                    "lang",
-                    "device",
-                    "start_page",
-                    "end_page",
-                    "formula",
-                    "table",
-                    "backend",
-                    "source",
-                ]
-            }
-            current_config.update(relevant_kwargs)
+            current_config.update(self._relevant_parser_kwargs(kwargs))
 
             if cached_config != current_config:
                 self.logger.debug(f"Cache invalid - config changed: {cache_key}")
@@ -351,22 +346,7 @@ class ProcessorMixin:
             }
 
             # Add relevant kwargs to config
-            relevant_kwargs = {
-                k: v
-                for k, v in kwargs.items()
-                if k
-                in [
-                    "lang",
-                    "device",
-                    "start_page",
-                    "end_page",
-                    "formula",
-                    "table",
-                    "backend",
-                    "source",
-                ]
-            }
-            parse_config.update(relevant_kwargs)
+            parse_config.update(self._relevant_parser_kwargs(kwargs))
 
             cache_data = {
                 cache_key: {
@@ -401,7 +381,9 @@ class ProcessorMixin:
             output_dir: Output directory (defaults to config.parser_output_dir)
             parse_method: Parse method (defaults to config.parse_method)
             display_stats: Whether to display content statistics (defaults to config.display_content_stats)
-            **kwargs: Additional parameters for parser (e.g., lang, device, start_page, end_page, formula, table, backend, source)
+            **kwargs: Additional parameters for parser (e.g., lang, device,
+                start_page, end_page, formula, table, backend, source,
+                include_layout_blocks)
 
         Returns:
             tuple[List[Dict[str, Any]], str]: (content_list, doc_id)
@@ -1668,7 +1650,9 @@ class ProcessorMixin:
             split_by_character: Optional character to split the text by
             split_by_character_only: If True, split only by the specified character
             doc_id: Optional document ID, if not provided will be generated from content
-            **kwargs: Additional parameters for parser (e.g., lang, device, start_page, end_page, formula, table, backend, source)
+            **kwargs: Additional parameters for parser (e.g., lang, device,
+                start_page, end_page, formula, table, backend, source,
+                include_layout_blocks)
         """
         callback_manager = getattr(self, "callback_manager", None)
         doc_start_time = time.time()
@@ -1835,7 +1819,9 @@ class ProcessorMixin:
             split_by_character: Optional character to split the text by
             split_by_character_only: If True, split only by the specified character
             doc_id: Optional document ID, if not provided will be generated from content
-            **kwargs: Additional parameters for parser (e.g., lang, device, start_page, end_page, formula, table, backend, source)
+            **kwargs: Additional parameters for parser (e.g., lang, device,
+                start_page, end_page, formula, table, backend, source,
+                include_layout_blocks)
         """
         # Use full path or basename based on config
         file_name = self._get_file_reference(file_path)

--- a/tests/test_mineru_content.py
+++ b/tests/test_mineru_content.py
@@ -1,0 +1,469 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from raganything.mineru_content import (
+    MineruContentListV2Error,
+    convert_mineru_content_list_v2,
+)
+from raganything.parser import MineruParser
+from raganything.processor import ProcessorMixin
+from raganything.utils import separate_content
+
+
+def _text_span(text):
+    return {"type": "text", "content": text}
+
+
+def _v2_payload():
+    return [
+        [
+            {
+                "type": "page_header",
+                "content": {"page_header_content": [_text_span("Running header")]},
+                "bbox": [0, 0, 100, 20],
+            },
+            {
+                "type": "title",
+                "content": {
+                    "title_content": [_text_span("1 Introduction")],
+                    "level": 1,
+                },
+                "bbox": [83, 121, 917, 156],
+            },
+            {
+                "type": "paragraph",
+                "content": {
+                    "paragraph_content": [
+                        _text_span("The method uses"),
+                        {"type": "equation_inline", "content": "x^2"},
+                        _text_span("features."),
+                    ]
+                },
+            },
+            {
+                "type": "image",
+                "content": {
+                    "image_source": {"path": "images/figure.png"},
+                    "content": "A system overview",
+                    "image_caption": [_text_span("Figure 1")],
+                    "image_footnote": [_text_span("Source: paper")],
+                },
+            },
+            {
+                "type": "table",
+                "content": {
+                    "image_source": {"path": "images/table.png"},
+                    "html": "<table><tr><td>value</td></tr></table>",
+                    "table_caption": [_text_span("Results")],
+                    "table_footnote": [_text_span("Higher is better")],
+                    "table_type": "simple_table",
+                },
+            },
+            {
+                "type": "equation_interline",
+                "content": {
+                    "math_content": "E = mc^2",
+                    "math_type": "latex",
+                    "image_source": {"path": "images/equation.png"},
+                },
+            },
+            {
+                "type": "page_number",
+                "content": {"page_number_content": [_text_span("1")]},
+            },
+        ],
+        [
+            {
+                "type": "list",
+                "content": {
+                    "list_type": "text_list",
+                    "list_items": [
+                        {"item_type": "text", "item_content": [_text_span("First")]},
+                        {"item_type": "text", "item_content": [_text_span("Second")]},
+                    ],
+                },
+            }
+        ],
+    ]
+
+
+def test_convert_v2_flattens_pages_and_preserves_semantic_metadata():
+    content_list = convert_mineru_content_list_v2(_v2_payload())
+
+    assert [item["type"] for item in content_list] == [
+        "text",
+        "text",
+        "image",
+        "table",
+        "equation",
+        "text",
+    ]
+    assert content_list[0]["text"] == "1 Introduction"
+    assert content_list[0]["text_level"] == 1
+    assert content_list[0]["bbox"] == [83, 121, 917, 156]
+    assert content_list[1]["text"] == "The method uses $x^2$ features."
+    assert content_list[2]["img_path"] == "images/figure.png"
+    assert content_list[2]["image_caption"] == ["Figure 1"]
+    assert content_list[2]["image_footnote"] == ["Source: paper"]
+    assert content_list[3]["table_body"].startswith("<table>")
+    assert content_list[3]["table_caption"] == ["Results"]
+    assert content_list[4]["text"] == "E = mc^2"
+    assert content_list[4]["text_format"] == "latex"
+    assert content_list[5]["page_idx"] == 1
+    assert content_list[5]["list_items"] == ["First", "Second"]
+
+
+def test_convert_v2_filters_layout_blocks_by_default_and_can_restore_them():
+    default_content = convert_mineru_content_list_v2(_v2_payload())
+    with_layout = convert_mineru_content_list_v2(
+        _v2_payload(), include_layout_blocks=True
+    )
+
+    assert all(item["_mineru_v2_type"] != "page_header" for item in default_content)
+    assert all(item["_mineru_v2_type"] != "page_number" for item in default_content)
+    layout_items = [
+        item
+        for item in with_layout
+        if item["_mineru_v2_type"] in {"page_header", "page_number"}
+    ]
+    assert [item["text"] for item in layout_items] == ["Running header", "1"]
+    assert all(item["type"].startswith("page_") for item in layout_items)
+
+
+def test_convert_v2_preserves_extended_mineru_modalities_and_routes_text():
+    payload = [
+        [
+            {
+                "type": "list",
+                "content": {
+                    "list_type": "reference_list",
+                    "list_items": [
+                        {"item_type": "text", "item_content": [_text_span("[1] Ref")]}
+                    ],
+                },
+            },
+            {
+                "type": "chart",
+                "sub_type": "bar_chart",
+                "anchor": "figure-2",
+                "content": {
+                    "image_source": {"path": "images/chart.png"},
+                    "content": "Revenue by quarter",
+                    "chart_caption": [_text_span("Quarterly revenue")],
+                    "chart_footnote": [_text_span("USD millions")],
+                },
+            },
+            {
+                "type": "code",
+                "content": {
+                    "code_content": "print('hello')",
+                    "code_language": "python",
+                    "code_caption": [_text_span("Example")],
+                    "code_footnote": [_text_span("Simplified")],
+                },
+            },
+            {
+                "type": "algorithm",
+                "content": {
+                    "algorithm_content": "for each item",
+                    "algorithm_caption": [_text_span("Algorithm 1")],
+                    "algorithm_footnote": [_text_span("Pseudocode")],
+                },
+            },
+            {
+                "type": "abstract",
+                "content": {"abstract_content": [_text_span("Summary")]},
+            },
+            {
+                "type": "ref_text",
+                "content": {"ref_text_content": [_text_span("Reference")]},
+            },
+            {"type": "equation_inline", "content": "a+b"},
+        ]
+    ]
+
+    content_list = convert_mineru_content_list_v2(payload)
+
+    assert content_list[0] == {
+        "type": "text",
+        "text": "[1] Ref",
+        "list_items": ["[1] Ref"],
+        "list_type": "reference_list",
+        "page_idx": 0,
+        "_mineru_v2_type": "list",
+    }
+    assert content_list[1]["img_path"] == "images/chart.png"
+    assert content_list[1]["chart_caption"] == ["Quarterly revenue"]
+    assert content_list[1]["chart_footnote"] == ["USD millions"]
+    assert content_list[1]["sub_type"] == "bar_chart"
+    assert content_list[1]["anchor"] == "figure-2"
+    assert content_list[2]["code_body"] == "print('hello')"
+    assert content_list[2]["code_footnote"] == ["Simplified"]
+    assert content_list[3]["type"] == "code"
+    assert content_list[3]["sub_type"] == "algorithm"
+    assert content_list[3]["code_body"] == "for each item"
+    assert content_list[3]["algorithm_footnote"] == ["Pseudocode"]
+    assert content_list[4]["text"] == "Summary"
+    assert content_list[5]["list_type"] == "reference_list"
+    assert content_list[5]["text"] == "Reference"
+    assert content_list[6]["text"] == "$a+b$"
+
+    text_content, multimodal_items = separate_content(content_list)
+    assert text_content == "[1] Ref\n\nSummary\n\nReference\n\n$a+b$"
+    assert [item["type"] for item in multimodal_items] == [
+        "chart",
+        "code",
+        "code",
+    ]
+
+
+def test_convert_v2_preserves_explicit_span_spacing_and_nested_links():
+    payload = [
+        [
+            {
+                "type": "paragraph",
+                "content": {
+                    "paragraph_content": [
+                        {"type": "text", "content": "A "},
+                        {
+                            "type": "hyperlink",
+                            "content": "linked text",
+                            "children": [{"type": "text", "content": " text"}],
+                        },
+                        {"type": "equation_inline", "content": "x"},
+                        {"type": "text", "content": " works."},
+                    ]
+                },
+            }
+        ]
+    ]
+
+    assert convert_mineru_content_list_v2(payload)[0]["text"] == (
+        "A linked text $x$ works."
+    )
+
+
+def test_convert_v2_skips_unknown_blocks_but_rejects_nonsemantic_payloads(caplog):
+    payload = [
+        [
+            {"type": "future_block", "content": {"content": "ignored"}},
+            {"content": {"content": "also ignored"}},
+            {"type": "paragraph", "content": {"paragraph_content": "kept"}},
+        ]
+    ]
+
+    assert convert_mineru_content_list_v2(payload)[0]["text"] == "kept"
+    assert "future_block" in caplog.text
+
+    with pytest.raises(MineruContentListV2Error, match="supported content blocks"):
+        convert_mineru_content_list_v2([[{"type": "future_block"}]])
+
+
+def test_convert_v2_rejects_invalid_shapes():
+    with pytest.raises(MineruContentListV2Error):
+        convert_mineru_content_list_v2([])
+    with pytest.raises(MineruContentListV2Error):
+        convert_mineru_content_list_v2([{"type": "paragraph"}])
+    with pytest.raises(MineruContentListV2Error):
+        convert_mineru_content_list_v2([["not a block"]])
+
+
+def test_read_output_files_prefers_v2_and_resolves_media_paths(tmp_path):
+    output_dir = tmp_path / "output"
+    parse_dir = output_dir / "paper" / "auto"
+    images_dir = parse_dir / "images"
+    images_dir.mkdir(parents=True)
+    (images_dir / "figure.png").write_bytes(b"image")
+    (parse_dir / "paper.md").write_text("markdown", encoding="utf-8")
+    (parse_dir / "paper_content_list.json").write_text(
+        json.dumps([{"type": "text", "text": "legacy"}]), encoding="utf-8"
+    )
+    (parse_dir / "paper_content_list_v2.json").write_text(
+        json.dumps(_v2_payload()), encoding="utf-8"
+    )
+
+    content_list, markdown = MineruParser._read_output_files(
+        output_dir, "paper", method="auto"
+    )
+
+    assert markdown == "markdown"
+    assert content_list[0]["text"] == "1 Introduction"
+    image = next(item for item in content_list if item["type"] == "image")
+    assert image["img_path"] == str((images_dir / "figure.png").resolve())
+
+
+def test_read_output_files_prefers_exact_stem_over_generic_v2(tmp_path):
+    parse_dir = tmp_path / "paper" / "auto"
+    parse_dir.mkdir(parents=True)
+    (tmp_path / "content_list_v2.json").write_text(
+        json.dumps(
+            [[{"type": "paragraph", "content": {"paragraph_content": "wrong"}}]]
+        ),
+        encoding="utf-8",
+    )
+    (parse_dir / "paper_content_list_v2.json").write_text(
+        json.dumps(
+            [[{"type": "paragraph", "content": {"paragraph_content": "right"}}]]
+        ),
+        encoding="utf-8",
+    )
+
+    content_list, _ = MineruParser._read_output_files(tmp_path, "paper")
+
+    assert content_list[0]["text"] == "right"
+
+
+def test_read_output_files_prefers_scoped_legacy_over_shared_generic_v2(tmp_path):
+    parse_dir = tmp_path / "paper" / "auto"
+    parse_dir.mkdir(parents=True)
+    (tmp_path / "content_list_v2.json").write_text(
+        json.dumps(
+            [[{"type": "paragraph", "content": {"paragraph_content": "wrong"}}]]
+        ),
+        encoding="utf-8",
+    )
+    (parse_dir / "paper_content_list.json").write_text(
+        json.dumps([{"type": "text", "text": "right"}]), encoding="utf-8"
+    )
+
+    content_list, _ = MineruParser._read_output_files(tmp_path, "paper")
+
+    assert content_list[0]["text"] == "right"
+
+
+def test_read_output_files_prefers_v2_when_legacy_and_generic_v2_share_bundle(
+    tmp_path,
+):
+    legacy = [{"type": "text", "text": "legacy"}]
+    v2 = [[{"type": "paragraph", "content": {"paragraph_content": "v2"}}]]
+    (tmp_path / "paper_content_list.json").write_text(
+        json.dumps(legacy), encoding="utf-8"
+    )
+    (tmp_path / "content_list_v2.json").write_text(json.dumps(v2), encoding="utf-8")
+
+    content_list, _ = MineruParser._read_output_files(tmp_path, "paper")
+
+    assert content_list[0]["text"] == "v2"
+
+
+def test_read_output_files_accepts_generic_v2_filename_and_layout_option(tmp_path):
+    parse_dir = tmp_path / "paper" / "auto"
+    parse_dir.mkdir(parents=True)
+    (parse_dir / "content_list_v2.json").write_text(
+        json.dumps(_v2_payload()), encoding="utf-8"
+    )
+
+    content_list, _ = MineruParser._read_output_files(
+        tmp_path, "paper", include_layout_blocks=True
+    )
+
+    assert content_list[0]["type"] == "page_header"
+    assert content_list[-2]["type"] == "page_number"
+
+
+@pytest.mark.parametrize("v2_value", [[], {"not": "a page list"}, "invalid"])
+def test_read_output_files_falls_back_to_legacy_when_v2_is_unusable(tmp_path, v2_value):
+    parse_dir = tmp_path / "paper" / "auto"
+    parse_dir.mkdir(parents=True)
+    legacy = [{"type": "text", "text": "legacy", "page_idx": 0}]
+    (parse_dir / "paper_content_list.json").write_text(
+        json.dumps(legacy), encoding="utf-8"
+    )
+    (parse_dir / "paper_content_list_v2.json").write_text(
+        json.dumps(v2_value), encoding="utf-8"
+    )
+
+    content_list, _ = MineruParser._read_output_files(tmp_path, "paper")
+
+    assert content_list == legacy
+
+
+def test_read_output_files_falls_back_when_v2_json_is_malformed(tmp_path):
+    parse_dir = tmp_path / "paper" / "auto"
+    parse_dir.mkdir(parents=True)
+    legacy = [{"type": "text", "text": "legacy", "page_idx": 0}]
+    (parse_dir / "paper_content_list.json").write_text(
+        json.dumps(legacy), encoding="utf-8"
+    )
+    (parse_dir / "paper_content_list_v2.json").write_text(
+        "{not valid json", encoding="utf-8"
+    )
+
+    content_list, _ = MineruParser._read_output_files(tmp_path, "paper")
+
+    assert content_list == legacy
+
+
+def test_read_output_files_refreshes_markdown_when_v2_falls_back(tmp_path):
+    output_dir = tmp_path / "output"
+    v2_dir = output_dir / "paper" / "auto"
+    legacy_dir = output_dir
+    v2_dir.mkdir(parents=True)
+    (v2_dir / "paper_content_list_v2.json").write_text("[]", encoding="utf-8")
+    (legacy_dir / "paper_content_list.json").write_text(
+        json.dumps([{"type": "text", "text": "legacy"}]), encoding="utf-8"
+    )
+    (legacy_dir / "paper.md").write_text("legacy markdown", encoding="utf-8")
+
+    content_list, markdown = MineruParser._read_output_files(output_dir, "paper")
+
+    assert content_list == [{"type": "text", "text": "legacy"}]
+    assert markdown == "legacy markdown"
+
+
+def test_layout_option_isolated_in_parse_cache_key(tmp_path):
+    class DummyProcessor(ProcessorMixin):
+        pass
+
+    processor = DummyProcessor()
+    processor.config = type(
+        "Config", (), {"parser": "mineru", "parse_method": "auto"}
+    )()
+    source = tmp_path / "document.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+
+    default_key = processor._generate_cache_key(source, include_layout_blocks=False)
+    layout_key = processor._generate_cache_key(source, include_layout_blocks=True)
+
+    assert default_key != layout_key
+    assert processor._relevant_parser_kwargs(
+        {"include_layout_blocks": True, "unrelated": "ignored"}
+    ) == {"include_layout_blocks": True}
+    assert (
+        processor._relevant_parser_kwargs(
+            {"include_layout_blocks": False, "unrelated": "ignored"}
+        )
+        == {}
+    )
+
+
+def test_parse_pdf_wires_layout_option_to_output_reader(tmp_path):
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    with (
+        patch.object(MineruParser, "_run_mineru_command"),
+        patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read,
+    ):
+        MineruParser().parse_pdf(
+            pdf_path, output_dir=tmp_path / "out", include_layout_blocks=True
+        )
+
+    assert read.call_args.kwargs["include_layout_blocks"] is True
+
+
+def test_parse_image_wires_layout_option_to_output_reader(tmp_path):
+    image_path = tmp_path / "paper.png"
+    image_path.write_bytes(b"\x89PNG\r\n")
+
+    with (
+        patch.object(MineruParser, "_run_mineru_command"),
+        patch.object(MineruParser, "_read_output_files", return_value=([], "")) as read,
+    ):
+        MineruParser().parse_image(
+            image_path, output_dir=tmp_path / "out", include_layout_blocks=True
+        )
+
+    assert read.call_args.kwargs["include_layout_blocks"] is True


### PR DESCRIPTION
## Summary

- Add a standalone adapter for MinerU 3.x `content_list_v2.json` (`list[list[dict]]`) and normalize it into RAG-Anything's existing flat content-list contract.
- Route titles, paragraphs, lists/indexes, inline/interline equations, images, tables, charts, code, and algorithms into the existing text/multimodal pipeline while preserving `page_idx`, `bbox`, `anchor`, heading levels, captions, footnotes, and visual metadata.
- Filter `page_header`, `page_footer`, `page_number`, `page_aside_text`, and `page_footnote` by default; expose `include_layout_blocks=True` for explicit opt-in.
- Add deterministic MinerU artifact discovery for exact and generic v2/legacy filenames. Document-scoped output trees win over shared roots; within one bundle v2 wins over legacy, with exact stem names preferred within the same schema.
- Keep legacy ingestion resilient: malformed, structurally invalid, or semantic-empty v2 output falls back to an available legacy content list.
- Include `include_layout_blocks` in parser-cache isolation and document the supported contract in English and Chinese READMEs.

Algorithms are represented as the existing compatible `type="code", sub_type="algorithm"` shape, while retaining the original MinerU v2 type metadata. Unknown future v2 block types are skipped with a warning so one schema extension does not discard supported content.

## Compatibility

Legacy `*_content_list.json` and `content_list.json` bundles remain supported. Existing relative-media path resolution and traversal checks are applied after v2 normalization as well.

## Validation

- `pytest -q`
- `pytest -q tests/test_mineru_content.py`
- `ruff check raganything/mineru_content.py tests/test_mineru_content.py`
- `ruff format --check raganything/mineru_content.py tests/test_mineru_content.py`
- `ruff check raganything/parser.py --select E9,F63,F7,F82`
- `python -m compileall -q raganything`

Closes #224