### PR TITLE
feat(processor): route audio/video files through parse_document as media items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,7 +1222,7 @@ Different content types require specific optional dependencies:
 - **Office Documents** (.doc, .docx, .ppt, .pptx, .xls, .xlsx): Install [LibreOffice](https://www.libreoffice.org/download/download/)
 - **Extended Image Formats** (.bmp, .tiff, .gif, .webp): Install with `pip install raganything[image]`
 - **Audio** (.mp3, .wav, .flac, .m4a, .ogg): Install with `pip install raganything[audio]` and set `enable_audio_processing=True` (env `ENABLE_AUDIO_PROCESSING`); local transcription via faster-whisper, model picked by `WHISPER_MODEL`
-- **Video** (.mp4, .mov, .webm, .avi, .mkv): Install with `pip install raganything[video]` (also needs ffmpeg on PATH) and set `enable_video_processing=True` (env `ENABLE_VIDEO_PROCESSING`); dual-channel: SceneDetect + keyframe VLM description + audio-track transcription
+- **Video** (.mp4, .mov, .webm, .avi, .mkv): Install with `pip install raganything[video]` (also needs ffmpeg on PATH) and set `enable_video_processing=True` (env `ENABLE_VIDEO_PROCESSING`); dual-channel: SceneDetect + keyframe VLM description + audio-track transcription. Media files can be passed directly to `process_document_complete()` / folder batches, or inserted as content-list items
 - **Text Files** (.txt, .md): Install with `pip install raganything[text]`. Parsed directly (no PDF/OCR round trip); markdown image references (`![alt](path)`) that point to readable local files become image blocks and flow through the same multimodal pipeline as images extracted from PDFs — URLs and missing files stay as plain text
 - **PaddleOCR Parser** (`parser="paddleocr"`): Install with `pip install raganything[paddleocr]`, then install `paddlepaddle` for your platform
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1161,7 +1161,7 @@ MinerU 将 v2 标记为持续演进的输出 schema。RAG-Anything 会记录并�
 - **Office文档** (.doc, .docx, .ppt, .pptx, .xls, .xlsx): 安装并配置 [LibreOffice](https://www.libreoffice.org/download/download/)
 - **扩展图像格式** (.bmp, .tiff, .gif, .webp): 使用 `pip install raganything[image]` 安装
 - **音频** (.mp3, .wav, .flac, .m4a, .ogg): 使用 `pip install raganything[audio]` 安装，并设置 `enable_audio_processing=True`（环境变量 `ENABLE_AUDIO_PROCESSING`）；由 faster-whisper 本地转写（`WHISPER_MODEL` 选模型），长音频自动切分为有序分块
-- **视频** (.mp4, .mov, .webm, .avi, .mkv): 使用 `pip install raganything[video]` 安装（另需系统 ffmpeg），并设置 `enable_video_processing=True`（环境变量 `ENABLE_VIDEO_PROCESSING`）；双通道处理：SceneDetect 场景切分 + 关键帧 VLM 描述 + 音轨转写，按时间戳合并
+- **视频** (.mp4, .mov, .webm, .avi, .mkv): 使用 `pip install raganything[video]` 安装（另需系统 ffmpeg），并设置 `enable_video_processing=True`（环境变量 `ENABLE_VIDEO_PROCESSING`）；双通道处理：SceneDetect 场景切分 + 关键帧 VLM 描述 + 音轨转写，按时间戳合并。媒体文件可以直接传给 `process_document_complete()` / 文件夹批处理，也可以作为 content list 项插入
 - **文本文件** (.txt, .md): 使用 `pip install raganything[text]` 安装。直接解析，不再经过 PDF/OCR 中转；markdown 中指向本地可读文件的图片引用（`![alt](path)`）会生成图像块，与 PDF 中提取的图片走同一条多模态管线——URL 与不存在的文件保持为纯文本
 
 > **📋 快速安装**: 使用 `pip install raganything[all]` 启用所有格式支持（仅Python依赖 - LibreOffice仍需单独安装）

--- a/raganything/processor.py
+++ b/raganything/processor.py
@@ -29,6 +29,13 @@ import asyncio
 from lightrag.utils import compute_mdhash_id
 
 
+AUDIO_FILE_EXTENSIONS = frozenset(
+    {".mp3", ".wav", ".flac", ".m4a", ".ogg", ".wma", ".aac", ".opus"}
+)
+VIDEO_FILE_EXTENSIONS = frozenset(
+    {".mp4", ".mov", ".webm", ".avi", ".mkv", ".flv", ".wmv", ".m4v"}
+)
+
 _PARSER_CACHE_KWARGS = frozenset(
     {
         "lang",
@@ -470,6 +477,26 @@ class ProcessorMixin:
                     method=parse_method,
                     **kwargs,
                 )
+            elif ext in AUDIO_FILE_EXTENSIONS or ext in VIDEO_FILE_EXTENSIONS:
+                # Media files need no document parser: they become a single
+                # audio/video content item and are handled by the modal
+                # processors (faster-whisper / SceneDetect+VLM) downstream.
+                # media_sha256 ties the content-based doc_id to the file
+                # bytes, so replacing the file re-ingests it as new content.
+                kind = "audio" if ext in AUDIO_FILE_EXTENSIONS else "video"
+                self.logger.info(
+                    f"Detected {kind} file; building {kind} content item "
+                    "(no document parser involved)..."
+                )
+                content_list = [
+                    {
+                        "type": kind,
+                        f"{kind}_path": str(file_path.absolute()),
+                        f"{kind}_caption": [],
+                        "page_idx": 0,
+                        "media_sha256": self._file_content_fingerprint(file_path),
+                    }
+                ]
             elif ext in [
                 ".jpg",
                 ".jpeg",


### PR DESCRIPTION
## Description

`SUPPORTED_FILE_EXTENSIONS` has advertised `.mp3/.wav/.mp4/…` since #292, but `parse_document` fell through to the document parser for them — `process_document_complete("meeting.mp3")` died inside MinerU with an unrelated error, and `process_folder_complete` picked media files up and crashed on each. Media could only enter via hand-built `insert_content_list` items.

A media file now short-circuits the parser dispatch into a single `{"type": "audio"|"video", …}` content item and flows to the modal processors via the normal multimodal path. The item carries `media_sha256` (streaming, reusing #325's fingerprint helper) so the content-based doc_id changes when the file bytes change — without it a replaced recording at the same path would keep its old doc_id and be skipped as already processed.

## Testing

- 15 new tests (`tests/test_media_file_routing.py`) incl. an exploding-parser guard proving the document parser is never touched for media, doc-id-changes-on-content-change, cache behavior, and a non-media control
- Full suite 411 passed; pinned ruff clean
- Real end-to-end matrix on a Linux test host follows in this thread (formats × languages × combinations)

## Checklist
- [x] Changes tested locally
- [x] Documentation updated (both READMEs)
- [x] Unit tests added