### PR TITLE
chore: bump version to 1.4.1 (unreleased)

### DIFF
--- a/raganything/__init__.py
+++ b/raganything/__init__.py
@@ -57,7 +57,7 @@ except ModuleNotFoundError:
 except ImportError:
     pass
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "Zirui Guo"
 __url__ = "https://github.com/HKUDS/RAG-Anything"
 


### PR DESCRIPTION
Moves the working version past the v1.4.0 tag while the next batch (markdown image extraction, #292 audio/video) is under test. Deliberately NOT tagged and NOT released — the PyPI workflow only fires on a published GitHub release, so merging this publishes nothing. Installs from git remain fully usable and report 1.4.1.