### PR TITLE
feat(parser): extract markdown image references as MinerU-shaped image blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1219,7 +1219,7 @@ Different content types require specific optional dependencies:
 
 - **Office Documents** (.doc, .docx, .ppt, .pptx, .xls, .xlsx): Install [LibreOffice](https://www.libreoffice.org/download/download/)
 - **Extended Image Formats** (.bmp, .tiff, .gif, .webp): Install with `pip install raganything[image]`
-- **Text Files** (.txt, .md): Install with `pip install raganything[text]`
+- **Text Files** (.txt, .md): Install with `pip install raganything[text]`. Parsed directly (no PDF/OCR round trip); markdown image references (`![alt](path)`) that point to readable local files become image blocks and flow through the same multimodal pipeline as images extracted from PDFs — URLs and missing files stay as plain text
 - **PaddleOCR Parser** (`parser="paddleocr"`): Install with `pip install raganything[paddleocr]`, then install `paddlepaddle` for your platform
 
 > **📋 Quick Install**: Use `pip install raganything[all]` to enable all format support (Python dependencies only - LibreOffice still needs separate installation)

--- a/README_zh.md
+++ b/README_zh.md
@@ -1158,7 +1158,7 @@ MinerU 将 v2 标记为持续演进的输出 schema。RAG-Anything 会记录并�
 
 - **Office文档** (.doc, .docx, .ppt, .pptx, .xls, .xlsx): 安装并配置 [LibreOffice](https://www.libreoffice.org/download/download/)
 - **扩展图像格式** (.bmp, .tiff, .gif, .webp): 使用 `pip install raganything[image]` 安装
-- **文本文件** (.txt, .md): 使用 `pip install raganything[text]` 安装
+- **文本文件** (.txt, .md): 使用 `pip install raganything[text]` 安装。直接解析，不再经过 PDF/OCR 中转；markdown 中指向本地可读文件的图片引用（`![alt](path)`）会生成图像块，与 PDF 中提取的图片走同一条多模态管线——URL 与不存在的文件保持为纯文本
 
 > **📋 快速安装**: 使用 `pip install raganything[all]` 启用所有格式支持（仅Python依赖 - LibreOffice仍需单独安装）
 

--- a/docs/enhanced_markdown.md
+++ b/docs/enhanced_markdown.md
@@ -2,6 +2,8 @@
 
 This document describes the enhanced markdown conversion feature for RAG-Anything, which provides high-quality PDF generation from markdown files with multiple backend options and advanced styling.
 
+> **Note**: Since v1.4.0, document **ingestion** no longer converts `.txt`/`.md` to PDF — text files are parsed directly, and markdown image references pointing to readable local files become image blocks in the multimodal pipeline. This converter is for *producing* styled PDF deliverables from markdown, not part of the ingest path.
+
 ## Overview
 
 The enhanced markdown conversion feature provides professional-quality PDF generation from markdown files. It supports multiple conversion backends, advanced styling options, syntax highlighting, and seamless integration with RAG-Anything's document processing pipeline.

--- a/raganything/parser.py
+++ b/raganything/parser.py
@@ -739,16 +739,61 @@ class Parser:
                 f"Could not decode text file {text_path.name} with any supported encoding"
             )
 
+    _MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]*)\)")
+
+    @classmethod
+    def _resolve_md_image(
+        cls, target: str, source_dir: Optional[Path]
+    ) -> Optional[Tuple[str, List[str]]]:
+        """Resolve one markdown image target to (img_path, extra_captions).
+
+        Returns None when the reference cannot become an image block — a URL,
+        a missing file, or an unreadable target — in which case the literal
+        markdown text is preserved, matching what the old PDF round trip
+        produced (it rendered the syntax as plain text and embedded nothing).
+        """
+        inner = target.strip()
+        captions: List[str] = []
+        # optional title: ![alt](path "title")
+        title = re.search(r'\s+"([^"]*)"\s*$', inner)
+        if title:
+            captions.append(title.group(1))
+            inner = inner[: title.start()].strip()
+        # angle-bracketed targets: ![alt](<path with spaces>)
+        if inner.startswith("<") and inner.endswith(">"):
+            inner = inner[1:-1].strip()
+        if not inner or re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", inner):
+            return None
+        path = Path(inner)
+        if not path.is_absolute():
+            if source_dir is None:
+                return None
+            path = source_dir / path
+        try:
+            if not path.is_file():
+                return None
+        except OSError:
+            return None
+        return str(path.resolve()), captions
+
     @classmethod
     def _text_to_content_blocks(
-        cls, text_content: str, is_markdown: bool
+        cls,
+        text_content: str,
+        is_markdown: bool,
+        source_dir: Optional[Path] = None,
     ) -> List[Dict[str, Any]]:
         """
         Split raw text into MinerU-style content blocks.
 
         Paragraphs are delimited by blank lines; in markdown, an ATX heading
-        (`# ...`) becomes its own block carrying `text_level`, matching how
-        MinerU marks headings in its content list.
+        (`# ...`) becomes its own block carrying `text_level`, and an inline
+        image reference (``![alt](path)``) whose target is a readable local
+        file becomes an image block shaped exactly like MinerU's
+        (``img_path``/``img_caption``/``img_footnote``/``page_idx``), so it
+        flows into the same multimodal pipeline as images extracted from
+        PDFs. URLs and missing files stay literal text. Content inside
+        fenced code blocks (``` or ~~~) is never interpreted.
         """
         # Normalize line endings up front so CRLF/CR input behaves the same
         # as LF however the text arrived (text-mode file reads translate
@@ -757,6 +802,7 @@ class Parser:
 
         blocks: List[Dict[str, Any]] = []
         paragraph: List[str] = []
+        pending_images: List[Dict[str, Any]] = []
 
         def flush() -> None:
             if paragraph:
@@ -764,9 +810,27 @@ class Parser:
                     {"type": "text", "text": "\n".join(paragraph), "page_idx": 0}
                 )
                 paragraph.clear()
+            if pending_images:
+                blocks.extend(pending_images)
+                pending_images.clear()
 
+        in_fence = False
+        fence_marker = ""
         for line in lines:
             stripped = line.strip()
+            if is_markdown:
+                fence = re.match(r"^(`{3,}|~{3,})", stripped)
+                if fence:
+                    if not in_fence:
+                        in_fence = True
+                        fence_marker = fence.group(1)[0] * 3
+                    elif stripped.startswith(fence_marker):
+                        in_fence = False
+                    paragraph.append(line.rstrip())
+                    continue
+                if in_fence:
+                    paragraph.append(line.rstrip())
+                    continue
             if not stripped:
                 flush()
                 continue
@@ -783,6 +847,42 @@ class Parser:
                         }
                     )
                     continue
+                if cls._MD_IMAGE_RE.search(stripped):
+                    # A line that is nothing but image reference(s) becomes
+                    # image block(s) in place; a reference inside a sentence
+                    # keeps the sentence (alt text substituted in) and emits
+                    # the image block after the enclosing paragraph.
+                    standalone = not cls._MD_IMAGE_RE.sub("", stripped).strip()
+                    line_images: List[Dict[str, Any]] = []
+
+                    def replace(match: "re.Match[str]") -> str:
+                        alt = match.group(1).strip()
+                        resolved = cls._resolve_md_image(match.group(2), source_dir)
+                        if resolved is None:
+                            return match.group(0)  # keep literal text
+                        img_path, extra = resolved
+                        line_images.append(
+                            {
+                                "type": "image",
+                                "img_path": img_path,
+                                "img_caption": ([alt] if alt else []) + extra,
+                                "img_footnote": [],
+                                "page_idx": 0,
+                            }
+                        )
+                        return "" if standalone else alt
+
+                    remainder = cls._MD_IMAGE_RE.sub(replace, stripped).strip()
+                    if line_images:
+                        if standalone:
+                            flush()
+                            blocks.extend(line_images)
+                            if remainder:  # unresolvable refs stay as text
+                                paragraph.append(remainder)
+                        else:
+                            paragraph.append(remainder)
+                            pending_images.extend(line_images)
+                        continue
             paragraph.append(line.rstrip())
         flush()
 
@@ -821,7 +921,9 @@ class Parser:
 
         text_content = self._read_text_with_fallback(text_path)
         return self._text_to_content_blocks(
-            text_content, is_markdown=text_path.suffix.lower() == ".md"
+            text_content,
+            is_markdown=text_path.suffix.lower() == ".md",
+            source_dir=text_path.parent,
         )
 
     def parse_pdf(


### PR DESCRIPTION
## Description

The old `.md` → ReportLab → PDF → MinerU round trip was intended to carry images into the pipeline but never did: ReportLab rendered `![alt](path)` as literal text and embedded nothing (verified empirically — 0 embedded images in the generated PDF). Since #333 the text path is direct, so this implements the intent properly: every markdown image reference that resolves to a readable local file becomes an image block **shaped exactly like MinerU's** (`img_path`/`img_caption`/`img_footnote`/`page_idx`) and flows through the same multimodal pipeline as images extracted from PDFs — lossless originals instead of a PDF re-encode.

## Behavior

- alt text (and optional `"title"`) → `img_caption`; relative targets resolve against the .md file's directory; `<bracketed targets with spaces>` work
- URLs and missing files stay literal text (exactly what the old path produced)
- a line that is only image reference(s) becomes block(s) in place; an inline reference keeps its sentence (alt substituted in) and emits the block after the paragraph
- fenced code (``` / ~~~) is never interpreted — also fixes ATX headings inside fences becoming heading blocks (known follow-up from #333 review)
- `.txt` files untouched

## Testing

- 15 new unit tests (tests/test_md_image_blocks.py); full suite 360 passed; pinned ruff clean
- **Real E2E** (live LLM/VLM/embeddings): parse produced the exact MinerU block shape → ingest routed it through ImageModalProcessor → the VLM description recognized both labeled components in the test figure → a hybrid query answered correctly **from the image content**
- Cross-validation against real MinerU 3.4.5 output shape in progress on a test server (image-embedded PDF parse running)

## Docs

README.md / README_zh.md text-format sections updated; docs/enhanced_markdown.md now clarifies it is an output tool, not part of the ingest path.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [x] Unit tests added