### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/raganything/__init__.py
+++ b/raganything/__init__.py
@@ -57,7 +57,7 @@ except ModuleNotFoundError:
 except ImportError:
     pass
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 __author__ = "Zirui Guo"
 __url__ = "https://github.com/HKUDS/RAG-Anything"
 


### PR DESCRIPTION
Version bump for the 1.4.0 release. Release notes land with the tag once #318 is merged.