### PR TITLE
fix(tests): stop test_modalprocessors_config corrupting sys.modules for the session

### DIFF
--- a/tests/test_modalprocessors_config.py
+++ b/tests/test_modalprocessors_config.py
@@ -4,6 +4,12 @@ import types
 from dataclasses import dataclass
 from pathlib import Path
 
+# Import the real modules up front so every sys.modules key this file
+# manipulates has a genuine cached entry for monkeypatch to record and
+# restore — otherwise a key first imported inside the stubbed fixture
+# would leak a stub-derived module into the rest of the session.
+import raganything.modalprocessors  # noqa: F401  (imports .prompt and .utils too)
+
 
 class FakeLogger:
     def info(self, *args, **kwargs):
@@ -66,13 +72,20 @@ def _import_modalprocessors_with_lightrag_stubs(monkeypatch):
     operate_module.extract_entities = None
     operate_module.merge_nodes_and_edges = None
 
+    # Remove cached modules THROUGH monkeypatch so teardown restores the
+    # real entries. A bare sys.modules.pop() before setitem() made
+    # monkeypatch record "absent" as the original value: its LIFO undo then
+    # deleted the keys instead of restoring the real package, and every
+    # test module imported afterwards got a fresh, stub-derived
+    # `raganything` — which is why unrelated monkeypatch.setattr targets
+    # (e.g. raganything.modalprocessors_video) vanished mid-session.
     for module_name in [
         "raganything",
         "raganything.prompt",
         "raganything.utils",
         "raganything.modalprocessors",
     ]:
-        sys.modules.pop(module_name, None)
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
 
     monkeypatch.setitem(sys.modules, "raganything", raganything_package)
     monkeypatch.setitem(sys.modules, "lightrag", lightrag_package)
@@ -88,21 +101,15 @@ def _import_modalprocessors_with_lightrag_stubs(monkeypatch):
 
 
 def test_base_modal_processor_uses_lightrag_runtime_global_config(monkeypatch):
-    try:
-        modalprocessors = _import_modalprocessors_with_lightrag_stubs(monkeypatch)
-        lightrag = FakeLightRAG()
+    # No manual cleanup: the fixture registers every sys.modules mutation
+    # with monkeypatch, whose LIFO teardown restores the real modules.
+    modalprocessors = _import_modalprocessors_with_lightrag_stubs(monkeypatch)
+    lightrag = FakeLightRAG()
 
-        processor = modalprocessors.BaseModalProcessor(
-            lightrag=lightrag,
-            modal_caption_func=lambda *args, **kwargs: "",
-        )
+    processor = modalprocessors.BaseModalProcessor(
+        lightrag=lightrag,
+        modal_caption_func=lambda *args, **kwargs: "",
+    )
 
-        assert processor.global_config["working_dir"] == "workdir"
-        assert processor.global_config["role_llm_funcs"] is lightrag.role_llm_funcs
-    finally:
-        for module_name in [
-            "raganything.prompt",
-            "raganything.utils",
-            "raganything.modalprocessors",
-        ]:
-            sys.modules.pop(module_name, None)
+    assert processor.global_config["working_dir"] == "workdir"
+    assert processor.global_config["role_llm_funcs"] is lightrag.role_llm_funcs


### PR DESCRIPTION
## Description

`tests/test_modalprocessors_config.py` popped four `raganything*` keys from `sys.modules` **before** registering stubs via `monkeypatch.setitem`, so monkeypatch recorded "absent" as the original value — its teardown then **deleted** the keys instead of restoring the real modules, and the `finally` block popped them again. Every test module imported later in the pytest session received a fresh, stub-derived `raganything` package, making unrelated `monkeypatch.setattr` targets vanish. This is the exact mechanism behind the 2 false failures on the audio/video branch (#292): `test_video_processor.py`'s target `raganything.modalprocessors_video` disappears whenever this file runs first.

## Changes Made

- Route removals through `monkeypatch.delitem(..., raising=False)` so teardown restores the real entries (LIFO ordering handles the subsequent `setitem` stubs correctly)
- Drop the manual `finally` cleanup — monkeypatch owns the restore now
- Import the real modules at file top so every manipulated key has a genuine cached entry to restore, regardless of session import order

## Testing

- The file's own test still passes
- Subprocess probe: run this file, then assert `sys.modules["raganything"]` is the real package again — passes after the fix, fails before
- Full suite: 345 passed; pinned ruff clean

## Checklist

- [x] Changes tested locally
- [x] Unit tests added (the probe is documented in the commit; the fix itself is test code)