### PR TITLE
fix(example): tolerate LM Studio model discovery failures

### DIFF
--- a/examples/lmstudio_integration_example.py
+++ b/examples/lmstudio_integration_example.py
@@ -28,13 +28,13 @@ from typing import List, Dict, Optional
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
 
-# Load environment variables
-load_dotenv()
-
 # RAG-Anything imports
 from raganything import RAGAnything, RAGAnythingConfig
 from lightrag.utils import EmbeddingFunc
 from lightrag.llm.openai import openai_complete_if_cache
+
+# Load environment variables
+load_dotenv()
 
 LM_BASE_URL = os.getenv("LLM_BINDING_HOST", "http://localhost:1234/v1")
 LM_API_KEY = os.getenv("LLM_BINDING_API_KEY", "lm-studio")
@@ -101,10 +101,21 @@ class LMStudioRAGIntegration:
 
     async def test_connection(self) -> bool:
         """Test LM Studio connection."""
+        client = None
         try:
             print(f"🔌 Testing LM Studio connection at: {self.base_url}")
             client = AsyncOpenAI(base_url=self.base_url, api_key=self.api_key)
-            models = await client.models.list()
+            try:
+                models = await client.models.list()
+            except Exception as e:
+                # Some OpenAI-compatible servers, including older LM Studio
+                # versions, do not expose a working /models endpoint. The
+                # chat completion check below is the authoritative health
+                # check for this example.
+                print(f"⚠️ Model discovery unavailable: {str(e)}")
+                print("💡 Continuing; chat completion will verify the server.")
+                return True
+
             print(f"✅ Connected successfully! Found {len(models.data)} models")
 
             # Show available models
@@ -126,10 +137,8 @@ class LMStudioRAGIntegration:
             print(f"4. Verify server address: {self.base_url}")
             return False
         finally:
-            try:
+            if client is not None:
                 await client.close()
-            except Exception:
-                pass
 
     async def test_chat_completion(self) -> bool:
         """Test basic chat functionality."""

--- a/tests/test_lmstudio_integration_example.py
+++ b/tests/test_lmstudio_integration_example.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_example(monkeypatch):
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda: None
+
+    openai = types.ModuleType("openai")
+    openai.AsyncOpenAI = object
+
+    raganything = types.ModuleType("raganything")
+    raganything.RAGAnything = object
+    raganything.RAGAnythingConfig = lambda **kwargs: types.SimpleNamespace(**kwargs)
+
+    lightrag = types.ModuleType("lightrag")
+    lightrag_utils = types.ModuleType("lightrag.utils")
+    lightrag_utils.EmbeddingFunc = object
+    lightrag_llm = types.ModuleType("lightrag.llm")
+    lightrag_openai = types.ModuleType("lightrag.llm.openai")
+    lightrag_openai.openai_complete_if_cache = object()
+
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv)
+    monkeypatch.setitem(sys.modules, "openai", openai)
+    monkeypatch.setitem(sys.modules, "raganything", raganything)
+    monkeypatch.setitem(sys.modules, "lightrag", lightrag)
+    monkeypatch.setitem(sys.modules, "lightrag.utils", lightrag_utils)
+    monkeypatch.setitem(sys.modules, "lightrag.llm", lightrag_llm)
+    monkeypatch.setitem(sys.modules, "lightrag.llm.openai", lightrag_openai)
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "lmstudio_integration_example.py"
+    )
+    spec = importlib.util.spec_from_file_location("lmstudio_integration_example", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_model_discovery_failure_does_not_skip_chat_health_check(monkeypatch, capsys):
+    module = _load_example(monkeypatch)
+
+    class Models:
+        async def list(self):
+            raise RuntimeError("/models is unavailable")
+
+    class Client:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.models = Models()
+            self.closed = False
+            self.kwargs = kwargs
+            self.instances.append(self)
+
+        async def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(module, "AsyncOpenAI", Client)
+    integration = module.LMStudioRAGIntegration()
+
+    assert asyncio.run(integration.test_connection()) is True
+    assert Client.instances[0].closed is True
+    output = capsys.readouterr().out
+    assert "Model discovery unavailable" in output
+    assert "chat completion will verify" in output

--- a/tests/test_lmstudio_integration_example.py
+++ b/tests/test_lmstudio_integration_example.py
@@ -38,7 +38,9 @@ def _load_example(monkeypatch):
         / "examples"
         / "lmstudio_integration_example.py"
     )
-    spec = importlib.util.spec_from_file_location("lmstudio_integration_example", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "lmstudio_integration_example", module_path
+    )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)


### PR DESCRIPTION
## Description

The LM Studio integration example treated `/models` discovery as a hard connection requirement. When an OpenAI-compatible LM Studio server does not expose a working models endpoint, the example returned early and never ran its chat-completion health check.

Model discovery is now best-effort; chat completion remains the authoritative health check. The client cleanup path is also safe when initialization fails.

## Changes Made

- Continue to `test_chat_completion()` when `client.models.list()` fails.
- Add a regression test with a mocked unavailable `/models` endpoint.

## Validation

- `python3 -m py_compile examples/lmstudio_integration_example.py tests/test_lmstudio_integration_example.py`
- `pytest -q tests/test_lmstudio_integration_example.py` (1 passed)
- `ruff check examples/lmstudio_integration_example.py tests/test_lmstudio_integration_example.py`
- `git diff --check`